### PR TITLE
docs(s057): close — re-measured, nothing moved, and the readiness snapshot session-rules asks for was never actually on the page

### DIFF
--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -32,12 +32,30 @@ a **real purchase**, behind item 0(a).
 > working app, it takes about a minute, and everything else on that path is
 > finished and measured.
 
+## Readiness snapshot — three different questions, three different answers
+
+A single "% done" hides the thing you actually need to know, which is *done for
+what*. These are measured, and each one names its own remaining blockers.
+
+| Question | Where it stands | What is left |
+|---|---|---|
+| **Is the MVP built?** | **100%** — M1→M6.3 including M5.3 all merged (`implementation-plan.md`). App suite 1625 tests / 87.4% coverage (gate 68); Functions 97.2% (gate 80). Both backends run current code and current rules. | Nothing. M6.5 (Android) is a Gate-3-gated follow-on, deliberately not MVP (ADR-006). |
+| **Can your five friends install it?** | **~95%** — build 113 is VALID in TestFlight, attached to `Friends`, all five testers in place, export compliance answered, Test Information copy complete. | **Item 2(c): four contact fields.** ~1 minute of your time, then 24–48 h of Apple's. Nothing else. |
+| **Could this go on the public App Store?** | **~55%** — and this is the honest number, not the discouraging one. The build is ready; the *business and legal surface around it* is not. | Items **0(a)** (purchases take money and do not unlock Premium — the single most serious open item on this page), **0(b)** (the sandbox purchase has never been run, so the paid loop is unproven end to end), **9** (legal bundle: three blanks, unreviewed, one KVKK filing), **1** and **★** (native TR/AR review — the biggest quality risk, and the crisis lexicon is a safety gate), **8(c)/(d)/(e)** (store URLs, age rating, App Privacy), and **analytics** (Gates 2 and 3 are unfalsifiable without it). |
+
+**The one-sentence version:** the software is finished, the beta is one form
+field away, and public launch is gated on money, law and language — none of
+which is an engineering problem, and most of which needs you rather than a
+session.
+
 ---
 
 # 🔴 2(c). Four secrets — the only thing left between your friends and the app
 
-Measured against Apple at **2026-07-31 11:20 UTC**, immediately after the
-build-113 release:
+Measured against Apple immediately after the build-113 release, and
+**re-confirmed unchanged at 2026-07-31 11:24 UTC** at the session close
+(`gh secret list --env release` still returns only the three signing secrets —
+nobody has set the four below yet):
 
 ```
 app: ikimiz (com.beyondkaira.hayati)  id=6794737016

--- a/docs/past-prompts.md
+++ b/docs/past-prompts.md
@@ -2072,3 +2072,13 @@ Two deliberate structural choices:
 * **The one thing a session cannot close:** a surname and a phone number. `gh api user` returns `name=Aytek E`, and the git history carries a personal email that *suggests* a surname — which is precisely why it was not used. Apple's Beta App Review contact is a real person Apple may actually call; a plausible guess is worse than an empty field, because an empty field is honestly reported by the tool and a wrong one is not.
 
 **Final state at the close:** build **113** VALID in TestFlight, attached to `founders` + `Friends`, carrying every fix from ADR-039/ADR-040; the five testers in place; export compliance answered; Test Information copy complete; **the four contact fields the only gap, and the only item on the founder's critical path.**
+
+### Session 057 close addendum — the re-measurement, and why the readiness number was split into three
+
+At the close the founder asked for status, a readiness percentage, and the next-session goal. Re-derived rather than carried forward, and **nothing had moved**: `gh secret list --env release` still returns only `ASC_API_KEY_P8` / `ASC_ISSUER_ID` / `ASC_KEY_ID`, and a fresh read-only dispatch still reports build 113 `VALID` / `external=READY_FOR_BETA_SUBMISSION` / `groups: founders, Friends` with the same four contact gaps. The operator page needed **no item change** — the honest update was a dated *re-confirmation*, which is a different thing from a refresh and worth writing as such.
+
+**The percentage was deliberately refused as a single number** and given as three, because "how done are we" has three different answers here and the average of them is information-destroying: **MVP built ≈ 100%** (M1→M6.3 incl. M5.3, both suites green, both backends current); **installable by the five external testers ≈ 95%** (one founder form field); **shippable to the public App Store ≈ 55%** (the paid loop is unproven end to end and #115 means a real purchase would take money without unlocking Premium; the legal bundle has three blanks and a KVKK filing; TR/AR copy and the crisis lexicon are unreviewed; analytics is absent, so Gates 2 and 3 cannot be read at all). A single blended figure would have implied the product is ~85% shippable, which is false in the direction that costs money.
+
+`session-rules.md` §3 already asked for a *"plan-progress/readiness snapshot"* on that page and it had never actually been carried there — the page had drifted into pure checklist. Added as a three-row table, each row naming its own blockers by item number.
+
+**Session closed.** Next objective unchanged in `resume-prompt.md`: **#140**, deferred a fifth time, now with five sessions of deferral history recorded as evidence for it rather than against it (addendum 68).


### PR DESCRIPTION
Session close. The founder asked for status, a completion percentage and the next-session goal.

## Re-derived, not carried forward — and nothing moved

```
$ gh secret list --env release
ASC_API_KEY_P8 · ASC_ISSUER_ID · ASC_KEY_ID        # the four contact secrets: still absent

build 113  processing=VALID  external=READY_FOR_BETA_SUBMISSION  internal=IN_BETA_TESTING
           groups: founders, Friends
  MISSING - Test Information: review contact {email, first name, last name, phone}
```

So the operator page needed **no item change**. The honest update is a dated *re-confirmation*, which is a different claim from a refresh, and is written as such.

## The percentage is three numbers, not one

| Question | Answer | Blockers |
|---|---|---|
| MVP built? | **~100%** | none — M1→M6.3 incl. M5.3, both suites green, both backends current |
| Installable by the five external testers? | **~95%** | one founder form field (item `2(c)`) |
| Shippable to the public App Store? | **~55%** | `0(a)` purchases take money without unlocking Premium · `0(b)` the paid loop has never been proven end to end · `9` legal blanks + KVKK filing · `1`/`★` TR/AR copy and crisis lexicon unreviewed · `8(c)/(d)/(e)` · analytics absent, so Gates 2–3 are unfalsifiable |

A single blended figure would read ~85% shippable, which is false **in the direction that costs money**.

`session-rules.md` §3 already required a *"plan-progress/readiness snapshot"* on that page and it had never actually been carried there — the page had drifted into a pure checklist. Added as a three-row table, each row naming its own blockers by item number.

## Next session

Unchanged in `resume-prompt.md`: **#140** — nothing in CI compares what is *merged* to what is *deployed*. Deferred a fifth time, now with the deferral history recorded as evidence *for* the issue rather than against it (addendum 68).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)