### PR TITLE
test(130): make ADR-026's "five readers" claim true by construction — and it was four enums, not three

### DIFF
--- a/app/test/features/daily_question/data/question_pack_dto_test.dart
+++ b/app/test/features/daily_question/data/question_pack_dto_test.dart
@@ -58,18 +58,32 @@ void main() {
       expect(pack.questions.last.seasonalWindow, 'new_year');
     });
 
-    test('accepts every value of the closed seasonal vocabulary', () {
-      for (final window in knownSeasonalWindows) {
-        final json = validPack();
-        ((json['questions'] as List).single
-                as Map<String, dynamic>)['seasonalWindow'] =
-            window;
-        expect(
-          questionPackFromJson(json).questions.single.seasonalWindow,
-          window,
-        );
-      }
-    });
+    // NOT a parity guard, and it must not be mistaken for one — that mistake is
+    // issue #130. Iterating `knownSeasonalWindows` proves the DTO accepts every
+    // value the app already knows; it cannot detect that the app's list has
+    // drifted from the schema, because the schema is never read here. A fixture
+    // derived from its own subject proves only self-consistency.
+    //
+    // The actual parity net is `schema_enum_parity_test.dart`, which reads
+    // `content/schema/question-pack.schema.json`. This case is kept because the
+    // property it DOES check is real and distinct — the parse path accepts each
+    // known value — and its name now says which of the two it is.
+    test(
+      'the DTO parse path accepts each KNOWN seasonal value (self-consistency '
+      'only — schema parity lives in schema_enum_parity_test.dart)',
+      () {
+        for (final window in knownSeasonalWindows) {
+          final json = validPack();
+          ((json['questions'] as List).single
+                  as Map<String, dynamic>)['seasonalWindow'] =
+              window;
+          expect(
+            questionPackFromJson(json).questions.single.seasonalWindow,
+            window,
+          );
+        }
+      },
+    );
 
     test('rejects a seasonalWindow outside the closed vocabulary (ADR-026 D3 '
         '— a tag nothing recognises is a question never selected)', () {

--- a/app/test/features/daily_question/schema_enum_parity_test.dart
+++ b/app/test/features/daily_question/schema_enum_parity_test.dart
@@ -1,0 +1,214 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hayati_app/features/daily_question/domain/question.dart';
+import 'package:hayati_app/features/profile/domain/relationship_profile.dart';
+
+/// A CROSS-TREE PARITY test (issue #130), in the shape of
+/// `brandkit_token_parity_test.dart` and of the TWO guards that already exist
+/// for this same schema — `validateSchemaAgreement` in
+/// `content/validator/validator_core.dart` and
+/// `functions/test/unit/schema-agreement.test.ts`.
+///
+/// WHY. ADR-026 D3 guarantees the seasonal vocabulary is closed and "enforced
+/// in five places". All five readers do REJECT an unknown value; what did not
+/// exist was the parity net keeping them in sync. The validator and both TS
+/// readers are checked against `content/schema/question-pack.schema.json`. The
+/// APP was not — and the test that looked like the fifth guard,
+/// `question_pack_dto_test.dart`'s "accepts every value of the closed seasonal
+/// vocabulary", iterated `knownSeasonalWindows` itself: a fixture derived from
+/// its own subject, which cannot detect drift because the schema is never read.
+///
+/// The failure it permitted: add a season to the schema, the validator and both
+/// TS readers, forget the Dart list, and CI is **fully green** while the app
+/// throws `FormatException` at pack-load time on a real device.
+///
+/// ## Scope: every enum in the schema, not just seasonalWindow
+///
+/// The issue asked for the seasonal one and suggested widening. Widening turned
+/// up more than the issue listed, so this covers all four and asserts that
+/// there are exactly four (see `the schema declares no enum this test has not
+/// been taught about`). The four app-side mirrors and what guarded them before:
+///
+///   | schema enum | app mirror         | guard before this test        |
+///   |-------------|--------------------|-------------------------------|
+///   | locale      | [ContentLanguage]  | a COUNT (`hasLength(3)`)      |
+///   | register    | [QuestionRegister] | a hardcoded list, no schema   |
+///   | category    | [QuestionCategory] | a COUNT (`hasLength(5)`)      |
+///   | seasonalWindow | [knownSeasonalWindows] | self-referential loop |
+///
+/// **A count is weaker than it looks**: `expect(QuestionCategory.values,
+/// hasLength(5))` passes after renaming `gratitude` to `banter`. Two of the
+/// four "guards" were cardinality assertions wearing a vocabulary's clothing.
+///
+/// **`locale` was not in the issue at all.** Its mirror, [ContentLanguage],
+/// lives in `features/profile/`, a different feature from the pack DTO that
+/// consumes it — which is exactly why a sweep over `daily_question/` missed it.
+///
+/// ## The comparison is EXACT and ORDERED, deliberately
+///
+/// **Ordered**, because the two guards that already exist are: the TS test
+/// asserts `toEqual([...tsValues])` and says why in its header ("a reordered
+/// enum is a diff worth seeing"), and `validator_core`'s `checkEnum` compares
+/// with `_sameList`. Both use `.sort()` in exactly one place — the field-NAME
+/// sets, where order carries nothing. A third guard written as a set comparison
+/// would be the weakest of the three while looking identical to them.
+///
+/// **Exact rather than "the app may know a subset"**, and this one is worth
+/// stating because the asymmetry sounds like it should favour a subset. It does
+/// not. Every one of the four mirrors THROWS on a value it does not recognise
+/// (`_questionFromJson`, `_localeField`, `_registerField` in
+/// `question_pack_dto.dart`). So an app that knows fewer values than the schema
+/// is not "failing closed" in any useful sense — it is a `FormatException` on a
+/// real device, waiting for the first pack that uses the new value. The runtime
+/// concern that DOES sound like this ("a shipped binary is older than the
+/// schema") is real and is a different problem: this test compares the schema
+/// and the Dart in the SAME commit, so both sides always move together here.
+///
+/// If this test fails, do NOT edit whichever side is easier. The schema is the
+/// source of truth for the content format; adding a value there is a five-file
+/// change (ADR-026 D3) and this test is the thing that now says so out loud.
+void main() {
+  const schemaPath = '../content/schema/question-pack.schema.json';
+
+  late Map<String, dynamic> schema;
+
+  setUpAll(() {
+    final file = File(schemaPath);
+    // FAIL, never skip. A parity test that cannot find its source of truth has
+    // measured nothing, and reporting green for that is the exact defect this
+    // whole class of test exists to prevent (cf. ADR-041's exit-code taxonomy:
+    // "could not measure" must never render as "no difference").
+    expect(
+      file.existsSync(),
+      isTrue,
+      reason:
+          'the schema was renamed or moved rather than this test passing '
+          'vacuously — re-point schemaPath and keep the guard',
+    );
+    schema = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+  });
+
+  List<String> enumAt(List<String> path) {
+    Object? node = schema;
+    for (final key in path) {
+      expect(
+        node,
+        isA<Map<String, dynamic>>(),
+        reason: 'schema shape changed: ${path.join('.')} not reachable',
+      );
+      node = (node! as Map<String, dynamic>)[key];
+    }
+    expect(
+      node,
+      isA<Map<String, dynamic>>(),
+      reason: 'schema shape changed: ${path.join('.')} is not an object',
+    );
+    final values = (node! as Map<String, dynamic>)['enum'];
+    expect(
+      values,
+      isA<List<dynamic>>(),
+      reason:
+          '${path.join('.')} has no enum — the vocabulary was opened up, '
+          'which is a content-format decision and not a test failure to patch',
+    );
+    return (values! as List<dynamic>).cast<String>();
+  }
+
+  const localePath = ['properties', 'locale'];
+  const registerPath = ['properties', 'register'];
+  const categoryPath = [
+    'properties',
+    'questions',
+    'items',
+    'properties',
+    'category',
+  ];
+  const seasonalPath = [
+    'properties',
+    'questions',
+    'items',
+    'properties',
+    'seasonalWindow',
+  ];
+
+  group('question-pack schema ↔ app domain vocabularies', () {
+    test('seasonalWindow — the gap #130 was filed for', () {
+      expect(knownSeasonalWindows, enumAt(seasonalPath));
+    });
+
+    test('category — QuestionCategory.name is the wire spelling', () {
+      expect(
+        QuestionCategory.values.map((c) => c.name).toList(),
+        enumAt(categoryPath),
+      );
+    });
+
+    test('register — QuestionRegister.wire, NOT ContentRegister', () {
+      expect(
+        QuestionRegister.values.map((r) => r.wire).toList(),
+        enumAt(registerPath),
+      );
+    });
+
+    test('locale — ContentLanguage.name, and it lives in another feature', () {
+      expect(
+        ContentLanguage.values.map((l) => l.name).toList(),
+        enumAt(localePath),
+      );
+    });
+
+    test('ContentRegister is a DIFFERENT enum and is deliberately not '
+        'compared to the schema', () {
+      // A trap worth a red test rather than a comment. Two enums in this app
+      // are called "register": ContentRegister is the user's captured
+      // preference (docs/prd.md F1) and QuestionRegister is the pack's tone.
+      // Only the second mirrors the schema. Pointing a parity test at
+      // ContentRegister would FAIL and look like it had found real drift, so
+      // pin the distinction: if these two ever converge, this test says so and
+      // whoever converged them decides what the parity guard should compare.
+      expect(
+        ContentRegister.values.map((r) => r.name).toList(),
+        isNot(QuestionRegister.values.map((r) => r.wire).toList()),
+        reason:
+            'ContentRegister and QuestionRegister have merged — decide '
+            'which one the schema register enum should be compared against',
+      );
+      expect(ContentRegister.values.map((r) => r.name), [
+        'playful',
+        'respectful',
+      ]);
+    });
+
+    test('the schema declares no enum this test has not been taught about', () {
+      // Coverage asserted, not assumed. Every check above is a claim about ONE
+      // vocabulary; without this, a FIFTH enum added to the schema would be
+      // mirrored by nothing, guarded by nothing, and every test here would
+      // still be green — the same partial-green shape the guards themselves
+      // exist to prevent.
+      final found = <String>[];
+      void walk(Object? node, String path) {
+        if (node is Map<String, dynamic>) {
+          if (node.containsKey('enum')) found.add(path);
+          node.forEach((k, v) => walk(v, path.isEmpty ? k : '$path.$k'));
+        } else if (node is List) {
+          for (var i = 0; i < node.length; i++) {
+            walk(node[i], '$path[$i]');
+          }
+        }
+      }
+
+      walk(schema, '');
+      expect(
+        found..sort(),
+        [
+          categoryPath.join('.'),
+          localePath.join('.'),
+          registerPath.join('.'),
+          seasonalPath.join('.'),
+        ]..sort(),
+      );
+    });
+  });
+}

--- a/docs/adr/026-seasonal-question-windows.md
+++ b/docs/adr/026-seasonal-question-windows.md
@@ -149,7 +149,7 @@ over a calendar library). Throwing instead would turn a cosmetic capability
 loss into a total outage of the product's core loop, dressed up as N
 per-couple skips.
 
-### D3 — The window vocabulary becomes a CLOSED enum, gated in FIVE places
+### D3 — The window vocabulary becomes a CLOSED enum, gated in FIVE places ~~and kept in sync in four~~ *(see the correction below — the fifth reader had no parity net until 2026-08-02)*
 
 | id | calendar | window (inclusive) |
 |---|---|---|
@@ -174,6 +174,50 @@ in fact a three-way sync, not a two-way one):
    narrowing `Question.seasonalWindow`, mirroring `QUESTION_CATEGORIES`);
 5. the Dart pack DTO (defense-in-depth at the app's consumption edge, the
    existing pattern for every other enum in this schema).
