### PR TITLE
docs(session-002): close M0.2 — past-prompts + Session 003 resume prompt

### DIFF
--- a/docs/past-prompts.md
+++ b/docs/past-prompts.md
@@ -49,3 +49,26 @@
 - Flutter SDK on the dev machine lives at `~/flutter` (3.44.5 stable), installed this session.
 
 **Next objective written to resume-prompt.md:** Session 002 — M0.2 GitHub Actions CI + branch protection + PR template + ADR skeleton + Fastlane init.
+
+## Session 002 — 2026-07-08 — M0.2: GitHub Actions CI, branch protection, repo process skeleton
+
+**Objective (from resume-prompt.md):** M0.2 — `ci.yml` (format → analyze → RTL lint → test --coverage → coverage gate ≥60% → iOS build smoke per ADR-006), branch protection on `main`, PR template (W3 sections), ADR skeleton (README + 001..005 backfill), Fastlane init (iOS stub only).
+
+**Outcome:** done. **M0 is complete.**
+- `ci.yml`: `quality` job (ubuntu; the five-step gate sequence) + `ios-build-smoke` (macos-15, `flutter build ios --no-codesign --debug --target lib/main_dev.dart`). Cost containment on the 10×-billed macOS leg: draft PRs skip it, `needs: quality` fail-fasts it, concurrency cancels superseded runs; `pull_request` types include `ready_for_review` so a draft→ready flip re-fires the required check. Push trigger is main-only (every change lands via PR per W3; avoids double-billed duplicate runs). Timings with warm cache: quality ~1m, iOS smoke ~2m37s (~26 billed macOS min/run — sustainable).
+- `tool/coverage_gate.dart`: zero-dep lcov gate (PASS 0 / FAIL 1 / usage+zero-LF 64; zero-LF is an explicit error so an empty report can't silently pass). Baseline coverage 87.50% (LF 32, LH 28) vs the 60% floor.
+- Branch protection via `gh api` (NOT plan-gated — worked on this private repo): required contexts `quality` + `ios-build-smoke`, `enforce_admins`, linear history, no force pushes/deletions, no review requirement (solo self-merge, green required — rule #7). Repo set to squash-merge-only + delete-branch-on-merge (W3).
+- Acceptance proofs (PR #2, draft, closed unmerged): (1) deliberately failing test → `quality` FAILURE → `mergeStateStatus: BLOCKED` (run 28905568279); (2) gate raised to `--min 99` → job fails at the coverage step, `87.50% is below the 99% threshold` → BLOCKED (run 28905881305). `ios-build-smoke` correctly SKIPPED on the draft both times.
+- iOS smoke earned its keep on first contact: caught that the scaffold has no `lib/main.dart` (flavors are Dart entrypoints, Session 001) — fixed with explicit `--target`. Not reproducible locally (no macOS).
+- ADR-001..005 backfilled from `architecture.md` §11 in the ADR-006 format (provenance noted per file); `adr/README.md` format note + index; §11 now links all six records.
+- Fastlane skeleton: iOS lanes only (`build_debug` mirrors the CI smoke; `beta` fails fast pointing to M6); Appfile `com.hayati.app`, zero secrets; root Gemfile pins fastlane `~> 2.225`.
+- **Founder directive mid-session:** brand kit v1.0 dropped at `brandkit/` (logos incl. AR lockup, tokens css/json, app icons incl. discreet-mode alt, TR/AR/EN social/store graphics) — committed straight to `main` (75ba8cb + 473842a) with a pointer added in `frontend-brandkit.md`; kept out of the M0.2 PR (scope guard). All future design work sources from it.
+
+**Commits:** PR #1 → squash `d0b0a00` on main; brandkit `75ba8cb` + `473842a`; session-close docs PR (this commit).
+**CI:** green (PR #1 both checks; post-merge main run watched green via `gh run watch`).
+**Docs touched:** adr/README.md + adr/001..005 (new), architecture.md §11, frontend-brandkit.md (brandkit pointer), resume-prompt.md, past-prompts.md.
+**Notes / debt logged (none silent):**
+- `Gemfile.lock` intentionally absent until fastlane first runs for real (M6) — no ruby/bundler on the dev machine. Documented in `Gemfile` + `fastlane/README.md`.
+- Docs-only PRs run the full pipeline including the macOS smoke: `paths-ignore` on a required check would deadlock merges ("expected" forever), so it was deliberately not used. Revisit only if the Actions minute budget tightens.
+- Coverage ratchet: floor stays 60% in `ci.yml`; first bump to 62% lands when M1 closes (test-suite §3).
+**Next objective written to resume-prompt.md:** Session 003 — content pack validator v1 (Phase-0-parallel content tooling; Gate 1 standing note honored — M1.1 stays blocked until Gate 1 passes).

--- a/docs/resume-prompt.md
+++ b/docs/resume-prompt.md
@@ -2,30 +2,30 @@
 
 > This file contains ONE and only ONE objective. Every session executes ONLY this file. (See `project-rules.md` #1, `session-rules.md`.)
 >
-> **Standing gate note:** Gate 1 (content validation, `roadmap.md` Phase 0) must PASS before any session beyond milestone M0 is scheduled here.
+> **Standing gate note:** Gate 1 (content validation, `roadmap.md` Phase 0) must PASS before any session beyond milestone M0 is scheduled here. Gate 1 had not passed as of 2026-07-08 (Phase 0 content ops just starting), so M1.1 remains unscheduled; this objective is Phase-0-parallel content tooling, allowed by `implementation-plan.md` cross-cutting rules ("the pack validator is the only code dependency" of content authoring) and `agent-workflows.md` W8 (product questions and TikTok hooks share one pipeline through `content/` packs).
 >
 > **Standing sequencing note (ADR-006):** iOS-first — milestones validate and ship on iOS first; Android work is re-sequenced into M6.5.
 
-## Objective — Session 002: M0.2 — GitHub Actions CI, branch protection, repo process skeleton
+## Objective — Session 003: Content pack validator v1 (Phase-0 content-ops tooling)
 
-Stand up the validation pipeline per `implementation-plan.md` M0 item 2 and `architecture.md` §9:
+Replace the `content/validator/validate.dart` placeholder (exits 1 by design, unwired) with a real validator, TDD throughout (domain logic — test-first is mandatory per `session-rules.md` §2):
 
-1. `.github/workflows/ci.yml` on every push/PR (ubuntu runner is sufficient — all M0 checks are platform-neutral): `dart format --set-exit-if-changed` → `flutter analyze` → `dart tool/rtl_lint.dart app/lib` → `flutter test --coverage` → coverage gate ≥60% (ratchet note: +2%/milestone per `test-suite.md` §3) → `flutter build ios --no-codesign --debug` on a macos runner as the iOS-first build smoke (ADR-006).
-2. Branch protection on `main` via `gh api`: require the `ci.yml` checks, no force pushes. (Solo-founder: self-merge allowed, green required — `project-rules.md` #7.)
-3. PR template with the W3 sections: Objective (resume-prompt link) / Tests added / Docs touched / Screens (goldens both directions) / Risk.
-4. ADR skeleton: `docs/adr/README.md` (format note) + backfill ADR-001..005 as short records from `architecture.md` §11 (ADR-006 already exists).
-5. Fastlane init: minimal `fastlane/` skeleton with iOS lane stub only (ADR-006 — Android lanes come with M6.5); no signing secrets in repo.
+1. **Validation rules** against `content/schema/question-pack.schema.json` and `content/README.md`: pack metadata well-formed (locale ∈ {tr, ar, en}; register enums incl. dual-register TR per `prd.md`); question ids unique within a pack and across packs of the same locale; non-empty question text; category/depth within schema ranges; `seasonalWindow` well-formed when present; duplicate question text per locale rejected; pack filename ↔ metadata consistency. Implement only the JSON-Schema subset our schema actually uses — this is a pack linter, not a spec-complete validator.
+2. **Testability**: structure so the rules are unit-tested (small package with `pubspec.yaml` + `test/`, or equivalent — session's design call). Red → green per rule class.
+3. **Fixtures**: one valid pack + one invalid fixture per violation class under a test fixtures dir; validator exits 0 on clean, 1 with an actionable per-error report (file, question id, rule) on violations.
+4. **CI wiring**: add one step to the `quality` job in `.github/workflows/ci.yml` (after `rtl lint`): run the validator over `content/packs/`. `content/packs/en.example.json` must pass (fix it if the schema tightened).
+5. **Docs-with-code**: update `content/README.md` (rules list, how to run); note the validator's arrival in `docs/implementation-plan.md` M3 item (it lands early, Phase-0-parallel — M3 will consume, not build, it).
 
-**Acceptance criteria:** a pushed PR shows all checks running and green; a deliberately failing test on a branch blocks merge (prove it, then remove the failing test); `gh run watch` green on `main` after merge; coverage gate demonstrably enforced (job fails below threshold); ADR files exist and are linked from `architecture.md` §11.
+**Acceptance criteria:** `flutter test`/`dart test` green including validator unit tests; each invalid fixture class rejected with an actionable message (demonstrated in tests); example pack passes; CI `quality` job runs the validator and stays green; coverage gate still ≥60%; docs updated in the same PR.
 
-**Files likely to change:** `.github/workflows/ci.yml`, `.github/pull_request_template.md`, `docs/adr/README.md`, `docs/adr/001..005-*.md`, `fastlane/`, `docs/architecture.md` (§11 links), `docs/past-prompts.md`, this file.
+**Files likely to change:** `content/validator/` (real implementation + tests + pubspec), `content/packs/en.example.json`, `content/README.md`, `.github/workflows/ci.yml` (one step), `docs/implementation-plan.md` (M3 note), `docs/past-prompts.md`, this file.
 
-**Validation steps:** local `flutter test` + `flutter analyze` + `dart tool/rtl_lint.dart app/lib` before push; then the failing-test branch-protection proof; then `gh run watch`.
+**Validation steps:** local validator run over `content/packs/` (clean + seeded-violation fixtures); full local gate sequence (`dart format` → `flutter analyze` → `dart tool/rtl_lint.dart app/lib` → `flutter test --coverage` → `dart tool/coverage_gate.dart --min 60 app/coverage/lcov.info`); push PR; `gh pr checks --watch`; squash-merge; `gh run watch` on main.
 
-**Complexity:** medium (CI matrix + macos runner quirks are the risk). **Estimated duration:** one session (1–3 h).
+**Complexity:** low-medium. **Estimated duration:** one session (1–3 h).
 
-**Stopping conditions:** if the macos iOS build smoke proves flaky or slow beyond ~15 min of fixing, drop it to a follow-up issue (`ci-debt` label) and keep the ubuntu pipeline as the merge gate — do not let the session overflow; if branch-protection API needs plan permissions the account lacks, document and defer that single item.
+**Stopping conditions:** if schema-conformance checking balloons toward full JSON-Schema semantics, implement only the subset our schema uses and file a `ci-debt` issue for the rest; if the dual-register/locale enum set is ambiguous in the docs, validate the uncontested subset and file a docs issue rather than inventing enum values.
 
-**Explicitly out of scope this session:** Firebase wiring (M1), any feature code, store-level flavor split (arrives with Fastlane release work, not `ci.yml`), `release.yml` (that belongs to M6/M6.5 release hardening).
+**Explicitly out of scope this session:** remote pack sync and in-app bundling (M3); authoring real TR/AR packs (content ops, non-code); Firebase/M1 anything (Gate 1 standing note); Ramadan window *logic* (M3 rollover — only the `seasonalWindow` *shape* is validated here).
 
-On completion, follow `session-rules.md` §3: append to `past-prompts.md`, regenerate this file with the next single objective (expected: M1.1 — Firebase project + Auth foundation, *only if Gate 1 status permits per the standing gate note; otherwise the highest-priority unblocked M0/Phase-0 task*), commit, push, verify CI via `gh run watch`.
+On completion, follow `session-rules.md` §3: append to `past-prompts.md`, regenerate this file with the next single objective (expected: M1.1 — Firebase project + Auth foundation, *only if Gate 1 has passed per the standing gate note; otherwise the highest-priority unblocked Phase-0 task, e.g. TikTok slideshow-generation tooling from the `brandkit/` question-card templates*), commit, push, verify CI via `gh run watch`.


### PR DESCRIPTION
## Objective

Executes: **Session 002 — M0.2** end sequence (session-rules §3): append `past-prompts.md`, regenerate `resume-prompt.md` with the single next objective.

## Tests added

- None — docs only.

## Docs touched

- `docs/past-prompts.md` (Session 002 entry, append-only)
- `docs/resume-prompt.md` (Session 003: content pack validator v1; Gate 1 standing note honored)

## Screens

- [x] No golden changes (no UI touched)

## Risk

- None (docs). Rollback: revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)