### PR TITLE
feat(testflight): merge a beta group into another and delete it — link, RE-READ, then delete

### DIFF
--- a/.github/workflows/testflight-testers.yml
+++ b/.github/workflows/testflight-testers.yml
@@ -35,6 +35,15 @@ on:
         description: 'Attach the newest VALID build to the group (a group with no build is inert)'
         type: boolean
         default: false
+      # DESTRUCTIVE and outward-facing: it deletes a beta group. A free-text
+      # box rather than a boolean on purpose — typing the name is the
+      # confirmation, and there is no default that could fire by accident.
+      # The tool links, RE-READS to confirm every member landed, and only then
+      # deletes; it refuses on an unknown or internal source.
+      merge_group:
+        description: 'DELETES this group after moving its testers into `group` (e.g. arkadaslar). Blank = do nothing'
+        required: false
+        default: ''
       # ADR-038. NOTE what is NOT here: a text box for the contact details.
       # This repository is PUBLIC and workflow_dispatch inputs are recorded in
       # run metadata, so a box asking for the founder's mobile number would
@@ -85,6 +94,7 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
           STATUS_ONLY: ${{ inputs.status_only }}
           ASSIGN_BUILD: ${{ inputs.assign_latest_build }}
+          MERGE_GROUP: ${{ inputs.merge_group }}
           SET_CONTACT: ${{ inputs.set_review_contact }}
           SUBMIT_REVIEW: ${{ inputs.submit_for_review }}
           # The four founder facts. Absent secrets resolve to empty strings and
@@ -103,6 +113,7 @@ jobs:
           if [ "$DRY_RUN" = "true" ]; then args+=(--dry-run); fi
           if [ "$STATUS_ONLY" = "true" ]; then args+=(--status); fi
           if [ "$ASSIGN_BUILD" = "true" ]; then args+=(--assign-latest-build); fi
+          if [ -n "$MERGE_GROUP" ]; then args+=(--merge-group "$MERGE_GROUP"); fi
           if [ "$SET_CONTACT" = "true" ]; then args+=(--set-review-contact); fi
           if [ "$SUBMIT_REVIEW" = "true" ]; then args+=(--submit-for-review); fi
           python3 tool/ci/testflight_testers.py "${args[@]}"

--- a/tool/ci/testflight_testers.py
+++ b/tool/ci/testflight_testers.py
@@ -132,12 +132,16 @@ def find_app(token: str, bundle_id: str) -> dict:
     return found[0]
 
 
+def list_groups(token: str, app_id: str) -> list[dict]:
+    query = urllib.parse.urlencode({"filter[app]": app_id, "limit": 200})
+    return _call(token, "GET", f"/v1/betaGroups?{query}").get("data", [])
+
+
 def find_group(token: str, app_id: str, name: str) -> dict | None:
     """Look the group up by app, then match the name HERE rather than with a
     server-side filter[name]: the list filter is exact and case-sensitive, and
     a near-miss would silently create a second 'friends' beside 'Friends'."""
-    query = urllib.parse.urlencode({"filter[app]": app_id, "limit": 200})
-    for group in _call(token, "GET", f"/v1/betaGroups?{query}").get("data", []):
+    for group in list_groups(token, app_id):
         if group["attributes"]["name"].strip().casefold() == name.strip().casefold():
             return group
     return None
@@ -154,13 +158,23 @@ def create_group(token: str, app_id: str, name: str) -> dict:
     return _call(token, "POST", "/v1/betaGroups", payload)["data"]
 
 
-def group_member_emails(token: str, group_id: str) -> set[str]:
+def group_members(token: str, group_id: str) -> list[dict]:
+    """The tester RECORDS in a group, not just their addresses.
+
+    `merge_group` needs the ids: linking a tester to another group by id is one
+    call and cannot mis-resolve, whereas re-deriving them from an email would
+    round-trip through `filter[email]` and depend on Apple's case handling for
+    an address we already hold."""
     query = urllib.parse.urlencode({"limit": 200})
-    members = _call(
+    return _call(
         token, "GET", f"/v1/betaGroups/{group_id}/betaTesters?{query}"
     ).get("data", [])
+
+
+def group_member_emails(token: str, group_id: str) -> set[str]:
     return {
-        (tester["attributes"].get("email") or "").casefold() for tester in members
+        (tester["attributes"].get("email") or "").casefold()
+        for tester in group_members(token, group_id)
     }
 
 
@@ -203,6 +217,116 @@ def add_tester(token: str, group_id: str, email: str) -> str:
         },
     )
     return "invited-new"
