### PR TITLE
feat(testflight): --status finally answers "who is in the group, and did anything reach them?"

### DIFF
--- a/tool/ci/testflight_testers.py
+++ b/tool/ci/testflight_testers.py
@@ -219,6 +219,28 @@ def add_tester(token: str, group_id: str, email: str) -> str:
     return "invited-new"
 
 
+def tester_line(attributes: dict) -> str:
+    """One tester, with everything Apple says about them, printed VERBATIM.
+
+    ADR-038 D5's rule applied one resource down. Nothing in this repo has ever
+    measured what `betaTesters` returns — whether the state field is called
+    `state`, `betaTesterState`, or lives on a `betaTesterMetrics` relationship
+    entirely — and addendum 63 is explicit that only the vendor can settle a
+    vendor API shape. So this formats whatever arrived instead of selecting the
+    fields someone guessed: a field Apple adds tomorrow still reaches the
+    founder's eyes, and a field that is missing is visibly missing rather than
+    silently defaulted.
+
+    The email leads because that is what the founder matches against a person;
+    the rest is sorted so two runs diff cleanly against each other.
+    """
+    email = attributes.get("email") or "(no email)"
+    rest = ", ".join(
+        f"{key}={attributes[key]!r}" for key in sorted(attributes) if key != "email"
+    )
+    return f"{email}  {rest}" if rest else email
+
+
 def merge_group(
     token: str,
     app_id: str,
@@ -695,12 +717,23 @@ def print_status(token: str, app: dict, group_name: str) -> None:
     """Read-only. Writes nothing, invites nobody."""
     app_id = app["id"]
     print("\nbeta groups:")
-    query = urllib.parse.urlencode({"filter[app]": app_id, "limit": 200})
-    for group in _call(token, "GET", f"/v1/betaGroups?{query}").get("data", []):
+    for group in list_groups(token, app_id):
         attributes = group["attributes"]
         kind = "internal" if attributes.get("isInternalGroup") else "external"
         marker = " <-- target" if attributes["name"] == group_name else ""
         print(f"  {attributes['name']!r} ({kind}){marker}")
+        # Issue #146's actual request, finally in the read-only path: membership
+        # used to print ONLY on the add/assign path, so the one command the
+        # founder was told to run for a safe look could not answer "who is in
+        # this group, and did anything reach them?".
+        #
+        # A failure here must not empty the listing, for the same reason the
+        # build/group inversion below degrades instead of dying.
+        try:
+            for tester in group_members(token, group["id"]):
+                print(f"      {tester_line(tester.get('attributes') or {})}")
+        except AscError as failure:
+            print(f"      (membership unavailable: {failure})")
 
     # One inverted lookup for the whole listing (see group_names_by_build), and
     # a FAILURE HERE MUST NOT EMPTY THE LISTING: a read-only status command that

--- a/tool/ci/testflight_testers_test.py
+++ b/tool/ci/testflight_testers_test.py
@@ -594,6 +594,34 @@ def test_merge_group() -> None:
     check("dry run says WOULD", any("WOULD" in line for line in lines), True)
 
 
+def test_tester_line() -> None:
+    """Apple's tester state is printed VERBATIM, for the ADR-038 D5 reason.
+
+    Nobody here has measured what `betaTesters` actually returns — the fields
+    below are what the docs imply, and addendum 63 says only the vendor can
+    settle a vendor API shape. So this must not switch-case on a closed enum:
+    whatever Apple sends has to reach the founder's eyes unaltered, including a
+    field added tomorrow. The test pins that property, not a field list."""
+    print("tester_line")
+    line = tf.tester_line({"email": "a@b.co", "inviteType": "EMAIL",
+                           "state": "INSTALLED"})
+    check("email leads", line.startswith("a@b.co"), True)
+    check("state is present verbatim", "state='INSTALLED'" in line, True)
+    check("inviteType is present verbatim", "inviteType='EMAIL'" in line, True)
+
+    # A field this code has never heard of must still be printed.
+    line = tf.tester_line({"email": "a@b.co", "somethingApplAddedLater": "NEW"})
+    check("an unknown field survives", "somethingApplAddedLater='NEW'" in line, True)
+
+    # Attributes are sorted, so two runs are diffable against each other.
+    line = tf.tester_line({"email": "a@b.co", "zeta": 1, "alpha": 2})
+    check("fields sorted for a stable diff", line.index("alpha") < line.index("zeta"), True)
+
+    # No attributes at all must not crash or invent a state.
+    check("no email reads as unknown, not blank",
+          tf.tester_line({}).startswith("(no email)"), True)
+
+
 def main() -> int:
     test_parse_emails()
     test_token()
@@ -606,6 +634,7 @@ def main() -> int:
     test_dry_run_against_a_missing_group_still_exits_non_zero()
     test_group_membership_is_looked_up_the_readable_way()
     test_merge_group()
+    test_tester_line()
     if _failures:
         print(f"\n{len(_failures)} check(s) FAILED: {', '.join(_failures)}")
         return 1


### PR DESCRIPTION
The founder asked whether the testers had been emailed. **The tool could not answer.** `--status` printed group *names* only, and membership printed exclusively on the add/assign path — so the one command the founder is told to run for a safe look was the one command that could not see people.

That was issue #146's *actual* request. Closing #146 on the membership measurement was right, but it left the capability gap open.

## Verbatim, not selected

Tester attributes are printed **verbatim** — ADR-038 D5's rule, one resource down. Nothing in this repo has measured what `betaTesters` returns: whether the state field is `state`, `betaTesterState`, or lives on a `betaTesterMetrics` relationship at all. Addendum 63 is explicit that **only the vendor can settle a vendor API shape**.

So `tester_line()` formats whatever arrived rather than selecting fields someone guessed:

* a field Apple adds tomorrow still reaches the founder's eyes;
* an absent field is *visibly* absent rather than silently defaulted.

The test pins that **property** — `an unknown field survives` — rather than a field list, which is the only assertion that stays true when Apple changes something.

## Also

* Email leads (it is what a founder matches against a person); the rest is sorted so two runs diff cleanly.
* A membership failure degrades to a note instead of emptying the listing — the lesson the `builds → betaGroups` inversion already cost once.

## Recorded, not hidden

This puts tester **email addresses into the read-only status log**, which previously only the add path produced. On a public repo that is *more* exposure, not less. It is the founder's own question that requires it, and `operator-expected.md` `2(c)` already records the standing PII posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)