### PR TITLE
docs(s055): the post-merge measurement — build 110 is already installable, and already in Friends

### DIFF
--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -250,13 +250,17 @@ incomplete, so the tool refuses a partial write and names what is missing.
 # Look first. Writes nothing, invites nobody.
 gh workflow run testflight-testers.yml -f dry_run=true -f set_review_contact=true
 
-# Then, for real: fill the page, attach build 110 to Friends, submit for review.
+# Then, for real: fill the page and send build 110 to Beta App Review.
 gh workflow run testflight-testers.yml \
   -f dry_run=false \
   -f set_review_contact=true \
-  -f assign_latest_build=true \
   -f submit_for_review=true
 ```
+
+> **`assign_latest_build` is not needed** — measured at the S055 close, build 110
+> is already attached to **`founders, Friends`**. The group is not empty and the
+> build is not unassigned; only the contact fields are missing. Pass
+> `-f assign_latest_build=true` anyway if you like: it is idempotent.
 
 `submit_for_review` **refuses** if anything is still missing rather than earning you
 a rejection, and is a no-op if the build is already through the gate. Apple's Beta

--- a/docs/past-prompts.md
+++ b/docs/past-prompts.md
@@ -1912,3 +1912,29 @@ Created the `ikimiz` Hosting site in `hayatiapp-prod` (it did not exist; `fireba
 **Operator action required: YES, and 2(c) is now two minutes of work.** Four `gh secret set` lines and one dispatch puts build 110 in front of Apple's reviewer. **2(d) is newly blocking** — the `applinks:` entitlement means the *next* release build fails to sign until Associated Domains is ticked on the App ID; build 110 predates it, which is why 2(c) ships 110.
 
 **Outcome:** **ADR-038** written and merged. **#146** filed. #140 remains the top engineering item and moves to Session 056.
+
+### S055 post-merge addendum — the bug only Apple could find, and the picture it completed
+
+After the merge, `testflight-testers.yml --status` was dispatched against the **real** App Store Connect API — the "read the ARTEFACT, not just the source" rule, applied to a lane that had until then only ever met a fake. It exited **1**:
+
+```
+403 FORBIDDEN_ERROR — The relationship 'betaGroups' does not allow 'GET_RELATED'.
+Allowed operations are: CREATE, DELETE
+```
+
+`GET /v1/builds/{id}/betaGroups` does not exist. The hermetic tests could not see it — this file's own test docstring predicted exactly that (*"a fake that agrees with a wrong assumption is worse than no test"*) — and **neither could twelve review agents across two workflows**, because none of them can call Apple. Five design lenses, five build-diff lenses and two completeness critics all passed the forward direction.
+
+**Two failures, not one.** The forbidden call also took the *build listing* down with it: exit 1 after printing a single build. A read-only status command that dies on an optional extra tells the founder less than one that degrades and says so. Both per-build extras are now individually survivable, and the lookup is inverted to the readable direction (group → builds, one call per group). PR **#148**, merged, then **re-dispatched and proven: exit 0, full listing**.
+
+What the two runs together established, which is the answer the founder's directive was actually asking for:
+
+```
+build 110  processing=VALID  external=READY_FOR_BETA_SUBMISSION  internal=IN_BETA_TESTING
+           groups: founders, Friends
+```
+
+- **`internal=IN_BETA_TESTING`** — build 110 is installable **today** by the `founders` internal group. Nothing on the operator page is required for that. This had been true since 27 July and nobody had measured it.
+- **`groups: founders, Friends`** — the build is already attached to the external group too, so `--assign-latest-build` is not part of the remaining recipe. The operator page was corrected.
+- **`READY_FOR_BETA_SUBMISSION`** is in neither of the named state sets and printed **verbatim**, on the first real run — ADR-038 D5's open-enum decision paying off immediately rather than theoretically.
+
+The remaining gap is exactly four fields, and it is the founder's to fill.


### PR DESCRIPTION
Two documentation corrections, both from measuring the real API after #148 merged rather than reasoning about it.

**1. `assign_latest_build` is not part of the remaining recipe.** Build 110 is already attached to `founders, Friends`. The operator page told the founder to pass a flag that changes nothing; it now says so and explains that passing it anyway is harmless (idempotent).

**2. The session log gains its post-merge addendum** — the `403 FORBIDDEN_ERROR` on `builds→betaGroups` that twelve review agents across two workflows could not find, because none of them can call Apple; the fact that it took the whole build listing down with it; and the picture the corrected run finally produced:

```
build 110  processing=VALID  external=READY_FOR_BETA_SUBMISSION  internal=IN_BETA_TESTING
           groups: founders, Friends
```

`internal=IN_BETA_TESTING` had been true since 27 July and nobody had measured it — the founder could have installed the app any day this week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)