### PR TITLE
docs(directive): adopt CodeGraph for session/agent code navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ firebase-debug.*.log
 ui-debug.log
 .firebase/
 firestore-debug.log
+
+# CodeGraph local index (machine-local sqlite DB; each machine runs `codegraph init` once — session-rules §1)
+.codegraph/

--- a/docs/agent-workflows.md
+++ b/docs/agent-workflows.md
@@ -8,7 +8,7 @@ Trigger: any new feature idea. Steps: (1) write a one-paragraph hypothesis + the
 
 ## W2 — Coding session (the core loop)
 
-Governed by `project-rules.md` + `session-rules.md`. Sequence: read `resume-prompt.md` → plan (≤10 bullets) → **Tester sub-agent** drafts failing tests from acceptance criteria → implement to green → **Reviewer sub-agent** pass (diff review against `architecture.md` conventions, security rules, RTL lint) → docs sync → end-of-session sequence (append `past-prompts.md`, regenerate `resume-prompt.md` from `roadmap.md` + progress, `git add/commit/push`, verify CI via `gh run watch`; fix-fast or log-and-defer per rule #5).
+Governed by `project-rules.md` + `session-rules.md`. Sequence: read `resume-prompt.md` → orient via **CodeGraph** (`codegraph_explore`/`codegraph_node` MCP tools for symbol/call-path/impact questions; sub-agents use them too, via ToolSearch — session-rules §1) → plan (≤10 bullets) → **Tester sub-agent** drafts failing tests from acceptance criteria → implement to green → **Reviewer sub-agent** pass (diff review against `architecture.md` conventions, security rules, RTL lint) → docs sync → end-of-session sequence (append `past-prompts.md`, regenerate `resume-prompt.md` from `roadmap.md` + progress, `git add/commit/push`, verify CI via `gh run watch`, `codegraph sync` post-merge; fix-fast or log-and-defer per rule #5).
 
 ## W3 — PR workflow
 

--- a/docs/past-prompts.md
+++ b/docs/past-prompts.md
@@ -144,3 +144,16 @@
 - Brandkit visual application + goldens (test-suite §1 six-cell matrix, now unblocked by l10n) remains the final M1 slice after M1.3.
 
 **Next objective written to resume-prompt.md:** Session 005 — M1.3: Apple + phone auth providers (emulator-first), Crashlytics + App Check, CI emulator integration leg (#6).
+
+## Directive — 2026-07-09 — Adopt CodeGraph for code navigation (sessions + agents)
+
+**Trigger (founder, post-Session-004 close):** CodeGraph newly installed; "starting from next session I will utilize it" — agents should use CodeGraph during sessions, and the index must be updated before each session ends.
+
+**Resolution:** CodeGraph (CLI at `~/.local/bin/codegraph`; MCP server `codegraph` registered globally in `~/.claude.json`, so `codegraph_explore`/`codegraph_node` tools are live from Session 005 on) becomes the standing code-navigation layer:
+- **Session start (session-rules §1 step 4):** `codegraph status`, sync if stale; orientation and symbol/call-path/impact questions go through `codegraph_explore`/`codegraph_node` (CLI fallback `codegraph explore|node|callers`) instead of raw grep sweeps; sub-agents/workflow agents are pointed at the same MCP tools (reachable via ToolSearch).
+- **Session end (session-rules §3 step 5):** `codegraph sync` after the merge lands, so the index reflects merged `main` for the next session.
+- **Index hygiene:** the index is a machine-local sqlite DB — `.codegraph/` added to the root `.gitignore` (2.93 MB at adoption; never repo content); a fresh machine runs `codegraph init` once. Repo indexed this session: 82 files, 739 nodes, 1,820 edges, current with main `58faae6`.
+
+**Docs touched:** session-rules.md (§1 step 4 new, §3 step 5 new), agent-workflows.md (W2 sequence), resume-prompt.md (standing tooling note in the header block — survives regenerations like the ADR-006/007 notes), .gitignore (`.codegraph/`), past-prompts.md (this entry).
+**Outcome:** docs-only change, merged via PR with green pipeline.
+**Next objective in resume-prompt.md:** unchanged — Session 005 — M1.3 (Apple + phone providers, Crashlytics + App Check, ci-debt #6 CI emulator leg).

--- a/docs/resume-prompt.md
+++ b/docs/resume-prompt.md
@@ -5,6 +5,8 @@
 > **Standing de-gating note (ADR-007):** engineering milestones M1→M6 proceed without content-ops preconditions. Gates 1–3 are decision instruments for marketing/spend/launch posture, not build blockers. TikTok/content-ops work is out of session scope unless the founder re-activates it. First release target: the founder couple's own devices (personal-use-first).
 >
 > **Standing sequencing note (ADR-006):** iOS-first — milestones validate and ship on iOS first; Android work is re-sequenced into M6.5.
+>
+> **Standing tooling note (CodeGraph, founder directive 2026-07-09):** orient with CodeGraph at session start and use it for symbol/call-path/impact navigation throughout — `codegraph_explore`/`codegraph_node` MCP tools (CLI fallback `codegraph explore|node|callers`); sub-agents and workflow agents use the same tools via ToolSearch. Before the session ends, `codegraph sync` after the merge (session-rules §1 step 4 / §3 step 5). The index is machine-local (`.codegraph/`, gitignored).
 
 ## Objective — Session 005: M1.3 — Apple + phone providers, Crashlytics + App Check, emulator leg in CI
 

--- a/docs/session-rules.md
+++ b/docs/session-rules.md
@@ -7,7 +7,8 @@ The operating contract for every coding session. `project-rules.md` is the const
 1. Read `project-rules.md` (skim, it's short and immutable).
 2. Read `resume-prompt.md`. It contains exactly one objective. **That objective is the session. Nothing else is.**
 3. Read the acceptance criteria of the relevant milestone in `implementation-plan.md`.
-4. Write a plan of ≤10 bullets before touching code. If the plan reveals the objective is mis-scoped (>1 session of work), split it: do the first coherent slice, and note the remainder for the next `resume-prompt.md` — do not stretch the session.
+4. Orient with **CodeGraph** (founder directive 2026-07-09): `codegraph status` — sync if stale (the previous end sequence should have left it current; a fresh machine runs `codegraph init` once). For symbol/call-path/impact questions during the session, use the `codegraph_explore`/`codegraph_node` MCP tools (CLI fallback: `codegraph explore|node|callers`) instead of raw grep sweeps — and point sub-agents/workflow agents at the same tools (they reach MCP via ToolSearch). The index is machine-local (`.codegraph/`, gitignored).
+5. Write a plan of ≤10 bullets before touching code. If the plan reveals the objective is mis-scoped (>1 session of work), split it: do the first coherent slice, and note the remainder for the next `resume-prompt.md` — do not stretch the session.
 
 ## 2. During the session
 
@@ -22,6 +23,7 @@ The operating contract for every coding session. `project-rules.md` is the const
 2. Regenerate `resume-prompt.md`: inspect `roadmap.md` + current milestone progress + open `ci-debt` issues → choose the single highest-priority next task → write it with concrete acceptance criteria (rule #3). One objective only.
 3. `git add -A && git commit` (Conventional Commits: `feat(m2): partner preview screen with locked answer state`) `&& git push`.
 4. `gh run watch` until the pipeline concludes. Green → session over. Red → quick fix (≤15 min) now and re-push; structural → `gh issue create --label ci-debt` with failing-log excerpt, note it in `past-prompts.md`, and only then end (rule #5). A session never ends with an *unexamined* red pipeline.
+5. `codegraph sync` after the merge lands, so the local index reflects merged `main` — the next session's step-4 orientation depends on it (founder directive 2026-07-09).
 
 ## 4. Blocked protocol
 


### PR DESCRIPTION
## Objective

Executes: founder directive 2026-07-09 (post-Session-004) — CodeGraph becomes the standing code-navigation layer for sessions and sub-agents, with the index updated before each session end.

- **session-rules.md** — §1 step 4: orient via `codegraph status` + `codegraph_explore`/`codegraph_node` MCP tools (sub-agents included, via ToolSearch); §3 step 5: `codegraph sync` after the merge lands.
- **agent-workflows.md** — W2 core-loop sequence updated (orient step + post-merge sync).
- **resume-prompt.md** — standing tooling note in the header block (survives regenerations, like the ADR-006/007 notes). Session 005 objective unchanged.
- **past-prompts.md** — Directive entry (append-only).
- **.gitignore** — `.codegraph/` (machine-local sqlite index, 2.93 MB — never repo content).

Context: MCP server `codegraph` is registered globally in `~/.claude.json`; repo indexed 2026-07-09 (82 files / 739 nodes / 1,820 edges, current with main `58faae6`).

## Tests added

- None — docs + .gitignore only (no behavior touched).

## Docs touched

- session-rules.md, agent-workflows.md, resume-prompt.md, past-prompts.md (listed above)

## Screens

- [x] No golden changes (no UI touched)

## Risk

- Docs-only; rollback = revert this PR. Process risk is nil — CodeGraph is additive tooling; grep remains available where the graph has no answer.

---

### Pre-merge checklist (session-rules §2 quality bar)

- [x] `dart format` + `flutter analyze` clean (no Dart touched)
- [x] All tests green locally
- [x] Coverage gate satisfied (≥ current floor; never lowered — test-suite §3)
- [x] `dart tool/rtl_lint.dart app/lib` clean
- [x] Scope guard: no drive-by refactors — unrelated findings filed as `gh issue`, not smuggled into this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)