### PR TITLE
fix(release): ADR-037's auto-assignment has NEVER worked — bare `pip` and `python3` were different interpreters

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -430,6 +430,15 @@ jobs:
           XCODE=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)
           if [ -n "$XCODE" ]; then sudo xcode-select -s "$XCODE"; fi
           xcodebuild -version
+      # Pins the interpreter the Friends-assignment step below installs into and
+      # runs from. Without it this job had NO managed python, so bare `pip` and
+      # `python3` were different interpreters and the assignment step could never
+      # import PyJWT (S056 — it failed on its first ever run, silently, behind
+      # continue-on-error). Same version and same shape as
+      # testflight-testers.yml, which is the lane that demonstrably works.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: fastlane beta (match sign + TestFlight)
         # match installs the Apple Distribution cert + App Store profile from the
         # encrypted MATCH_GIT_URL into the CI keychain, then the Flutter build signs
@@ -462,6 +471,14 @@ jobs:
         # shipped in the step above, and Apple's processing queue is a third
         # party's schedule. Reddening a release because a queue was slow is the
         # cries-wolf mistake ADR-034 rejected; the tool prints how to re-run.
+        #
+        # ⚠️ The cost of that non-blocking choice was measured at S056: this step
+        # failed on its FIRST EVER execution (release run 30502948416, build 112)
+        # and the release still reported success. `continue-on-error` is still
+        # right — Apple's queue is a third party's schedule — but "non-blocking"
+        # must not mean "unread". Whoever dispatches a release reads THIS step's
+        # log, or confirms with `-f status_only=true`, before believing a build
+        # reached anybody.
         continue-on-error: true
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
@@ -478,7 +495,24 @@ jobs:
           ASC_REVIEW_CONTACT_EMAIL: ${{ secrets.ASC_REVIEW_CONTACT_EMAIL }}
           ASC_REVIEW_CONTACT_PHONE: ${{ secrets.ASC_REVIEW_CONTACT_PHONE }}
         run: |
-          pip install --quiet 'pyjwt[crypto]==2.10.1'
+          # `python3 -m pip`, NOT bare `pip` — and this is the whole reason this
+          # step has never once worked (S056). On macos-15 there is no
+          # actions/setup-python in this job, so bare `pip` resolves to a
+          # DIFFERENT interpreter than `python3`: the install reported success,
+          # printed a pip-upgrade notice, and then `python3` raised
+          # `ModuleNotFoundError: No module named 'jwt'`. Because the step is
+          # continue-on-error, the release went green while ADR-037's central
+          # guarantee — every build reaches Friends automatically — silently did
+          # not happen. Routing pip through the same interpreter that runs the
+          # script makes them the same by CONSTRUCTION rather than by PATH order.
+          # The setup-python step above is what keeps that interpreter free of
+          # PEP-668 "externally managed" refusals, exactly as
+          # testflight-testers.yml does it.
+          python3 -m pip install --quiet 'pyjwt[crypto]==2.10.1'
+          # Prove the import before spending 25 minutes on Apple's queue: a
+          # missing module must fail HERE, loudly, and not as a silent no-op
+          # inside a continue-on-error step.
+          python3 -c "import jwt, cryptography; print('pyjwt', jwt.__version__, 'ok')"
           # The same synthesized number the build carries (ADR-032 D3).
           # --set-review-contact is passed unconditionally; if the four secrets
           # are unset the tool fails closed naming them, and this step is

--- a/docs/adr/037-testflight-friends-auto-assignment.md
+++ b/docs/adr/037-testflight-friends-auto-assignment.md
@@ -3,7 +3,38 @@
 - **Status:** Accepted
 - **Date:** 2026-07-28 (Session 054)
 - **Deciders:** founder (that external testers should get every build); session agent (upload-fast/assign-separately, and the non-blocking posture)
-- **Related:** **#139** (the S052 lane that created the group), **ADR-032** (the release lane), **ADR-034** (why a third party's schedule must not redden a build), `tool/ci/testflight_testers.py`
+- **Related:** **#139** (the S052 lane that created the group), **ADR-032** (the release lane), **ADR-034** (why a third party's schedule must not redden a build), **ADR-040** (the build this ADR's guarantee was first measured on), `tool/ci/testflight_testers.py`
+
+> ## ⚠️ Correction — 2026-07-30 (Session 056): this ADR's central guarantee did not hold on its first execution
+>
+> **The title claim was false for two days and nothing said so.** ADR-037 was
+> written in S054; the release that followed it (build 112, run `30502948416`) was
+> the **first** release run to reach the assignment step at all — build 110's
+> release predates this ADR — and that step **failed**:
+>
+> ```
+> ModuleNotFoundError: No module named 'jwt'
+> ##[error]Process completed with exit code 1
+> ```
+>
+> The `sign-upload` job had no `actions/setup-python`, so bare `pip install` and
+> `python3` resolved to **different interpreters** on `macos-15`. The install
+> reported success. The import did not exist. And because Decision 3 makes the
+> step `continue-on-error` — still the right call — **the release reported
+> success while no build was attached to anything.** Build 112 had to be assigned
+> by a separate `testflight-testers.yml` dispatch, exactly the manual step this
+> ADR exists to remove.
+>
+> Fixed by pinning the interpreter (`actions/setup-python` + `python3 -m pip`, so
+> installer and runner are the same by **construction**, not by PATH order) and by
+> asserting the import *before* the 25-minute Apple wait, so a missing dependency
+> fails loudly at a named line instead of silently inside a tolerated step.
+>
+> **The lesson is not "continue-on-error was wrong".** It is that **non-blocking
+> must not mean unread** — a tolerated failure still needs a reader, and this one
+> had none. Decision 3's reasoning stands; Decision 3's *verification* was
+> missing, and that is the gap. It is the #140 shape (a green check that guards
+> nothing) inside the very lane ADR-037 built, met for the fourth recorded time.
 
 ## Context
 