+
+
+def merge_group(
+    token: str,
+    app_id: str,
+    source_name: str,
+    target: dict,
+    dry_run: bool = False,
+) -> list[str]:
+    """Move every tester from `source_name` into `target`, then DELETE the source.
+
+    Founder request (S057): *"merge those groups and only keep Friends"* — two
+    external groups had been a standing source of confusion (issue #146), and
+    one group that always gets the build is simpler than two that might.
+
+    THE ORDER IS THE GUARANTEE: link, then RE-READ the target, then delete. A
+    version that deletes on the strength of a 2xx from the link call would, on
+    the day Apple accepts the request and does not apply it, silently strip a
+    real person's access — and every `--status` afterwards would report a clean
+    single-group setup, because the evidence would be gone with the group. This
+    refuses to delete unless it has SEEN each member on the other side.
+
+    Deleting a beta group does not delete its testers: `betaTesters` are
+    app-scoped, so anyone who was only in the source remains a tester on the app
+    and is now in the target as well.
+    """
+    lines: list[str] = []
+    target_name = target["attributes"]["name"]
+    if source_name.strip().casefold() == target_name.strip().casefold():
+        raise AscError(
+            f"refusing to merge {source_name!r} into itself — that is a plain "
+            "delete wearing a friendlier name. Name a different source group."
+        )
+
+    source = find_group(token, app_id, source_name)
+    if source is None:
+        # Loudly, NOT as a no-op. A mistyped source that reported "nothing to
+        # merge" would read exactly like a successful second run while the real
+        # group sat untouched — the false-clean this repo keeps paying for.
+        existing = ", ".join(
+            repr(group["attributes"]["name"]) for group in list_groups(token, app_id)
+        )
+        raise AscError(
+            f"no beta group named {source_name!r} exists for this app. "
+            f"Existing groups: {existing}. (If you have already merged it, that "
+            "is the expected message — there is nothing left to do.)"
+        )
+    if source["attributes"].get("isInternalGroup"):
+        raise AscError(
+            f"{source_name!r} is an internal group. Internal membership is an "
+            "App Store Connect USER SEAT, not an invite, so deleting it is a "
+            "different act than merging external testers. Refusing."
+        )
+
+    members = group_members(token, source["id"])
+    already = group_member_emails(token, target["id"])
+    moving = [
+        tester
+        for tester in members
+        if (tester["attributes"].get("email") or "").casefold() not in already
+    ]
+    staying = len(members) - len(moving)
+    lines.append(
+        f"merge: {source_name!r} has {len(members)} tester(s); "
+        f"{staying} already in {target_name!r}, {len(moving)} to move"
+    )
+    for tester in moving:
+        lines.append(f"  move {tester['attributes'].get('email')}")
+
+    if dry_run:
+        lines.append(
+            f"  WOULD move the above into {target_name!r}, verify, then "
+            f"DELETE the group {source_name!r}"
+        )
+        return lines
+
+    if moving:
+        _call(
+            token,
+            "POST",
+            f"/v1/betaGroups/{target['id']}/relationships/betaTesters",
+            {
+                "data": [
+                    {"type": "betaTesters", "id": tester["id"]} for tester in moving
+                ]
+            },
+        )
+
+    # The re-read. Not a formality — this is the only thing standing between a
+    # partially-applied link and an unrecoverable delete.
+    confirmed = group_member_emails(token, target["id"])
+    missing = sorted(
+        (tester["attributes"].get("email") or "")
+        for tester in members
+        if (tester["attributes"].get("email") or "").casefold() not in confirmed
+    )
+    if missing:
+        raise AscError(
+            f"NOT deleting {source_name!r}: after the move, "
+            f"{', '.join(missing)} still cannot be seen in {target_name!r}. "
+            "Both groups are intact — re-run, or add them by hand. Nothing was "
+            "lost, which is the point of checking."
+        )
+
+    _call(token, "DELETE", f"/v1/betaGroups/{source['id']}")
+    lines.append(
+        f"  verified all {len(members)} tester(s) in {target_name!r}; "
+        f"deleted the group {source_name!r}"
+    )
+    return lines
 
 
 def list_builds(token: str, app_id: str, limit: int = 5) -> list[dict]:
