### PR TITLE
S028: ADR-025 slice 1 — the Material default floor (and the stopping condition that fired)

### DIFF
--- a/app/lib/core/design_system/hayati_theme.dart
+++ b/app/lib/core/design_system/hayati_theme.dart
@@ -40,7 +40,31 @@ ThemeData hayatiTheme({required String languageCode}) {
     onError: ColorTokens.night,
     surface: ColorTokens.night,
     onSurface: ColorTokens.sand,
+    // ── The raised-surface family (ADR-025 slice 1) ──────────────────────────
+    // Material 3 resolves component backgrounds through these slots, and an
+    // UNSET slot does not fall back to something sensible — Flutter falls
+    // `surfaceContainer*` back to `surface` and `inverseSurface` to
+    // `onSurface` (color_scheme.dart). Before slice 1 only `Highest` was set,
+    // which is the slot almost nothing reads: `AlertDialog` reads
+    // `surfaceContainerHigh` (one word apart), `Card`/`BottomSheet` read
+    // `surfaceContainerLow`. All three therefore rendered flat `night` — the
+    // same value as the page behind them, i.e. no separation at all — while
+    // `SnackBar` resolved `inverseSurface ?? onSurface` and rendered on `sand`,
+    // a cream slab in a dark-first app.
+    //
+    // The brandkit assigns night.raised to "Cards, sheets" (§2/§4), so the
+    // whole container family takes it: one raised tone, used consistently,
+    // rather than a tonal ladder the brandkit does not define.
+    surfaceContainerLowest: ColorTokens.nightRaised,
+    surfaceContainerLow: ColorTokens.nightRaised,
+    surfaceContainer: ColorTokens.nightRaised,
+    surfaceContainerHigh: ColorTokens.nightRaised,
     surfaceContainerHighest: ColorTokens.nightRaised,
+    // The inverse pair is what SnackBar reads. Keeping it inside the brand
+    // (raised plum + sand) is the whole point: an "inverse" surface in a
+    // dark-first app must not become a light-mode intrusion.
+    inverseSurface: ColorTokens.nightRaised,
+    onInverseSurface: ColorTokens.sand,
   );
 
   return ThemeData(
@@ -111,6 +135,48 @@ ThemeData hayatiTheme({required String languageCode}) {
     ),
     progressIndicatorTheme: const ProgressIndicatorThemeData(
       color: ColorTokens.pomegranate,
+    ),
+    // ── ADR-025 slice 1: the components the app actually mounts ─────────────
+    // Only these. The slice deliberately does NOT add CardTheme,
+    // BottomSheetThemeData or PopupMenuThemeData: `grep` finds zero `Card(`,
+    // zero bottom sheets and zero popup menus in `lib/`, and theming a widget
+    // the app never builds is dead configuration that reads as coverage. The
+    // ColorScheme container family above already carries the right value for
+    // all three the day one of them is used.
+    //
+    // The brandkit fixes no dialog/snackbar radius, so each takes the NEAREST
+    // defined token, following the M1.4 precedent that mapped buttons to the
+    // chip token and inputs to the card token (frontend-brandkit §10).
+    dialogTheme: DialogThemeData(
+      // A dialog is a sheet-scale surface -> the sheet token (24).
+      backgroundColor: ColorTokens.nightRaised,
+      surfaceTintColor: Colors.transparent,
+      shape: const RoundedRectangleBorder(
+        borderRadius: RadiusTokens.sheetRadius,
+      ),
+      titleTextStyle: textTheme.titleLarge,
+      contentTextStyle: textTheme.bodyMedium,
+    ),
+    snackBarTheme: SnackBarThemeData(
+      // Card-scale surface -> the card token (16). Explicit background rather
+      // than relying on inverseSurface, so a future ColorScheme edit cannot
+      // silently return the snackbar to a light slab.
+      backgroundColor: ColorTokens.nightRaised,
+      contentTextStyle: textTheme.bodyMedium,
+      shape: const RoundedRectangleBorder(
+        borderRadius: RadiusTokens.cardRadius,
+      ),
+      behavior: SnackBarBehavior.floating,
+    ),
+    tooltipTheme: TooltipThemeData(
+      // Used on three icon buttons (export copy, new conversation, settings
+      // gear) — all inside the Navigator, never on the lock screen, where a
+      // Tooltip has no Overlay to mount into (ADR-018 D3, sentinel-enforced).
+      decoration: const BoxDecoration(
+        color: ColorTokens.nightRaised,
+        borderRadius: RadiusTokens.cardRadius,
+      ),
+      textStyle: textTheme.bodySmall,
     ),
   );
 }

