### PR TITLE
fix(testflight): builds→betaGroups is FORBIDDEN by Apple — invert the lookup

### DIFF
--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -16,8 +16,8 @@
 _Last refreshed: 2026-07-28, **Session 055 close**._
 
 **Where things stand in one line:** the MVP is code-complete, both backends run
-current code and current rules, and a good TestFlight build (**110**, real icon)
-has been sitting there since 27 July — **the only thing between it and your five
+current code and current rules, and build **110** (real icon) is **installable on
+your own phone right now** via the `founders` internal group — **the only thing between it and your five
 testers is four contact fields, and item 2(c) is now a four-line recipe for
 them**; the website is built and proven on a preview URL and waits only on a DNS
 record and one legal blank; the product's one unproven link is still a **real
@@ -204,6 +204,24 @@ beta app review readiness (external testers need this):
 filled in — only the four *contact* fields are empty, and none of them is copy. They
 are your name, your email and your phone number. A good build has been sitting in
 TestFlight since 27 July waiting on a form.
+
+> ### ✅ You can install build 110 today. Right now.
+>
+> Measured against Apple immediately after the Session 055 merge:
+>
+> ```
+> build 110  processing=VALID  external=READY_FOR_BETA_SUBMISSION  internal=IN_BETA_TESTING
+> ```
+>
+> **`internal=IN_BETA_TESTING`** means the **`founders`** internal group already has
+> it. Open TestFlight on your iPhone and it is there — no review, no waiting, nothing
+> below required. If your partner is not seeing it, she is not in that group yet:
+> App Store Connect → **Users and Access** → invite her Apple ID → add her to
+> `founders`. Internal testers never wait for Beta App Review.
+>
+> `external=READY_FOR_BETA_SUBMISSION` is the other half: the *external* groups
+> (`Friends`, `arkadaslar`) are not in review yet, which is what the four fields
+> below unblock.
 
 A session can now write that form for you (ADR-038), but the four values are facts
 about *you*, so they come from secrets rather than from a text box. **They must not

--- a/tool/ci/testflight_testers.py
+++ b/tool/ci/testflight_testers.py
@@ -337,13 +337,33 @@ def build_beta_detail(token: str, build_id: str) -> dict:
     return (data or {}).get("attributes") or {}
 
 
-def build_group_names(token: str, build_id: str) -> list[str]:
-    """Which beta groups a build is attached to. A build in no group is inert."""
-    query = urllib.parse.urlencode({"limit": 200})
-    data = _call(token, "GET", f"/v1/builds/{build_id}/betaGroups?{query}").get(
-        "data", []
-    )
-    return [group.get("attributes", {}).get("name", "?") for group in data]
+def group_names_by_build(token: str, app_id: str) -> dict:
+    """Map build id -> the beta groups it is attached to. Inverted DELIBERATELY.
+
+    The obvious call is `GET /v1/builds/{id}/betaGroups`, and Apple refuses it:
+
+        403 FORBIDDEN_ERROR — The relationship 'betaGroups' does not allow
+        'GET_RELATED'. Allowed operations are: CREATE, DELETE
+
+    Measured against the real API on 2026-07-28, after the hermetic tests, five
+    design-review lenses and a completeness critic had all passed the forward
+    version — none of them can call Apple, which is exactly what this file's own
+    test docstring says about mocking Apple's shapes. The readable direction is
+    group -> builds, so ask each group once and invert.
+
+    Cost is one call per beta group (three here), not one per build.
+    """
+    query = urllib.parse.urlencode({"filter[app]": app_id, "limit": 200})
+    groups = _call(token, "GET", f"/v1/betaGroups?{query}").get("data", [])
+    by_build: dict[str, list[str]] = {}
+    for group in groups:
+        name = group.get("attributes", {}).get("name", "?")
+        builds = _call(
+            token, "GET", f"/v1/betaGroups/{group['id']}/builds?limit=200"
+        ).get("data", [])
+        for build in builds:
+            by_build.setdefault(build["id"], []).append(name)
+    return by_build
 
 
 # States meaning the build has already entered, or passed, the external gate.
@@ -558,6 +578,18 @@ def print_status(token: str, app: dict, group_name: str) -> None:
         marker = " <-- target" if attributes["name"] == group_name else ""
         print(f"  {attributes['name']!r} ({kind}){marker}")
 
+    # One inverted lookup for the whole listing (see group_names_by_build), and
+    # a FAILURE HERE MUST NOT EMPTY THE LISTING: a read-only status command that
+    # dies on an optional extra tells the founder less than one that degrades and
+    # says so. This is what the forbidden per-build call actually cost — it took
+    # the build list down with it.
+    try:
+        groups_by_build = group_names_by_build(token, app_id)
+        groups_available = True
+    except AscError as failure:
+        print(f"\n(group membership unavailable: {failure})")
+        groups_by_build, groups_available = {}, False
+
     print("\nbuilds (newest first):")
     for build in list_builds(token, app_id):
         attributes = build["attributes"]