@@ -703,6 +827,15 @@ def main() -> int:
         ),
     )
     parser.add_argument(
+        "--merge-group",
+        help=(
+            "Move every tester out of THIS group into --group, then delete it. "
+            "Outward-facing and destructive: links, RE-READS to confirm each "
+            "member landed, and only then deletes. Refuses on an unknown or "
+            "internal source rather than reporting a false clean."
+        ),
+    )
+    parser.add_argument(
         "--set-review-contact",
         action="store_true",
         help=(
@@ -778,6 +911,15 @@ def main() -> int:
                 "Rename it or pick another name — adding external testers to it "
                 "is not the same request."
             )
+
+    # BEFORE the tester adds, so `already` below is computed against the merged
+    # membership — otherwise a merge and an --testers add naming the same person
+    # in one dispatch would try to link them twice.
+    if args.merge_group:
+        for line in merge_group(
+            token, app["id"], args.merge_group, group, dry_run=args.dry_run
+        ):
+            print(line)
 
     already = group_member_emails(token, group["id"])
     for email in emails:

--- a/tool/ci/testflight_testers_test.py
+++ b/tool/ci/testflight_testers_test.py
@@ -490,6 +490,110 @@ def test_group_membership_is_looked_up_the_readable_way() -> None:
           len([p for _, p, _ in seen if "/builds" in p and "betaGroups/" in p]), 2)
 
 
+def test_merge_group() -> None:
+    """Merging is a DELETE wearing a friendly name, so every guard is pinned.
+
+    The founder asked to collapse `arkadaslar` into `Friends` and keep one
+    group. The dangerous version of that request is the one that deletes the
+    source before proving the members landed — a silent, unrecoverable loss of
+    someone's access that every status read afterwards would report as clean.
+    So the ordering (link -> RE-READ -> delete) is the guarantee, and the
+    re-read is asserted here rather than assumed."""
+    print("merge_group")
+    target = {"id": "tgt-1", "attributes": {"name": "Friends", "isInternalGroup": False}}
+
+    def groups(source=None):
+        return [
+            {"id": "tgt-1", "attributes": {"name": "Friends", "isInternalGroup": False}},
+            *([source] if source else []),
+        ]
+
+    external_source = {"id": "src-1",
+                       "attributes": {"name": "arkadaslar", "isInternalGroup": False}}
+
+    # Merging a group into itself is a pure delete with a reassuring label.
+    _fake_call([("GET", "/v1/betaGroups?", {"data": groups(external_source)})])
+    check_raises("refuses merging a group into itself",
+                 lambda: tf.merge_group("t", "app-1", "friends", target), "itself")
+
+    # A typo must NOT read as "already merged" — that is the false-clean this
+    # repo keeps being bitten by. Refuse, and name what does exist.
+    _fake_call([("GET", "/v1/betaGroups?", {"data": groups(external_source)})])
+    try:
+        tf.merge_group("t", "app-1", "arkadaslr", target)
+        check("refuses an unknown source group", "no error", "AscError")
+    except tf.AscError as failure:
+        check("unknown source names the typo", "arkadaslr" in str(failure), True)
+        check("unknown source lists what exists", "arkadaslar" in str(failure), True)
+
+    # Internal groups mean App Store Connect SEATS, not invites. Deleting one is
+    # a different act than the founder asked for.
+    _fake_call([("GET", "/v1/betaGroups?", {"data": groups(
+        {"id": "src-1", "attributes": {"name": "founders", "isInternalGroup": True}})})])
+    check_raises("refuses to delete an INTERNAL group",
+                 lambda: tf.merge_group("t", "app-1", "founders", target), "internal")
+
+    # ---- the happy path, with a stateful fake: the target membership must
+    # actually CHANGE between the link and the verification re-read, which a
+    # fragment-matched script cannot express.
+    def stateful(*, link_lands: bool):
+        state = {"target": [{"id": "u2", "attributes": {"email": "b@x.co"}}],
+                 "deleted": [], "linked": [], "reads": 0}
+
+        def call(_token, method, path, body=None):
+            if method == "GET" and "/v1/betaGroups?" in path:
+                return {"data": groups(external_source)}
+            if method == "GET" and "betaGroups/src-1/betaTesters" in path:
+                return {"data": [{"id": "u1", "attributes": {"email": "A@x.co"}},
+                                 {"id": "u2", "attributes": {"email": "b@x.co"}}]}
+            if method == "GET" and "betaGroups/tgt-1/betaTesters" in path:
+                state["reads"] += 1
+                return {"data": list(state["target"])}
+            if method == "POST" and "betaGroups/tgt-1/relationships" in path:
+                state["linked"] = [d["id"] for d in body["data"]]
+                if link_lands:
+                    state["target"].append(
+                        {"id": "u1", "attributes": {"email": "A@x.co"}})
+                return {}
+            if method == "DELETE":
+                state["deleted"].append(path)
+                return {}
+            return {}
+
+        tf._call = call
+        return state
+
+    state = stateful(link_lands=True)
+    lines = tf.merge_group("t", "app-1", "arkadaslar", target)
+    check("links ONLY the member not already in the target", state["linked"], ["u1"])
+    check("deletes the source group, once", state["deleted"], ["/v1/betaGroups/src-1"])
+    check("re-reads the target to verify before deleting", state["reads"] >= 2, True)
+    check("says what moved", any("A@x.co" in line for line in lines), True)
+    # Case-insensitivity is not cosmetic: 'A@x.co' vs 'a@x.co' deciding
+    # membership would re-invite a tester who is already there.
+    state = stateful(link_lands=True)
+    state["target"] = [{"id": "u1", "attributes": {"email": "a@x.co"}},
+                       {"id": "u2", "attributes": {"email": "b@x.co"}}]
+    tf.merge_group("t", "app-1", "arkadaslar", target)
+    check("a case-differing email counts as already present", state["linked"], [])
+    check("an already-merged group is still deleted",
+          state["deleted"], ["/v1/betaGroups/src-1"])
+
+    # THE load-bearing case: the link did not land. Deleting now would strip a
+    # real person's access and every later status read would look clean.
+    state = stateful(link_lands=False)
+    check_raises("refuses to delete when a member did not land",
+                 lambda: tf.merge_group("t", "app-1", "arkadaslar", target), "A@x.co")
+    check("nothing deleted when verification fails", state["deleted"], [])
+
+    # dry run touches nothing at all — especially not DELETE.
+    state = stateful(link_lands=True)
+    lines = tf.merge_group("t", "app-1", "arkadaslar", target, dry_run=True)
+    check("dry run links nothing", state["linked"], [])
+    check("dry run deletes nothing", state["deleted"], [])
+    check("dry run says WOULD", any("WOULD" in line for line in lines), True)
+
+
 def main() -> int:
     test_parse_emails()
     test_token()