+
+> #### Correction, 2026-08-02 (issue #130)
+>
+> **Reader 5 rejected an unknown value, as claimed — but nothing kept it in
+> SYNC, so "gated in five places" overstated what was built.** Readers 2–4 are
+> parity-checked against the schema (`validateSchemaAgreement` on the Dart side,
+> `schema-agreement.test.ts` on the TS side). The app's `knownSeasonalWindows`
+> was not, and **the test that looked like the fifth guard was
+> self-referential**: `question_pack_dto_test.dart`'s "accepts every value of
+> the closed seasonal vocabulary" iterated `knownSeasonalWindows` itself. A
+> fixture derived from its own subject cannot detect drift, because the schema
+> is never read.
+>
+> The failure it permitted: add a season to the schema, the validator and both
+> TS readers, forget the Dart list — **CI fully green, and the app throws
+> `FormatException` at pack-load on a real device.**
+>
+> Closed by `app/test/features/daily_question/schema_enum_parity_test.dart`,
+> which reads the schema file and compares **ordered** lists (matching the two
+> guards that already existed, both of which compare order deliberately — "a
+> reordered enum is a diff worth seeing").
+>
+> **Widening it found more than the issue listed**, and the extra findings are
+> the reason this correction is longer than a number change:
+>
+> * the schema has **FOUR** enums, not three. `locale` was in nobody's account
+>   of this — its app mirror is `ContentLanguage`, which lives in
+>   `features/profile/`, a different feature from the DTO that consumes it,
+>   which is exactly why a sweep over `daily_question/` missed it;
+> * two of the "guards" were **cardinality assertions wearing a vocabulary's
+>   clothing** — `expect(QuestionCategory.values, hasLength(5))` and the same
+>   for `ContentLanguage` both pass after *renaming* a value;
+> * the comparison is **exact, not subset**, and the asymmetry that sounds like
+>   it should favour a subset does not: every app mirror THROWS on an
+>   unrecognised value, so an app knowing fewer values than the schema is not
+>   failing closed — it is a device-side `FormatException` waiting for the first
+>   pack that uses the new one;
+> * the new test also asserts the schema declares **no fifth enum**, so a new
+>   vocabulary cannot arrive mirrored by nothing behind green tests.
+>
+> Mutation-checked in both directions plus a must-stay-green row: a season added
+> to the schema only → red; removed from the Dart list only → red; the category
+> enum reordered → red; a fifth enum added → red; **added to both sides in one
+> diff → green**, which is what proves the guard is not simply always failing.
 
 Why closed rather than free-string: with a free string, an author who
 writes `"Ramadan"`, `"eid"`, or `"ramadan_2027"` gets a question that is


### PR DESCRIPTION
Closes #130.

ADR-026 D3 guarantees the seasonal vocabulary is closed and *"enforced in five places"*. All five readers **do** reject an unknown value. What did not exist was the parity net keeping them in sync — and **the test that looked like the fifth guard was self-referential**: `question_pack_dto_test.dart`'s *"accepts every value of the closed seasonal vocabulary"* iterated `knownSeasonalWindows` itself. A fixture derived from its own subject cannot detect drift, because the schema is never read.

**The failure it permitted:** add a season to the schema, the validator and both TS readers, forget the Dart list → **CI fully green, and the app throws `FormatException` at pack-load on a real device.**

## Widening it found more than the issue listed

- **The schema has FOUR enums, not three.** `locale` appears in nobody's account of this. Its mirror `ContentLanguage` lives in `features/profile/` — a different feature from the DTO that consumes it, which is exactly why a sweep over `daily_question/` missed it.
- **Two of the existing "guards" were cardinality assertions wearing a vocabulary's clothing.** `expect(QuestionCategory.values, hasLength(5))` and the same for `ContentLanguage` both pass after *renaming* a value.
- **`ContentRegister` and `QuestionRegister` are two different enums both called "register"**, and only the second mirrors the schema. Pointing a parity test at the wrong one *fails* and looks like real drift — so the distinction is pinned by a test rather than left in a comment.
- The guard asserts the schema declares **no fifth enum**, so a new vocabulary cannot arrive mirrored by nothing behind green tests.

## Two decisions, argued

**Ordered, not set.** The two guards that already exist both compare order deliberately — the TS one says why in its header: *"a reordered enum is a diff worth seeing"*. A third written as a set comparison would be the weakest of the three while looking identical.

**Exact, not subset** — and this is the one that sounds like it should go the other way. Every app mirror *throws* on an unrecognised value, so an app knowing fewer values than the schema is not "failing closed": it is a device-side `FormatException` waiting for the first pack that uses the new one.

## Mutation check

Both directions **plus a must-stay-green row**, because four kills mean nothing without the row proving the guard is not simply always red:

| mutation | result |
|---|---|
| season added to the **schema only** | 🔴 killed |
| season removed from the **Dart list only** | 🔴 killed |
| category enum **reordered** | 🔴 killed |
| a **fifth enum** added | 🔴 killed |
| added to **both sides in one diff** | 🟢 **stayed green** |

Anchor uniqueness asserted before every edit.

The self-referential test is **kept but renamed** to say which of the two it is — the property it does check (the parse path accepts each known value) is real and distinct; what was wrong was that its name invited a reader to trust it as parity. ADR-026 D3 gains a dated correction recording all of the above.