@@ -589,13 +621,19 @@ def print_status(token: str, app: dict, group_name: str) -> None:
         # through a closed enum, so a state Apple adds tomorrow still shows up.
         # Group membership sits on the same rows because a build in no group
         # delivers to nobody however healthy every other field looks.
-        beta = build_beta_detail(token, build["id"])
-        print(
-            f"      external={beta.get('externalBuildState') or '(none)'}  "
-            f"internal={beta.get('internalBuildState') or '(none)'}"
-        )
-        groups = build_group_names(token, build["id"])
-        print(f"      groups: {', '.join(groups) if groups else '(none — inert)'}")
+        try:
+            beta = build_beta_detail(token, build["id"])
+            print(
+                f"      external={beta.get('externalBuildState') or '(none)'}  "
+                f"internal={beta.get('internalBuildState') or '(none)'}"
+            )
+        except AscError as failure:
+            print(f"      beta state unavailable: {failure}")
+        if groups_available:
+            groups = groups_by_build.get(build["id"], [])
+            print(
+                f"      groups: {', '.join(groups) if groups else '(none — inert)'}"
+            )
 
     gaps = review_readiness(token, app_id)
     print("\nbeta app review readiness (external testers need this):")

--- a/tool/ci/testflight_testers_test.py
+++ b/tool/ci/testflight_testers_test.py
@@ -460,6 +460,36 @@ def test_dry_run_against_a_missing_group_still_exits_non_zero() -> None:
     check("and is 0 when nothing failed", code, 0)
 
 
+def test_group_membership_is_looked_up_the_readable_way() -> None:
+    """The direction is the whole point, and Apple decided it, not us.
+
+    `GET /v1/builds/{id}/betaGroups` returns 403 FORBIDDEN_ERROR — that
+    relationship allows only CREATE and DELETE. Measured against the real API
+    AFTER the hermetic tests, five review lenses and a completeness critic had
+    all passed the forward version. This test pins the direction so nobody
+    "simplifies" it back."""
+    print("group membership is looked up the readable way")
+    seen = _fake_call([
+        ("GET", "/v1/betaGroups?", {"data": [
+            {"id": "g-1", "attributes": {"name": "Friends"}},
+            {"id": "g-2", "attributes": {"name": "arkadaslar"}},
+        ]}),
+        ("GET", "betaGroups/g-1/builds", {"data": [{"id": "b-110"}]}),
+        ("GET", "betaGroups/g-2/builds", {"data": [{"id": "b-109"}, {"id": "b-110"}]}),
+    ])
+    got = tf.group_names_by_build("t", "app-1")
+    check("a build in two groups lists both", sorted(got["b-110"]),
+          ["Friends", "arkadaslar"])
+    check("a build in one group lists one", got["b-109"], ["arkadaslar"])
+    check("a build in none is absent", "b-1" in got, False)
+    # The forbidden call must never be made.
+    check("never asks builds->betaGroups",
+          [p for _, p, _ in seen if "/betaGroups" in p and p.startswith("/v1/builds")],
+          [])
+    check("one call per group, not per build",
+          len([p for _, p, _ in seen if "/builds" in p and "betaGroups/" in p]), 2)
+
+
 def main() -> int:
     test_parse_emails()
     test_token()
@@ -470,6 +500,7 @@ def main() -> int:
     test_looks_already_submitted()
     test_missing_contact_does_not_block_assignment()
     test_dry_run_against_a_missing_group_still_exits_non_zero()
+    test_group_membership_is_looked_up_the_readable_way()
     if _failures:
         print(f"\n{len(_failures)} check(s) FAILED: {', '.join(_failures)}")
         return 1


### PR DESCRIPTION
Found by **dispatching the status lane against the real App Store Connect API** after #147 merged — not by any test, and not by any of the twelve review agents across two workflows. None of them can call Apple.

```
403 FORBIDDEN_ERROR — The relationship 'betaGroups' does not allow 'GET_RELATED'.
Allowed operations are: CREATE, DELETE
```

`tool/ci/testflight_testers_test.py`'s own docstring predicted this exactly: *"Apple's JSON:API shapes are not something a local fake can validate, and a fake that agrees with a wrong assumption is worse than no test."* My fake agreed with the wrong assumption.

**Two failures, not one.** The forbidden call also took the *build listing* down with it — `--status` exited 1 after printing a single build. A read-only status command that dies on an optional extra tells the founder less than one that degrades and says so. Both per-build extras are now individually survivable.

**The fix:** the readable direction is group → builds, so ask each group once and invert. One call per group (three here), not one per build. A test pins the direction so nobody "simplifies" it back, including an assertion that the forbidden path is never requested.

## What the same run measured — the answer the goal was actually about

```
build 110  processing=VALID  external=READY_FOR_BETA_SUBMISSION  internal=IN_BETA_TESTING
```

- **`internal=IN_BETA_TESTING`** — the `founders` internal group can install build 110 **right now**. No review, no waiting.
- **`external=READY_FOR_BETA_SUBMISSION`** — a state in *neither* named set, printed verbatim on the first real run, exactly as ADR-038 D5's open-enum decision intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)