@@ -501,6 +605,7 @@ def main() -> int:
     test_missing_contact_does_not_block_assignment()
     test_dry_run_against_a_missing_group_still_exits_non_zero()
     test_group_membership_is_looked_up_the_readable_way()
+    test_merge_group()
     if _failures:
         print(f"\n{len(_failures)} check(s) FAILED: {', '.join(_failures)}")
         return 1


### PR DESCRIPTION
Founder directive (S057): **"merge those groups and only keep Friends"**. Two external groups (`Friends`, `arkadaslar`) had been a standing source of confusion — issue #146 was filed on exactly that shape — and one group that always gets the build is simpler than two that might.

## The order is the guarantee

**link → RE-READ → delete.**

A version that deleted on the strength of a 2xx from the link call would, on the day Apple accepts the request without applying it, silently strip a real person's access — and every `--status` afterwards would report a clean single-group setup, *because the evidence would have gone with the group*.

## Guards, each pinned by a test

| Refuses when | Why |
|---|---|
| source == target | a plain delete wearing a friendly label |
| source does not exist | names the typo **and** lists what exists — never a no-op, because "nothing to merge" reads identically to a successful second run while the real group sits untouched |
| source is **internal** | internal membership is an App Store Connect *user seat*, not an invite — deleting one is a different act than was asked |
| any member is not visible in the target after the move | names who; both groups survive, nothing is lost |
| `--dry-run` | no writes at all, and specifically no `DELETE` |

Linking is **by tester ID**, not by email — the ids are already in hand from the source read, so a round-trip through `filter[email]` and a dependency on Apple's case handling for an address we already hold are avoided entirely. Membership comparison is casefolded, so `A@x.co` and `a@x.co` are one person.

## Mutation-checked in both directions

Disabling the verification re-read fails exactly the two intended assertions, and the fake records the `DELETE` that would have gone out:

```
FAIL refuses to delete when a member did not land: no AscError raised
FAIL nothing deleted when verification fails
       expected: []
       actual:   ['/v1/betaGroups/src-1']
```

Worth recording that the **first mutation attempt was invalid**: the anchor `if missing:` matched `_token()`'s credential guard rather than the delete guard, so it reddened two unrelated token tests and left `merge_group` green. A mutation check that mutates the wrong line is a test of nothing. The second attempt asserted its anchor was unique before editing.

## Notes

* New helpers `group_members()` (tester records, not just addresses) and `list_groups()` extracted from `find_group`. `group_member_emails` keeps its shape as a thin wrapper, so nothing existing moved.
* The workflow input is **free text, not a boolean** — typing the group's name is the confirmation, and there is no default that could fire by accident.
* 15 new assertions; full self-test suite green; `dart format` and `release_lane_lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)