--- a/app/test/core/design_system/material_default_floor_test.dart
+++ b/app/test/core/design_system/material_default_floor_test.dart
@@ -1,0 +1,196 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hayati_app/core/design_system/color_tokens.dart';
+import 'package:hayati_app/core/design_system/hayati_theme.dart';
+
+/// ADR-025 slice 1 — the Material default floor.
+///
+/// THE DEFECT (verified against the installed SDK before the fix): Material 3
+/// resolves component backgrounds through `ColorScheme` slots, and an UNSET
+/// slot does not fall back to something sensible. Flutter falls
+/// `surfaceContainer*` back to `surface` and `inverseSurface` back to
+/// `onSurface` (`color_scheme.dart`). `hayatiTheme` set only
+/// `surfaceContainerHighest` — the slot almost nothing reads — so:
+///
+///   * `AlertDialog` reads `surfaceContainerHigh` (one word apart) -> `night`,
+///     the SAME value as the page behind it: no separation at all. The three
+///     dialogs affected are the app's most consequential confirmations — the
+///     biometric shared-device warning, the irreversible-delete confirmation,
+///     and the consent-withdrawal dialog.
+///   * `Card` / `BottomSheet` read `surfaceContainerLow` -> `night`, same.
+///   * `SnackBar` reads `inverseSurface` -> `?? onSurface` -> **`sand`**, a
+///     cream slab in a dark-first app.
+///
+/// WHY A TEST AND NOT A GOLDEN: dialogs and snackbars are transient. They mount
+/// above the screen, so no golden in the 303-file matrix captures ANY of them —
+/// which is exactly why this defect survived from M1.4 to now with a full
+/// golden net in place. A widget test that pumps the real thing and reads back
+/// the resolved colour is the mechanism the golden matrix structurally cannot
+/// provide.
+///
+/// If this test fails, a `ColorScheme` slot was dropped or re-pointed. Do not
+/// re-stamp it against whatever the new value is — check first whether a
+/// surface has gone back to rendering flat against its own background.
+void main() {
+  final theme = hayatiTheme(languageCode: 'en');
+  final scheme = theme.colorScheme;
+
+  group('no component resolves a background through an unset slot', () {
+    test('every surface-container slot is the brandkit raised tone', () {
+      // The whole family, because M3 components read different members of it
+      // and the brandkit defines ONE raised tone ("Cards, sheets", §2/§4)
+      // rather than a tonal ladder.
+      expect(scheme.surfaceContainerLowest, ColorTokens.nightRaised);
+      expect(scheme.surfaceContainerLow, ColorTokens.nightRaised);
+      expect(scheme.surfaceContainer, ColorTokens.nightRaised);
+      expect(scheme.surfaceContainerHigh, ColorTokens.nightRaised);
+      expect(scheme.surfaceContainerHighest, ColorTokens.nightRaised);
+    });
+
+    test('no container slot silently equals surface (the original defect)', () {
+      // The regression that WAS shipping: an unset slot falls back to
+      // `surface`, so a raised surface renders flat against the page. Asserting
+      // "not equal to surface" catches it even if the raised tone is later
+      // re-pointed to some other brand colour.
+      for (final container in <Color>[
+        scheme.surfaceContainerLowest,
+        scheme.surfaceContainerLow,
+        scheme.surfaceContainer,
+        scheme.surfaceContainerHigh,
+        scheme.surfaceContainerHighest,
+      ]) {
+        expect(
+          container,
+          isNot(scheme.surface),
+          reason:
+              'a raised surface that equals `surface` has no separation from '
+              'the page behind it — this is the defect ADR-025 slice 1 fixed',
+        );
+      }
+    });
+
+    test('the inverse pair stays inside the dark brand', () {
+      // `inverseSurface ?? onSurface` was resolving to `sand`. In a dark-first
+      // app the "inverse" surface must not become a light-mode intrusion.
+      expect(scheme.inverseSurface, ColorTokens.nightRaised);
+      expect(scheme.onInverseSurface, ColorTokens.sand);
+      expect(
+        scheme.inverseSurface,
+        isNot(scheme.onSurface),
+        reason:
+            'inverseSurface falling back to onSurface is the cream-slab bug',
+      );
+    });
+  });
+
+  group('the transient surfaces no golden can capture', () {
+    testWidgets('an AlertDialog renders on the raised tone, not the page', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: theme,
+          home: Builder(
+            builder: (context) => TextButton(
+              onPressed: () => showDialog<void>(
+                context: context,
+                builder: (_) => const AlertDialog(content: Text('x')),
+              ),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      final dialog = tester.widget<Material>(
+        find
+            .descendant(
+              of: find.byType(AlertDialog),
+              matching: find.byType(Material),
+            )
+            .first,
+      );
+      expect(dialog.color, ColorTokens.nightRaised);
+      expect(
+        dialog.color,
+        isNot(ColorTokens.night),
+        reason:
+            'the biometric warning, the delete confirmation and the consent '
+            'withdrawal all render through this — flat-on-flat is the defect',
+      );
+    });
+
+    testWidgets('a SnackBar renders on the raised tone, not on sand', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: theme,
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => TextButton(
+                onPressed: () => ScaffoldMessenger.of(
+                  context,
+                ).showSnackBar(const SnackBar(content: Text('copied'))),
+                child: const Text('copy'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('copy'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 750));
+
+      final material = tester.widget<Material>(
+        find
+            .descendant(
+              of: find.byType(SnackBar),
+              matching: find.byType(Material),
+            )
+            .first,
+      );
+      expect(material.color, ColorTokens.nightRaised);
+      expect(
+        material.color,
+        isNot(ColorTokens.sand),
+        reason: 'the export screen\'s "copied" bar was a cream slab',
+      );
+    });
+  });
+
+  group('the sub-themes cover exactly the components the app mounts', () {
+    test('dialog, snackbar and tooltip carry brand shape and typography', () {
+      expect(theme.dialogTheme.backgroundColor, ColorTokens.nightRaised);
+      expect(theme.snackBarTheme.backgroundColor, ColorTokens.nightRaised);
+
+      // Compared property-by-property rather than by object equality:
+      // `ThemeData` merges a debugLabel and a decoration colour into the
+      // TextTheme it exposes, so the style read back is never `==` the style
+      // handed in even when it is the same brand step.
+      final title = theme.dialogTheme.titleTextStyle;
+      expect(title?.fontSize, theme.textTheme.titleLarge?.fontSize);
+      expect(title?.fontWeight, theme.textTheme.titleLarge?.fontWeight);
+      expect(title?.fontFamily, theme.textTheme.titleLarge?.fontFamily);
+
+      expect(
+        (theme.tooltipTheme.decoration as BoxDecoration?)?.color,
+        ColorTokens.nightRaised,
+      );
+    });
+
+    test('unused components are deliberately NOT themed', () {
+      // `grep` finds zero `Card(`, zero bottom sheets and zero popup menus in
+      // lib/. Theming a widget the app never builds is dead configuration that
+      // reads as coverage — and the ColorScheme family above already carries
+      // the right value the day one of them IS used. If this test fails
+      // because a sub-theme was added, first check whether the widget is now
+      // actually mounted; if it is, this expectation is what should change.
+      expect(theme.cardTheme.color, isNull);
+      expect(theme.bottomSheetTheme.backgroundColor, isNull);
+      expect(theme.popupMenuTheme.color, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Objective

`resume-prompt.md` Session 028: ADR-025 **slice 1 — the Material default floor**, the first pixel-moving slice. Preemptions checked first, all negative (Blaze re-verified factually: `billingEnabled: false` on both projects).

## The defect, verified against the installed SDK

Material 3 resolves component backgrounds through `ColorScheme` slots, and an **unset slot does not fall back to something sensible** — Flutter falls `surfaceContainer*` back to `surface` and `inverseSurface` back to `onSurface`. `hayatiTheme` set only `surfaceContainerHighest`, the slot almost nothing reads:

| Component | reads | resolved to |
|---|---|---|
| `AlertDialog` | `surfaceContainerHigh` — *one word apart* | flat `night`, **identical to the page behind it** |
| `Card` / `BottomSheet` | `surfaceContainerLow` | same |
| `SnackBar` | `inverseSurface ?? onSurface` | **`sand`** — a cream slab in a dark-first app |

The three dialogs affected are the app's most consequential confirmations: the **biometric shared-device warning**, the **irreversible-delete confirmation**, and the **consent-withdrawal dialog**.

## The stopping condition fired, and it shaped the slice

ADR-025 D3 forbids inventing a brand colour inside a refactor slice. The first attempt *also* set `onSurfaceVariant` and `outline` — which the brandkit does not define — using invented `sand` alphas. That changed 96 goldens, and **looking at the regenerated images rather than trusting the count** showed a regression: the settings toggles got visibly **dimmer**, because an M3 `Switch` reads both slots for its off-state thumb and track outline. Muting them made *enabled* controls read closer to disabled — worse affordance traded for tonal consistency.

Those two slots were dropped and handed to the founder as a brandkit question (**#67**), with the three options and the accessibility weight written out. What remains uses **only existing tokens** (`night.raised` / `sand`).

## Why this slice changes ZERO goldens — the finding worth keeping

Dialogs and snackbars mount *above* the screen, so **no golden in the 303-file matrix captures any of them**. That is precisely how this defect survived from M1.4 to now with a full golden net in place.

So the fix ships with its own mechanism: a widget test that pumps the real `AlertDialog` and the real `SnackBar` and reads the resolved colour back, plus an assertion that **no container slot silently equals `surface`** — which catches the original defect even if the raised tone is later re-pointed.

## Tests added

`material_default_floor_test.dart` — 7 tests, **mutation-checked 3×** (drop `surfaceContainerHigh` → dialog test red; drop `inverseSurface` → snackbar test red; drop `DialogTheme.backgroundColor` → sub-theme test red).

Sub-themes added only for components the app actually mounts (dialog, snackbar, tooltip; radii mapped to the nearest defined token per the M1.4 precedent). **Deliberately not added:** `CardTheme`, `BottomSheetThemeData`, `PopupMenuThemeData` — `grep` finds zero `Card(`, zero bottom sheets and zero popup menus in `lib/`. A test pins that absence so it stays a decision rather than an oversight.

## Screens

**Zero golden PNGs changed** — `git status --porcelain -- 'app/test/**/*.png'` is empty. Declared before regenerating per ADR-025 D8; the earlier 96-file set was measured, inspected, and then *withdrawn* along with the slots that caused it.

**Class F carve-out (ADR-025 D6):** `lock_screen`, `pin_setup_screen` and the two `probe` goldens are byte-identical — verified, and trivially so at zero churn.

Green: **1,435** app tests · analyze clean · coverage **86.43%** vs the 68 gate.

## Risk

Low. Theme-level, additive, no widget-tree or copy changes. The visible effect is confined to three dialogs and one snackbar, all of which previously rendered wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)