### PR TITLE
chore(ios): gitignore SwiftPM xcshareddata artifacts

### DIFF
--- a/app/ios/.gitignore
+++ b/app/ios/.gitignore
@@ -26,6 +26,7 @@ Flutter/flutter_assets/
 Flutter/flutter_export_environment.sh
 ServiceDefinitions.json
 Runner/GeneratedPluginRegistrant.*
+**/xcshareddata/swiftpm/
 
 # Exceptions to above rules.
 !default.mode1v3

--- a/app/ios/.gitignore
+++ b/app/ios/.gitignore
@@ -26,6 +26,19 @@ Flutter/flutter_assets/
 Flutter/flutter_export_environment.sh
 ServiceDefinitions.json
 Runner/GeneratedPluginRegistrant.*
+# Local device builds (SwiftPM plugin resolution) drop `Package.resolved` under
+# both `Runner.xcworkspace/xcshareddata/` and
+# `Runner.xcodeproj/project.xcworkspace/xcshareddata/`.
+#
+# COMPROMISE, recorded per project-rules #9: `Package.resolved` is SwiftPM's
+# LOCKFILE, and ignoring a lockfile normally costs reproducibility. It costs
+# nothing here, verified: this project has ZERO `XCRemoteSwiftPackageReference`
+# entries in `project.pbxproj` — the only Swift package is Flutter's own
+# path-based `FlutterGeneratedPluginSwiftPackage` under `Flutter/ephemeral/`,
+# and a path dependency has no version to pin. CI resolves fresh through the
+# Flutter toolchain either way. **If a REMOTE Swift package is ever added, this
+# line must go** and the `Runner.xcworkspace` copy should be committed like
+# `pubspec.lock`.
 **/xcshareddata/swiftpm/
 
 # Exceptions to above rules.


### PR DESCRIPTION
Local device builds (SwiftPM plugin resolution) drop `Package.resolved` under both `Runner.xcworkspace` and `project.xcworkspace` `xcshareddata/` — ignore them alongside the other iOS build outputs.

Note: `Package.resolved` is SPM's lockfile; if we ever want reproducible iOS dependency resolution we should instead commit the `Runner.xcworkspace` one (like `pubspec.lock`). Ignoring for now — CI builds via the Flutter toolchain resolve fresh either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)