### PR TITLE
feat(testflight): dispatchable lane to create a beta group and add testers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,16 @@ jobs:
         run: shellcheck tool/ci/*.sh
       - name: slack notifier self-tests
         run: bash tool/ci/slack_notify_test.sh
+      # tool/ci/testflight_testers.py holds a CREDENTIAL path (the ES256
+      # assertion for App Store Connect) that no other gate looks at — it is
+      # Python, so neither `dart format`/`analyze` nor shellcheck sees it, and
+      # the workflow that runs it is manual-dispatch-only, so a break would
+      # surface at the worst moment: the founder adding a real tester by hand.
+      # The self-test signs with a throwaway P-256 key, so it needs no secret.
+      - name: testflight tester tool self-tests
+        run: |
+          pip install --quiet 'pyjwt[crypto]==2.10.1'
+          python3 tool/ci/testflight_testers_test.py
       - name: pub get
         working-directory: app
         run: flutter pub get

--- a/.github/workflows/testflight-testers.yml
+++ b/.github/workflows/testflight-testers.yml
@@ -1,0 +1,70 @@
+# testflight-testers — create/reuse a TestFlight beta group and add testers.
+#
+# WHY A WORKFLOW AND NOT A DEV-BOX COMMAND: the App Store Connect API key lives
+# only in GitHub secrets (architecture.md §9 — zero credentials in this repo),
+# so this is the only place the three ASC_* values resolve. Same credential set
+# and same `environment: release` binding as release.yml's sign-upload job:
+# ASC_KEY_ID / ASC_ISSUER_ID are `release` ENVIRONMENT secrets while
+# ASC_API_KEY_P8_BASE64 is a REPOSITORY secret, and only a job that declares the
+# environment sees both (the REL-2 lesson recorded in release.yml).
+#
+# Manual dispatch ONLY — never on push. Adding an external tester emails a real
+# person; that is not something a merge should be able to do as a side effect.
+name: testflight-testers
+
+on:
+  workflow_dispatch:
+    inputs:
+      group:
+        description: 'Beta group name (created if absent, reused if present)'
+        required: true
+        default: 'Friends'
+      testers:
+        description: 'Comma-separated tester emails'
+        required: false
+        default: ''
+      dry_run:
+        description: 'Report what would change and touch nothing'
+        type: boolean
+        default: true
+
+concurrency:
+  group: testflight-testers
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  manage:
+    name: manage testers
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: release
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      # PyJWT signs the ES256 assertion Apple requires; cryptography is its
+      # backend for EC keys. Pinned so a future major cannot change the token
+      # shape under a lane the founder dispatches by hand.
+      - name: install deps
+        run: pip install 'pyjwt[crypto]==2.10.1'
+      - name: create group + add testers
+        # Inputs reach the shell as ENV, never interpolated into the script
+        # body: `${{ }}` expansion happens before bash sees the line, so a
+        # group name containing shell metacharacters would otherwise execute.
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_API_KEY_P8_BASE64: ${{ secrets.ASC_API_KEY_P8_BASE64 }}
+          GROUP_NAME: ${{ inputs.group }}
+          TESTER_EMAILS: ${{ inputs.testers }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          args=(--bundle-id com.beyondkaira.hayati
+                --group "$GROUP_NAME"
+                --testers "$TESTER_EMAILS")
+          [ "$DRY_RUN" = "true" ] && args+=(--dry-run)
+          python3 tool/ci/testflight_testers.py "${args[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ node_modules/
 fastlane/report.xml
 fastlane/Preview.html
 fastlane/test_output/
+
+# Python bytecode from tool/ci/*.py (the CI self-tests import by path).
+__pycache__/
+*.pyc

--- a/tool/ci/testflight_testers.py
+++ b/tool/ci/testflight_testers.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Create (idempotently) a TestFlight beta group and add testers to it.
+
+Why this exists, and why it is a CI script rather than a dev-box one: the App
+Store Connect API key lives ONLY in GitHub secrets (ASC_KEY_ID / ASC_ISSUER_ID
+in the `release` environment, ASC_API_KEY_P8_BASE64 as a repository secret) —
+architecture.md §9's zero-credentials-in-repo rule means no operator can run
+this locally without first exporting the key, and nothing should encourage
+that. The workflow that calls it (.github/workflows/testflight-testers.yml)
+resolves the same three secrets the release lane uses.
+
+Idempotent BY DESIGN, because the failure mode of a tester script is a
+duplicate invite email to a real person: an existing group of the same name is
+reused rather than duplicated (App Store Connect happily accepts two groups
+with the same name), an existing tester is looked up by email and linked to the
+group instead of re-created, and a tester already in the group is left alone.
+Re-running it is a no-op that prints the same final membership.
+
+External groups are the default (`isInternalGroup` is read-only on create and
+Apple defaults it to false). NOTE the operational consequence, which this
+script cannot do anything about: an external tester receives nothing until a
+build is assigned to their group AND that build clears Beta App Review. Adding
+people here is necessary, not sufficient.
+
+Usage (see the workflow for the credential wiring):
+
+    python3 tool/ci/testflight_testers.py \
+        --bundle-id com.beyondkaira.hayati \
+        --group Friends \
+        --testers a@example.com,b@example.com \
+        [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+import jwt  # PyJWT, with the `cryptography` backend for ES256.
+
+API = "https://api.appstoreconnect.apple.com"
+
+
+class AscError(RuntimeError):
+    """An App Store Connect API call that did not do what we asked."""
+
+
+def _token() -> str:
+    """Mint a short-lived ES256 JWT from the three release secrets.
+
+    Fails CLOSED with the missing NAMES (never values), mirroring the release
+    lane's own signing-secrets gate: a partial credential set must not reach
+    Apple to die on an opaque 401.
+    """
+    key_id = os.environ.get("ASC_KEY_ID", "").strip()
+    issuer_id = os.environ.get("ASC_ISSUER_ID", "").strip()
+    key_b64 = os.environ.get("ASC_API_KEY_P8_BASE64", "").strip()
+    missing = [
+        name
+        for name, value in (
+            ("ASC_KEY_ID", key_id),
+            ("ASC_ISSUER_ID", issuer_id),
+            ("ASC_API_KEY_P8_BASE64", key_b64),
+        )
+        if not value
+    ]
+    if missing:
+        raise AscError(
+            "App Store Connect credentials are not configured: "
+            + ", ".join(missing)
+            + " unset. See docs/operator-expected.md."
+        )
+
+    # The same whitespace strip the release lane's `tr -d '[:space:]'` applies:
+    # a base64 secret pasted with newlines decodes to garbage under strict
+    # decoders while working fine under lenient ones, so normalise here too.
+    private_key = base64.b64decode("".join(key_b64.split())).decode("utf-8")
+    if "BEGIN PRIVATE KEY" not in private_key:
+        raise AscError(
+            "ASC_API_KEY_P8_BASE64 did not decode to a PKCS#8 PEM private key "
+            "(expected a '-----BEGIN PRIVATE KEY-----' line)."
+        )
+
+    now = int(time.time())
+    return jwt.encode(
+        {
+            "iss": issuer_id,
+            "iat": now,
+            "exp": now + 1200,  # Apple caps team-key tokens at 20 minutes.
+            "aud": "appstoreconnect-v1",
+        },
+        private_key,
+        algorithm="ES256",
+        headers={"kid": key_id, "typ": "JWT"},
+    )
+
+
+def _call(token: str, method: str, path: str, body: dict | None = None) -> dict:
+    data = json.dumps(body).encode() if body is not None else None
+    request = urllib.request.Request(
+        API + path,
+        data=data,
+        method=method,
+        headers={
+            "Authorization": "Bearer " + token,
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request) as response:
+            raw = response.read()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as failure:
+        detail = failure.read().decode("utf-8", "replace")
+        raise AscError(f"{method} {path} -> HTTP {failure.code}: {detail}") from None
+
+
+def find_app(token: str, bundle_id: str) -> dict:
+    query = urllib.parse.urlencode({"filter[bundleId]": bundle_id})
+    found = _call(token, "GET", f"/v1/apps?{query}").get("data", [])
+    if not found:
+        raise AscError(
+            f"No app with bundle id {bundle_id} is visible to this API key."
+        )
+    return found[0]
+
+
+def find_group(token: str, app_id: str, name: str) -> dict | None:
+    """Look the group up by app, then match the name HERE rather than with a
+    server-side filter[name]: the list filter is exact and case-sensitive, and
+    a near-miss would silently create a second 'friends' beside 'Friends'."""
+    query = urllib.parse.urlencode({"filter[app]": app_id, "limit": 200})
+    for group in _call(token, "GET", f"/v1/betaGroups?{query}").get("data", []):
+        if group["attributes"]["name"].strip().casefold() == name.strip().casefold():
+            return group
+    return None
+
+
+def create_group(token: str, app_id: str, name: str) -> dict:
+    payload = {
+        "data": {
+            "type": "betaGroups",
+            "attributes": {"name": name},
+            "relationships": {"app": {"data": {"type": "apps", "id": app_id}}},
+        }
+    }
+    return _call(token, "POST", "/v1/betaGroups", payload)["data"]
+
+
+def group_member_emails(token: str, group_id: str) -> set[str]:
+    query = urllib.parse.urlencode({"limit": 200})
+    members = _call(
+        token, "GET", f"/v1/betaGroups/{group_id}/betaTesters?{query}"
+    ).get("data", [])
+    return {
+        (tester["attributes"].get("email") or "").casefold() for tester in members
+    }
+
+
+def find_tester(token: str, email: str) -> dict | None:
+    query = urllib.parse.urlencode({"filter[email]": email})
+    found = _call(token, "GET", f"/v1/betaTesters?{query}").get("data", [])
+    return found[0] if found else None
+
+
+def add_tester(token: str, group_id: str, email: str) -> str:
+    """Add one tester, returning a one-word outcome for the summary line.
+
+    No firstName/lastName is sent. They are optional to Apple, and a name
+    invented from an email local part would show up in the founder's App Store
+    Connect forever — a guess about a real person is worse than a blank field.
+    """
+    existing = find_tester(token, email)
+    if existing is not None:
+        _call(
+            token,
+            "POST",
+            f"/v1/betaGroups/{group_id}/relationships/betaTesters",
+            {"data": [{"type": "betaTesters", "id": existing["id"]}]},
+        )
+        return "linked-existing"
+    _call(
+        token,
+        "POST",
+        "/v1/betaTesters",
+        {
+            "data": {
+                "type": "betaTesters",
+                "attributes": {"email": email},
+                "relationships": {
+                    "betaGroups": {
+                        "data": [{"type": "betaGroups", "id": group_id}]
+                    }
+                },
+            }
+        },
+    )
+    return "invited-new"
+
+
+def parse_emails(raw: str) -> list[str]:
+    """Split a comma/whitespace separated list, preserving order, dropping
+    case-insensitive duplicates.
+
+    Case-insensitive because the duplicate that matters is the human one: a
+    founder pasting `A@x.com` on one dispatch and `a@x.com` on the next means
+    one person, and Apple would treat the second as a fresh invite email.
+    """
+    emails: list[str] = []
+    seen: set[str] = set()
+    for chunk in raw.replace(",", " ").split():
+        candidate = chunk.strip()
+        if candidate and candidate.casefold() not in seen:
+            seen.add(candidate.casefold())
+            emails.append(candidate)
+    return emails
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--group", required=True)
+    parser.add_argument("--testers", default="", help="comma/space separated emails")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change and touch nothing.",
+    )
+    args = parser.parse_args()
+
+    emails = parse_emails(args.testers)
+    token = _token()
+    app = find_app(token, args.bundle_id)
+    print(f"app: {app['attributes']['name']} ({args.bundle_id}) id={app['id']}")
+
+    group = find_group(token, app["id"], args.group)
+    if group is None:
+        if args.dry_run:
+            print(f"group: {args.group!r} does NOT exist — would create (external)")
+            for email in emails:
+                print(f"  would add {email}")
+            return 0
+        group = create_group(token, app["id"], args.group)
+        print(f"group: created {args.group!r} id={group['id']} (external)")
+    else:
+        internal = group["attributes"].get("isInternalGroup")
+        kind = "internal" if internal else "external"
+        print(f"group: reusing existing {args.group!r} id={group['id']} ({kind})")
+        if internal:
+            # Refuse rather than quietly add external testers to an INTERNAL
+            # group: internal membership requires an App Store Connect user
+            # seat, so the request would mean something different than asked.
+            raise AscError(
+                f"A group named {args.group!r} already exists but is INTERNAL. "
+                "Rename it or pick another name — adding external testers to it "
+                "is not the same request."
+            )
+
+    already = group_member_emails(token, group["id"])
+    for email in emails:
+        if email.casefold() in already:
+            print(f"  {email}: already in the group — untouched")
+            continue
+        if args.dry_run:
+            print(f"  {email}: would add")
+            continue
+        print(f"  {email}: {add_tester(token, group['id'], email)}")
+
+    if not args.dry_run:
+        final = sorted(group_member_emails(token, group["id"]))
+        print(f"\n{args.group!r} now has {len(final)} tester(s):")
+        for email in final:
+            print(f"  - {email}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except AscError as failure:
+        print(f"::error::{failure}", file=sys.stderr)
+        sys.exit(1)

--- a/tool/ci/testflight_testers_test.py
+++ b/tool/ci/testflight_testers_test.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Self-tests for tool/ci/testflight_testers.py (repo convention: every tool
+under tool/ carries one, run by ci.yml's quality job).
+
+Scope is deliberately the parts that can be wrong WITHOUT Apple noticing: the
+email list parse, and the ES256 assertion. The HTTP calls are not mocked —
+Apple's JSON:API shapes are not something a local fake can validate, and a fake
+that agrees with a wrong assumption is worse than no test. Those are proven by
+dispatching the workflow with --dry-run, which reads and writes nothing.
+
+Run: python3 tool/ci/testflight_testers_test.py
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import os
+import pathlib
+import sys
+
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+_MODULE_PATH = pathlib.Path(__file__).with_name("testflight_testers.py")
+_spec = importlib.util.spec_from_file_location("testflight_testers", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+tf = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(tf)
+
+_failures: list[str] = []
+
+
+def check(label: str, actual: object, expected: object) -> None:
+    if actual == expected:
+        print(f"  ok   {label}")
+    else:
+        print(f"  FAIL {label}\n         expected: {expected!r}\n         actual:   {actual!r}")
+        _failures.append(label)
+
+
+def check_raises(label: str, fn, needle: str) -> None:
+    try:
+        fn()
+    except tf.AscError as failure:
+        if needle in str(failure):
+            print(f"  ok   {label}")
+        else:
+            print(f"  FAIL {label}: message lacked {needle!r} -> {failure}")
+            _failures.append(label)
+        return
+    print(f"  FAIL {label}: no AscError raised")
+    _failures.append(label)
+
+
+def test_parse_emails() -> None:
+    print("parse_emails")
+    check("comma separated", tf.parse_emails("a@x.com,b@x.com"), ["a@x.com", "b@x.com"])
+    check("whitespace tolerated", tf.parse_emails(" a@x.com ,\n b@x.com "), ["a@x.com", "b@x.com"])
+    check("empty is empty", tf.parse_emails(""), [])
+    check("trailing comma", tf.parse_emails("a@x.com,"), ["a@x.com"])
+    # The duplicate guard is the one that protects a real person's inbox.
+    check("case-insensitive dedupe", tf.parse_emails("A@x.com,a@x.com"), ["A@x.com"])
+    check("order preserved", tf.parse_emails("c@x.com b@x.com a@x.com"),
+          ["c@x.com", "b@x.com", "a@x.com"])
+
+
+def _pkcs8_pem() -> str:
+    key = ec.generate_private_key(ec.SECP256R1())
+    return key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+
+
+def _set_creds(pem_b64: str) -> None:
+    os.environ["ASC_KEY_ID"] = "TESTKEYID1"
+    os.environ["ASC_ISSUER_ID"] = "11111111-2222-3333-4444-555555555555"
+    os.environ["ASC_API_KEY_P8_BASE64"] = pem_b64
+
+
+def test_token() -> None:
+    print("_token")
+    pem = _pkcs8_pem()
+    flat = base64.b64encode(pem.encode()).decode()
+
+    _set_creds(flat)
+    token = tf._token()
+    header = jwt.get_unverified_header(token)
+    check("alg is ES256", header["alg"], "ES256")
+    check("kid is the key id", header["kid"], "TESTKEYID1")
+    claims = jwt.decode(
+        token,
+        serialization.load_pem_private_key(pem.encode(), password=None).public_key(),
+        algorithms=["ES256"],
+        audience="appstoreconnect-v1",
+    )
+    check("iss is the issuer id", claims["iss"], "11111111-2222-3333-4444-555555555555")
+    check("ttl within Apple's 20-minute cap", claims["exp"] - claims["iat"] <= 1200, True)
+
+    # The release lane's documented footgun: a base64 secret pasted with
+    # newlines. Ruby's decode64 ignores them, strict decoders do not — so the
+    # wrapped form must mint the SAME token payload as the flat one.
+    wrapped = "\n".join(flat[i:i + 64] for i in range(0, len(flat), 64))
+    _set_creds(wrapped)
+    check("newline-wrapped base64 decodes identically",
+          jwt.get_unverified_header(tf._token())["kid"], "TESTKEYID1")
+
+    # Fail CLOSED, naming what is absent — never a silent unauthenticated call.
+    _set_creds(flat)
+    for name in ("ASC_KEY_ID", "ASC_ISSUER_ID", "ASC_API_KEY_P8_BASE64"):
+        saved = os.environ[name]
+        os.environ[name] = ""
+        check_raises(f"missing {name} fails closed", tf._token, name)
+        os.environ[name] = saved
+
+    os.environ["ASC_API_KEY_P8_BASE64"] = base64.b64encode(b"not a pem").decode()
+    check_raises("non-PEM secret fails closed", tf._token, "PKCS#8 PEM")
+
+
+def main() -> int:
+    test_parse_emails()
+    test_token()
+    if _failures:
+        print(f"\n{len(_failures)} check(s) FAILED: {', '.join(_failures)}")
+        return 1
+    print("\nall testflight_testers self-tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

The founder asked for an External Testing group **Friends** with five testers. There was no surface in this repo that could do it: the App Store Connect API key lives only in GitHub secrets (architecture.md §9), so no dev-box command can authenticate, and the release lane's `pilot` call only uploads a binary with `distribute_external: false`.

## What

- `.github/workflows/testflight-testers.yml` — manual-dispatch lane, `environment: release`, resolving the same three ASC secrets as `release.yml`'s sign-upload job. Never runs on push: adding an external tester emails a real person, and that must not be a side effect of a merge.
- `tool/ci/testflight_testers.py` — idempotent create-group + add-testers against the App Store Connect API. Reuses a same-name group, links an existing tester by email rather than re-creating, leaves current members alone, and **refuses** if a same-name group turns out to be INTERNAL.
- `tool/ci/testflight_testers_test.py` + one `ci.yml` step — the `tool/` self-test convention. Covers the email parse (case-insensitive dedupe protects a real inbox) and the ES256 assertion, including the newline-wrapped-base64 footgun `release.yml` documents. Signs with a throwaway P-256 key, so it needs no secret.

## Bounds, stated plainly

The HTTP calls are **not** mocked — a fake that agrees with a wrong assumption about Apple's JSON:API shapes is worse than no test. They are proven by dispatching with `--dry-run`, which reads and writes nothing.

Creating the group and adding testers is **necessary, not sufficient**: an external tester receives nothing until a build is assigned to the group and clears Beta App Review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)