### PR TITLE
fix(ci): pairing emulator suite — seed the M6.2-required profile before createInvite

### DIFF
--- a/app/integration_test/pairing_emulator_test.dart
+++ b/app/integration_test/pairing_emulator_test.dart
@@ -115,6 +115,25 @@ void main() {
   ) async {
     final repository = FunctionsInviteRepository();
 
+    // M6.2 (ADR-019 cascade invariant): createInvite fail-closes when the
+    // caller has no profile doc — the deleted-profile guard that kills the
+    // intra-cascade mint window. A live profile is therefore a precondition
+    // of issuing, exactly like the pairing test below seeds for its users.
+    // (Session 022 fix: this suite is main-only/macOS-only, so the M6.2
+    // precondition landed with its functions-side proofs while this
+    // app-side caller kept issuing profileless — the documented
+    // post-merge-signal trade-off.)
+    await FirestoreProfileRepository(
+      firestore: FirebaseFirestore.instance,
+    ).saveProfile(
+      FirebaseAuth.instance.currentUser!.uid,
+      const RelationshipProfile(
+        status: RelationshipStatus.married,
+        contentLanguage: ContentLanguage.tr,
+        register: ContentRegister.respectful,
+      ),
+    );
+
     final first = await repository.createInvite();
     expect(first.code, matches(_codePattern));
     expect(first.reused, isFalse);


### PR DESCRIPTION
## Summary

Quick-fix (session-rules §3.5) for an **inherited unexamined red** on main: the S021 post-merge run failed `integration-emulator` on `pairing_emulator_test.dart` "createInvite issues a code and re-issues it idempotently" with `failed-precondition: A profile is required before issuing an invite.`

M6.2 (ADR-019) added the creator-profile-must-exist precondition to `createInvite` (the cascade invariant that kills the intra-cascade mint window). Its functions-side proofs shipped in the same PR, but this app-side suite is main-only/macOS-only (the documented post-merge-signal trade-off) and kept calling `createInvite` without a profile.

Fix: seed the signed-in user's profile before issuing — the same pattern the pairing acceptance test in the same file already uses.

## Proof
- `flutter analyze` clean, `dart format` clean.
- The suite itself is macOS-only; proof is the post-merge main run + the release-lane dispatch re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)