### PR TITLE
fix(ios): ship iPhone-only — universal since the scaffold, and mvp.md puts iPad in v2

### DIFF
--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -386,7 +386,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Profile;
@@ -516,7 +516,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1";
 			};
 			name = Debug;
 		};
@@ -569,7 +569,7 @@
 				SUPPORTED_PLATFORMS = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/app/test/release/signing_sentinel_test.dart
+++ b/app/test/release/signing_sentinel_test.dart
@@ -2,7 +2,14 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// SOURCE-SENTINEL over the iOS project's **signing** settings (ADR-029 D3).
+/// SOURCE-SENTINEL over the iOS project's **release-critical** pbxproj settings
+/// — signing first (ADR-029 D3), and since S060 the device family too.
+///
+/// The two share a mechanism and a motivation, which is why they share a file
+/// rather than duplicating the hand parser at the bottom: both are settings no
+/// per-PR check reads, both are one Xcode click from changing, and both fail
+/// far from the edit — signing at release time, the device family in front of
+/// an Apple reviewer.
 ///
 /// WHY this shape: nothing in the per-PR merge gate can see a signing
 /// regression. `flutter analyze` and `flutter test` never read the pbxproj;
@@ -166,6 +173,67 @@ void main() {
         c.settings['CODE_SIGN_STYLE'],
         isNot('Manual'),
         reason: 'app-target config ${c.name} (${c.id}) flipped to Manual',
+      );
+    }
+  });
+
+  test('the PROJECT-level configs pin TARGETED_DEVICE_FAMILY = 1 (iPhone only)', () {
+    // WHY THIS IS SCOPED TO THE PROJECT AND NOT THE APP TARGET — measured
+    // before it was written, and it inverts every other test in this file.
+    // `TARGETED_DEVICE_FAMILY` does not appear on the app-target configs at
+    // all; the target INHERITS it from the three project-level blocks. So the
+    // obvious shape here — `for (final c in appTargets())`, the shape the four
+    // tests above take — would iterate a set in which the key is absent from
+    // every member, and pass while the project said "1,2", "2", or anything
+    // else. Same vacuous-green class the parser census at the top guards
+    // against, one scope down.
+    //
+    // WHY "1". Flutter scaffolds "1,2" (universal) and nothing here ever chose
+    // otherwise, while `docs/mvp.md` lists iPad under v2. Shipping universal
+    // costs twice: App Store Connect then REQUIRES 13" iPad screenshots for
+    // the listing, and Apple REVIEWS the app on an iPad — a surface with no
+    // golden, no widget test and no design pass in this repo. That is a
+    // rejection risk carried for a platform the roadmap does not yet claim.
+    final projectConfigs = configs.where((c) => c.bundleId == null).toList();
+    expect(
+      projectConfigs.length,
+      3,
+      reason:
+          'expected the three project-level XCBuildConfiguration blocks (the '
+          'ones with no PRODUCT_BUNDLE_IDENTIFIER); found '
+          '${projectConfigs.length}. If this is 0 the assertions below are '
+          'VACUOUS and this test is guarding nothing — fix the scoping, never '
+          'the expectation',
+    );
+    for (final c in projectConfigs) {
+      expect(
+        c.settings['TARGETED_DEVICE_FAMILY'],
+        '1',
+        reason:
+            'project config ${c.name} (${c.id}) must pin '
+            'TARGETED_DEVICE_FAMILY = "1"; found '
+            '${c.settings['TARGETED_DEVICE_FAMILY'] ?? '(absent)'} — "1,2" is '
+            "Flutter's scaffold default and puts the app in front of an Apple "
+            'reviewer on an untested iPad layout',
+      );
+    }
+  });
+
+  test('NO config anywhere re-admits the iPad family', () {
+    // The pin above is on the project; a per-target override would beat it
+    // silently. Asserting file-wide is correct HERE (unlike the team/style
+    // pins, which are deliberately app-target-scoped because a stray value on
+    // RunnerTests is harmless): a device family on ANY block that includes 2
+    // changes what Apple builds and reviews.
+    for (final c in configs) {
+      final family = c.settings['TARGETED_DEVICE_FAMILY'];
+      expect(
+        family == null || !family.contains('2'),
+        isTrue,
+        reason:
+            'config ${c.name} (${c.id}, bundle ${c.bundleId ?? 'project-level'}) '
+            'carries TARGETED_DEVICE_FAMILY = $family — family 2 is iPad, and '
+            'an override here beats the project-level pin without changing it',
       );
     }
   });


### PR DESCRIPTION

`TARGETED_DEVICE_FAMILY` was `"1,2"` in all three project-level configs. Nothing
in this repo ever chose that: it is Flutter's scaffold default, and it has been
carried into every build including the one sitting in Beta App Review.
`docs/mvp.md` lists "Widgets/watch/iPad" under **v2**.

Universal costs twice, and both costs land on the App Store submission that is
about to happen:

  1. App Store Connect **requires 13" iPad screenshots** (2064x2752) for the
     listing of a universal app. That is a second full screenshot set for a
     device the product does not target.
  2. Apple **reviews the app on an iPad**. There is no iPad golden, no iPad
     widget test and no iPad design pass anywhere in this repo — all 360
     goldens render at 390x844. An unexamined layout in front of a reviewer is
     a rejection risk taken for a platform the roadmap does not claim.

Set to `"1"`. iPhone only.

**The sentinel, and the trap it had to avoid.** The obvious shape — the shape
the four tests already in `signing_sentinel_test.dart` take — is
`for (final c in appTargets())`. Measured before writing it: that would guard
NOTHING. `TARGETED_DEVICE_FAMILY` does not appear on the app-target configs at
all; the target inherits it from the three PROJECT-level blocks, so an
app-target-scoped loop iterates a set in which the key is absent from every
member and passes against any project value at all. Same vacuous-green class the
file's parser census already guards, one scope down — so the new test asserts it
found exactly 3 project-level blocks BEFORE asserting their values.

A second test asserts file-wide that no config re-admits family 2. That
file-wide scope is correct here and deliberately unlike the team/style pins
above it, which are app-target-scoped because a stray value on RunnerTests is
harmless: a per-target device-family override would beat the project-level pin
without changing the line this PR just edited.

Mutation-checked: reverting the pbxproj to `"1,2"` turns both new tests red and
leaves the five existing ones green.

**Needs a new build.** 113 (in review) and 114 (queued behind it) are both
universal. The App Store submission wants a build carrying this change.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)