--- a/docs/adr/038-testflight-beta-review-readiness.md
+++ b/docs/adr/038-testflight-beta-review-readiness.md
@@ -127,6 +127,27 @@ ADR-037's guarantee that every release build reaches the Friends group, while `c
 kept the release green. The write now reports, continues, and still exits non-zero. A dedicated test
 drives `main()` with the secrets unset and asserts the assignment POST still happens.
 
+> **⚠️ Correction — 2026-07-30 (Session 056): D4 named the right failure and the wrong layer.**
+>
+> The paragraph above predicts, precisely, *"silently repealing ADR-037's guarantee that every
+> release build reaches the Friends group, while `continue-on-error` kept the release green."* That
+> is exactly what happened on the first release after these ADRs shipped (build 112, run
+> `30502948416`) — **and not for any of the reasons defended against here.** The step never reached
+> `read_review_contact()`, never reached the assignment POST, and never ran a line of
+> `testflight_testers.py`: it died on `import jwt`, because `sign-upload` had no
+> `actions/setup-python` and bare `pip` installed into a different interpreter than `python3`.
+>
+> So the non-fatal write and its dedicated test were both correct and both irrelevant. **The
+> hardening was one layer too high.** Every guard here assumed the tool RUNS; nothing established
+> that its dependencies were importable, and the hermetic test could not — it imports `jwt` from the
+> dev box's own environment, which is precisely the S055 warning about a fake that agrees with your
+> assumption, one level down in the stack.
+>
+> Fixed in `release.yml` (pinned interpreter + an explicit `import jwt, cryptography` assertion
+> before the 25-minute Apple wait). **The transferable rule: when you harden a step against its
+> failure modes, enumerate the ones BELOW your abstraction too — "the script raises" and "the script
+> never started" are different failures, and only the first one has a test.**
+
 ### D7 — `--dry-run` covers both new writes, and says which
 
 The review found dry-run semantics unstated for the two new operations — a gap that matters because

--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -19,10 +19,11 @@ _Last refreshed: 2026-07-30, **Session 056 close**._
 current code and current rules, **both of your bug reports are fixed and merged**
 (ADR-039 — the permanent loading screen, and invite links that landed on a
 certificate error), the **invite site is LIVE** (`https://ikimiz.web.app/i/<code>`
-→ 200, verified, item 2(e0) closed), and a fresh build carrying all of it is going
-to TestFlight — so **the only thing between your five friends and a working app is
-the four contact fields in item 2(c)**; the product's one unproven link is still a
-**real purchase**, behind item 0(a).
+→ 200, verified, item 2(e0) closed), and **build 112 carrying all of it is in
+TestFlight and attached to `Friends`, where your five testers already are** — so
+**the only thing between those five people and a working app is the four contact
+fields in item 2(c)**, one `gh secret set` each; the product's one unproven link
+is still a **real purchase**, behind item 0(a).
 
 > **⚠️ Read 2(c) first — it is now the ONLY thing between your friends and a
 > working app.** Four contact fields, ~2 minutes. Everything else on the path is
@@ -203,10 +204,27 @@ than this page used to imply:
 > Beta App Review would spend a 24–48 h review handing your friends the exact
 > build you filed two bug reports about.
 >
-> A fresh build carrying ADR-039 and ADR-040 was cut on **2026-07-30** and is
-> auto-assigned to `Friends` (ADR-037). Confirm which build you are about to
-> submit with `status_only=true` — you want the **newest VALID** one — and pass
-> `-f assign_latest_build=true` so the newest is the one attached.
+> **Build 112 is that build**, cut on **2026-07-30**, carrying ADR-039 and
+> ADR-040. Measured against Apple after upload:
+>
+> ```
+> build 112  processing=VALID  groups: founders, Friends
+> 'Friends' now has 5 tester(s):
+>   ahmetsahinerr66@icloud.com   erencemozturk@icloud.com
+>   kazimutkucitoglu@gmail.com   m.yahyaonder@gmail.com
+>   seymabutun9@gmail.com
+> ```
+>
+> **Your five friends are already in the group and the right build is already
+> attached to it.** Everything below Step 1 is done. The four secrets are the
+> only thing left.
+>
+> ⚠️ **It was NOT auto-assigned, despite ADR-037 promising it would be.** That
+> step failed on its first ever execution (`ModuleNotFoundError: No module named
+> 'jwt'`) and, being `continue-on-error`, took the release green with it. A
+> session attached build 112 by hand and fixed the lane. **The habit worth
+> keeping: after any release, run `status_only=true` and read `groups:` — do not
+> infer delivery from a green release.**
 
 ```
 app: ikimiz (com.beyondkaira.hayati)
@@ -272,13 +290,18 @@ incomplete, so the tool refuses a partial write and names what is missing.
 # Look first. Writes nothing, invites nobody.
 gh workflow run testflight-testers.yml -f dry_run=true -f set_review_contact=true
 
-# Then, for real: fill the page, attach the NEWEST build, and send it to review.
+# Then, for real: fill the page and send build 112 to Beta App Review.
+# (assign_latest_build is harmless and idempotent — 112 is already attached.)
 gh workflow run testflight-testers.yml \
   -f dry_run=false \
   -f set_review_contact=true \
   -f assign_latest_build=true \
   -f submit_for_review=true
 ```
