### PR TITLE
feat(testflight): print each build's iconAssetToken — "on main" is not "in the build"

### DIFF
--- a/tool/ci/testflight_testers.py
+++ b/tool/ci/testflight_testers.py
@@ -279,6 +279,22 @@ def print_status(token: str, app: dict, group_name: str) -> None:
             f"expired={attributes.get('expired')}  "
             f"uploaded={attributes.get('uploadedDate')}"
         )
+        # The icon Apple ACTUALLY extracted from the uploaded binary. Printed
+        # because "the right icon is on main" and "the right icon is in the
+        # build" are different claims, and this repo just spent eighteen days
+        # on a bug that was exactly that gap in another guise (issue #140).
+        # Session 052 shipped build 110 to replace a 109 that carried the stock
+        # Flutter icon; a differing token between two builds is the evidence.
+        icon = attributes.get("iconAssetToken")
+        if isinstance(icon, dict):
+            print(
+                f"      icon: {icon.get('templateUrl')}  "
+                f"({icon.get('width')}x{icon.get('height')})"
+            )
+        elif icon:
+            print(f"      icon: {icon}")
+        else:
+            print("      icon: (not reported by the API for this build)")
 
     gaps = review_readiness(token, app_id)
     print("\nbeta app review readiness (external testers need this):")


### PR DESCRIPTION
`--status` now reports the icon Apple actually extracted from each uploaded binary.

This exists because of the bug Session 052 was called in to fix. The founder reported the stock Flutter icon in TestFlight; the branded icon had been on `main` since `76ae5f3`, and the only successful release run had built from a branch that predated it. Nothing in this repo could answer *"which icon is in the build that shipped?"* without downloading the IPA — so the answer was eventually found by extracting the PNG out of a git object.

It is #140's shape one layer up: merged is not deployed, and built is not uploaded. A differing token between build 109 (stock Flutter) and build 110 (Two Seeds) is the cheapest possible evidence, available from a read-only dispatch.

Degrades honestly: the attribute is optional on Apple's side, so an absent one prints `(not reported by the API for this build)` rather than an empty field that reads like a verified negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)