+
+**That single command is the last step.** Apple's Beta App Review is typically
+24–48 h for a first submission; after it passes, all five names above get the
+install notification automatically.
 
 > **`assign_latest_build=true` IS needed now** — corrected from the S055 text,
 > which said it was not. That was true when build 110 was the newest build; it is


### PR DESCRIPTION
## Objective

Build 112's release was the **first run ever** to reach the `assign the new build to the Friends group` step — build 110's release predates ADR-037. It failed:

```
ModuleNotFoundError: No module named 'jwt'
##[error]Process completed with exit code 1
```

`sign-upload` has no `actions/setup-python`, so on `macos-15` bare `pip install` resolved to a **different interpreter** than `python3`. The install reported success and even printed a pip-upgrade notice; the import did not exist. Because the step is `continue-on-error` — still the right call — **the release reported SUCCESS while no build was attached to anything.**

**Measured, not inferred.** After the green release, Apple reported:

```
build 112  processing=VALID  groups: founders            <- not Friends
build 110  processing=VALID  groups: founders, Friends
```

Build 112 was then attached by a manual `testflight-testers.yml` dispatch — exactly the step ADR-037 exists to remove. That dispatch also surfaced that **`Friends` already holds five testers**, which nothing had reported.

## The fix

Structural rather than positional:

- `actions/setup-python@v5` pins the interpreter (and keeps it free of PEP-668 `externally-managed` refusals) — the same shape as `testflight-testers.yml`, the lane that demonstrably works;
- `python3 -m pip install` installs into the **same interpreter that runs the script**, by construction rather than by PATH order;
- an explicit `python3 -c "import jwt, cryptography"` assertion fails **loudly, at a named line, before** the 25-minute Apple wait — instead of silently inside a tolerated step.

`continue-on-error` **stays**. The lesson is not that it was wrong; Apple's queue really is a third party's schedule. It is that **non-blocking must not mean unread**, and this failure had no reader.

## Tests added

None, and the honesty about why matters: this is a **CI-runner environment defect**, which is the one class this repo's own doctrine says a local test cannot refute (ADR-024 D1: policy in YAML is policy no self-test can see; S055 addendum 63: only the vendor can refute a vendor shape). A hermetic test imports `jwt` from *this box's* environment and would pass in both directions.

What was verified instead:

- `release.yml` parses; `sign-upload` step order confirmed with `setup-python` ahead of both fastlane steps and the assignment.
- `dart tool/release_lane_lint_test.dart` — **80 checks passed**; `dart tool/release_lane_lint.dart` — **PASS (11 checks)**. The lint governs which secrets may reach `sign-upload` (ADR-032/038), so adding a step there is exactly what it exists to notice.
- **The real verification is the next release run.** Its assignment step now either prints `pyjwt 2.10.1 ok` and assigns, or fails at the import line. Both outcomes are readable; neither is silent.

## Docs touched

- **ADR-037** — dated correction. Its *title claim* was false from the moment it was written until this PR.
- **ADR-038 D4** — dated correction, and the sharper finding: that paragraph **predicted this exact failure** ("silently repealing ADR-037's guarantee … while `continue-on-error` kept the release green") **for the wrong cause, one layer too high**. Every guard there assumed the tool *runs*. Transferable rule recorded: *"the script raises" and "the script never started" are different failures, and only the first one has a test.*
- **`operator-expected.md` 2(c)** — measured state: build 112 VALID and attached, the five testers named, the four contact secrets as the only remaining step, plus the habit (read `groups:` from `status_only`; never infer delivery from a green release).

## Screens

None — CI config and docs.

## Risk

- **`setup-python` runs on the signing job**, which handles credentials. It is a first-party GitHub action already used in `testflight-testers.yml` under the same `release` environment, it is placed *after* the secrets gate and *before* the fastlane steps, and `release_lane_lint` passes — so the credential-gating invariant ADR-032 enforces is intact and proven, not assumed.
- **The next release is the first proof.** This PR cannot demonstrate the fix; it can only make the failure loud. Stated plainly rather than claimed as verified.
- **Build 112 is already correctly attached**, so nothing about the current TestFlight state depends on this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)