### PR TITLE
feat(store): render the App Store screenshots from the app's own widgets — on Linux, at Apple's exact size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,11 @@ jobs:
         run: flutter pub get
       - name: format
         # Explicit dirs (never '.') so we don't descend into build/ or ios/ Pods.
-        run: dart format --set-exit-if-changed app/lib app/test tool content
+        # `app/screenshots` is listed because an explicit allow-list silently
+        # drops anything added outside it: the App Store screenshot generator is
+        # Dart that `flutter analyze` DOES read (it analyses the whole package)
+        # and that this gate would have skipped forever.
+        run: dart format --set-exit-if-changed app/lib app/screenshots app/test tool content
       - name: analyze
         working-directory: app
         run: flutter analyze

--- a/app/screenshots/appstore_screenshots_test.dart
+++ b/app/screenshots/appstore_screenshots_test.dart
@@ -1,0 +1,477 @@
+// App Store screenshot generator. NOT a test, despite the `_test.dart` name and
+// the `testWidgets` bodies — it asserts nothing and it WRITES FILES.
+//
+// WHY IT LIVES OUTSIDE `test/`. `flutter test` with no path runs `test/` and
+// only `test/`, so this never enters the merge gate, never enters the coverage
+// number, and never fails a PR. It is driven explicitly:
+//
+//     tool/appstore_screenshots.sh
+//
+// WHY IT REUSES THE GOLDEN FAKES INSTEAD OF ITS OWN. Every state below is
+// arranged the same way its golden test arranges it, from the same fakes and
+// the same shipped question packs. A screenshot built from a bespoke mock is a
+// picture of something no test has ever checked; drift between the store
+// listing and the product would then be invisible in both directions. What is
+// deliberately NOT shared is the *selection*: the goldens capture every state
+// including `error` and `loading`, and this file curates the six that tell the
+// product's story.
+//
+// The surface comes from APPSTORE_SCREENSHOT_SURFACE (see golden_harness.dart),
+// so these render at 1290×2796 @3 — App Store Connect's 6.9" iPhone slot — from
+// the identical widget tree the 390×844 goldens pin.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hayati_app/core/storage/local_flag_store.dart';
+import 'package:hayati_app/core/storage/pin_lock_store.dart';
+import 'package:hayati_app/features/auth/domain/auth_repository_provider.dart';
+import 'package:hayati_app/features/auth/domain/auth_user.dart';
+import 'package:hayati_app/features/auth/presentation/ritual_preview_screen.dart';
+import 'package:hayati_app/features/coach/domain/coach_disclaimer.dart';
+import 'package:hayati_app/features/coach/domain/coach_reply.dart';
+import 'package:hayati_app/features/coach/domain/coach_repository_provider.dart';
+import 'package:hayati_app/features/coach/presentation/coach_screen.dart';
+import 'package:hayati_app/features/daily_question/data/asset_question_pack_repository.dart';
+import 'package:hayati_app/features/daily_question/data/asset_solo_question_pack_repository.dart';
+import 'package:hayati_app/features/daily_question/domain/couple.dart';
+import 'package:hayati_app/features/daily_question/domain/couple_answer.dart';
+import 'package:hayati_app/features/daily_question/domain/couple_answers_repository_provider.dart';
+import 'package:hayati_app/features/daily_question/domain/couple_day.dart';
+import 'package:hayati_app/features/daily_question/domain/couple_day_assignment.dart';
+import 'package:hayati_app/features/daily_question/domain/couple_day_repository_provider.dart';
+import 'package:hayati_app/features/daily_question/domain/couple_repository_provider.dart';
+import 'package:hayati_app/features/daily_question/domain/question_pack_repository_provider.dart';
+import 'package:hayati_app/features/daily_question/domain/solo_answer.dart';
+import 'package:hayati_app/features/daily_question/domain/solo_answers_repository_provider.dart';
+import 'package:hayati_app/features/daily_question/domain/solo_clock.dart';
+import 'package:hayati_app/features/daily_question/domain/solo_day.dart';
+import 'package:hayati_app/features/daily_question/domain/solo_question_pack_repository_provider.dart';
+import 'package:hayati_app/features/daily_question/presentation/paired_home_screen.dart';
+import 'package:hayati_app/features/daily_question/presentation/solo_home_screen.dart';
+import 'package:hayati_app/features/entitlements/domain/couple_entitlement.dart';
+import 'package:hayati_app/features/entitlements/domain/entitlement_repository_provider.dart';
+import 'package:hayati_app/features/entitlements/domain/purchases_repository_provider.dart';
+import 'package:hayati_app/features/pairing/domain/invite_repository_provider.dart';
+import 'package:hayati_app/features/pairing/domain/invite_share_launcher.dart';
+import 'package:hayati_app/features/privacy_lock/domain/biometric_authenticator.dart';
+import 'package:hayati_app/features/privacy_lock/presentation/lock_screen.dart';
+import 'package:hayati_app/features/profile/domain/profile_repository_provider.dart';
+import 'package:hayati_app/features/profile/domain/relationship_profile.dart';
+import 'package:hayati_app/features/settings/presentation/widgets/privacy_spotlight_card.dart';
+
+import '../test/support/fake_auth_repository.dart';
+import '../test/support/fake_biometric_authenticator.dart';
+import '../test/support/fake_coach_repository.dart';
+import '../test/support/fake_couple_answers_repository.dart';
+import '../test/support/fake_couple_day_repository.dart';
+import '../test/support/fake_couple_repository.dart';
+import '../test/support/fake_entitlement_repository.dart';
+import '../test/support/fake_invite_repository.dart';
+import '../test/support/fake_invite_share_launcher.dart';
+import '../test/support/fake_local_flag_store.dart';
+import '../test/support/fake_pin_lock_store.dart';
+import '../test/support/fake_profile_repository.dart';
+import '../test/support/fake_purchases_repository.dart';
+import '../test/support/fake_solo_answers_repository.dart';
+import '../test/support/golden/golden_harness.dart';
+import '../test/support/localized_app.dart';
+import '../test/support/pin_lock_fixtures.dart';
+import '../test/support/static_asset_bundle.dart';
+
+/// The store listing's locales — `fastlane/metadata/` carries exactly `en-US`
+/// and `tr`. Arabic is a SHIPPED app locale with full goldens but has no
+/// listing, so rendering it here would produce files with nowhere to go.
+const _locales = <String, Locale>{'tr': Locale('tr'), 'en': Locale('en')};
+
+const _coupleId = 'couple-1';
+const _ownUid = 'uid-1';
+const _partnerUid = 'uid-2';
+const _user = AuthUser(uid: _ownUid, displayName: 'Aytek');
+const _timezone = 'Europe/Istanbul';
+
+/// Pinned clocks, copied from the golden tests they mirror — the paired chain
+/// keys its day in the couple's stored zone (ADR-011), the solo chain in UTC.
+final _pairedNow = DateTime.utc(2026, 7, 10, 9);
+final _soloNow = DateTime(2026, 7, 10, 12);
+final _dayKey = coupleDayKey(_pairedNow, _timezone);
+
+const _couple = Couple(
+  id: _coupleId,
+  memberUids: [_ownUid, _partnerUid],
+  timezone: _timezone,
+  streak: CoupleStreak(count: 4, lastMutualDate: '20260709', graceTokens: 1),
+);
+
+const _assignment = CoupleDayAssignment(
+  questionId: 'solo_tr_001',
+  packId: 'solo_tr',
+  packVersion: 1,
+);
+
+/// The couple bank is `solo_tr` until W9, so the rendered question is Turkish
+/// in every locale — the same thing the paired goldens capture, and the same
+/// thing a real user on this build sees. Answers are Turkish to match.
+const _ownAnswerText = 'Kahvaltıda birlikte gülmemiz.';
+const _partnerAnswerText = 'Sabah çayını birlikte içmemiz.';
+
+const _soloAnswers = {
+  'tr': 'Birlikte sakin bir sabah.',
+  'en': 'A quiet morning together.',
+};
+
+/// THREE coach turns, not one. The transcript is bottom-anchored like any
+/// chat, so a single exchange renders two bubbles under two thirds of empty
+/// canvas at 6.9" — technically correct, useless as a store asset. Three fills
+/// the frame with what the surface actually looks like in use.
+///
+/// Deliberately ordinary planning talk: the coach's crisis path is a safety
+/// gate (ADR-028), not a marketing surface, and it is not shown here.
+const _coachTurns = <String, List<(String, String)>>{
+  'tr': [
+    (
+      'Bu hafta sonu için güzel bir buluşma fikri var mı?',
+      'Birlikte küçük bir plan yapalım: bir yürüyüş ve sevdiğiniz bir kahve.',
+    ),
+    (
+      'Yürüyüşü nerede yapalım?',
+      'Kalabalık olmayan bir sahil ya da park iyi olur — konuşmak kolaylaşır.',
+    ),
+    (
+      'Sonrasında ne yapabiliriz?',
+      'Eve dönünce bugünün sorusunu birlikte cevaplayın; gün böyle kapanır.',
+    ),
+  ],
+  'en': [
+    (
+      'Any nice date idea for this weekend?',
+      "Let's make a small plan together: a short walk and a coffee you both love.",
+    ),
+    (
+      'Where should we walk?',
+      'A quiet shoreline or park works well — it makes talking easier.',
+    ),
+    (
+      'And after that?',
+      "Back home, answer today's question together. That closes the day well.",
+    ),
+  ],
+};
+
+void main() {
+  final shippedSolo = shippedSoloPackBundle();
+  final shippedCouple = shippedSoloPackBundle();
+
+  /// Where the PNGs land. `build/` is already git-ignored by the Flutter
+  /// scaffold, so a generated store asset can never be committed by accident —
+  /// the deliverable is a folder the founder uploads, not repo content.
+  String out(String locale, String name) =>
+      'build/appstore/screenshots/$locale/$name.png';
+
+  // ---- 1. The reveal: today's question with both answers, streak running ----
+  _locales.forEach((tag, locale) {
+    testWidgets('01 reveal $tag', (tester) async {
+      final couples = FakeCoupleRepository(
+        initialCouples: {_coupleId: _couple},
+      );
+      final days = FakeCoupleDayRepository(
+        initialDays: {
+          FakeCoupleDayRepository.keyFor(_coupleId, _dayKey): _assignment,
+        },
+      );
+      CoupleAnswer answerOf(String text) => CoupleAnswer(
+        questionId: _assignment.questionId,
+        text: text,
+        answeredAt: FakeCoupleAnswersRepository.answeredAtStamp,
+      );
+      final answers = FakeCoupleAnswersRepository(
+        initialAnswers: {
+          FakeCoupleAnswersRepository.keyFor(_coupleId, _dayKey, _ownUid):
+              answerOf(_ownAnswerText),
+          FakeCoupleAnswersRepository.keyFor(_coupleId, _dayKey, _partnerUid):
+              answerOf(_partnerAnswerText),
+        },
+      );
+      final mirrors = FakeEntitlementRepository();
+      addTearDown(couples.dispose);
+      addTearDown(days.dispose);
+      addTearDown(answers.dispose);
+      addTearDown(mirrors.dispose);
+
+      await pumpGolden(
+        tester,
+        const PairedHomeScreen(uid: _ownUid, coupleId: _coupleId),
+        locale: locale,
+        direction: TextDirection.ltr,
+        overrides: [
+          coupleRepositoryProvider.overrideWith((ref) => couples),
+          coupleDayRepositoryProvider.overrideWith((ref) => days),
+          coupleAnswersRepositoryProvider.overrideWith((ref) => answers),
+          entitlementRepositoryProvider.overrideWith((ref) => mirrors),
+          questionPackRepositoryProvider.overrideWith(
+            (ref) => AssetQuestionPackRepository(bundle: shippedCouple),
+          ),
+          soloClockProvider.overrideWith(
+            (ref) =>
+                () => _pairedNow,
+          ),
+        ],
+      );
+      await tester.pumpAndSettle();
+
+      await writeSurfacePng(tester, out(tag, '01-reveal'));
+    });
+  });
+
+  // ---- 2. Before the reveal: your answer written, partner's still sealed ----
+  _locales.forEach((tag, locale) {
+    testWidgets('02 waiting $tag', (tester) async {
+      final couples = FakeCoupleRepository(
+        initialCouples: {_coupleId: _couple},
+      );
+      final days = FakeCoupleDayRepository(
+        initialDays: {
+          FakeCoupleDayRepository.keyFor(_coupleId, _dayKey): _assignment,
+        },
+      );
+      final answers = FakeCoupleAnswersRepository(
+        initialAnswers: {
+          FakeCoupleAnswersRepository.keyFor(
+            _coupleId,
+            _dayKey,
+            _ownUid,
+          ): CoupleAnswer(
+            questionId: _assignment.questionId,
+            text: _ownAnswerText,
+            answeredAt: FakeCoupleAnswersRepository.answeredAtStamp,
+          ),
+        },
+      );
+      final mirrors = FakeEntitlementRepository();
+      addTearDown(couples.dispose);
+      addTearDown(days.dispose);
+      addTearDown(answers.dispose);
+      addTearDown(mirrors.dispose);
+
+      await pumpGolden(
+        tester,
+        const PairedHomeScreen(uid: _ownUid, coupleId: _coupleId),
+        locale: locale,
+        direction: TextDirection.ltr,
+        overrides: [
+          coupleRepositoryProvider.overrideWith((ref) => couples),
+          coupleDayRepositoryProvider.overrideWith((ref) => days),
+          coupleAnswersRepositoryProvider.overrideWith((ref) => answers),
+          entitlementRepositoryProvider.overrideWith((ref) => mirrors),
+          questionPackRepositoryProvider.overrideWith(
+            (ref) => AssetQuestionPackRepository(bundle: shippedCouple),
+          ),
+          soloClockProvider.overrideWith(
+            (ref) =>
+                () => _pairedNow,
+          ),
+        ],
+      );
+      await tester.pumpAndSettle();
+
+      await writeSurfacePng(tester, out(tag, '02-waiting'));
+    });
+  });
+
+  // ---- 3. The promise, as onboarding states it ----
+  _locales.forEach((tag, locale) {
+    testWidgets('03 ritual $tag', (tester) async {
+      await pumpGolden(
+        tester,
+        const RitualPreviewScreen(),
+        locale: locale,
+        direction: TextDirection.ltr,
+      );
+      await tester.pumpAndSettle();
+
+      await writeSurfacePng(tester, out(tag, '03-ritual'));
+    });
+  });
+
+  // ---- 4. It works before your partner joins ----
+  _locales.forEach((tag, locale) {
+    testWidgets('04 solo $tag', (tester) async {
+      final answers = FakeSoloAnswersRepository(
+        initialAnswers: {
+          FakeSoloAnswersRepository.keyFor(
+            _ownUid,
+            soloDayKey(_soloNow),
+          ): SoloAnswer(
+            questionId: 'solo_${locale.languageCode}_003',
+            text: _soloAnswers[tag]!,
+            answeredAt: FakeSoloAnswersRepository.answeredAtStamp,
+          ),
+        },
+      );
+      final profiles = FakeProfileRepository();
+      final auth = FakeAuthRepository(initialUser: _user);
+      final invites = FakeInviteRepository();
+      final launcher = FakeInviteShareLauncher();
+      addTearDown(answers.dispose);
+      addTearDown(profiles.dispose);
+      addTearDown(auth.dispose);
+      addTearDown(invites.dispose);
+      addTearDown(launcher.dispose);
+
+      await pumpGolden(
+        tester,
+        SoloHomeScreen(
+          uid: _ownUid,
+          profile: RelationshipProfile(
+            status: RelationshipStatus.married,
+            contentLanguage: ContentLanguage.values.byName(locale.languageCode),
+            register: ContentRegister.respectful,
+            createdAt: DateTime(2026, 7, 8),
+          ),
+        ),
+        locale: locale,
+        direction: TextDirection.ltr,
+        overrides: [
+          soloQuestionPackRepositoryProvider.overrideWith(
+            (ref) => AssetSoloQuestionPackRepository(bundle: shippedSolo),
+          ),
+          soloAnswersRepositoryProvider.overrideWith((ref) => answers),
+          soloClockProvider.overrideWith(
+            (ref) =>
+                () => _soloNow,
+          ),
+          profileRepositoryProvider.overrideWith((ref) => profiles),
+          authRepositoryProvider.overrideWith((ref) => auth),
+          inviteRepositoryProvider.overrideWith((ref) => invites),
+          inviteShareLauncherProvider.overrideWith((ref) => launcher),
+          localFlagStoreProvider.overrideWithValue(
+            FakeLocalFlagStore(initial: {privacySpotlightSeenKey(_ownUid)}),
+          ),
+        ],
+      );
+      await tester.pumpAndSettle();
+
+      await writeSurfacePng(tester, out(tag, '04-solo'));
+    });
+  });
+
+  // ---- 5. The coach, mid-conversation ----
+  //
+  // NOT the pack-selection screen, which was here first. Rendered at 6.9" that
+  // screen is a centred lock icon over two thirds of empty canvas — a paywall
+  // pitch, not a feature. The coach transcript is the differentiator, and it
+  // fills the frame.
+  _locales.forEach((tag, locale) {
+    testWidgets('05 coach $tag', (tester) async {
+      final language = tag == 'tr' ? ContentLanguage.tr : ContentLanguage.en;
+      final turns = _coachTurns[tag]!;
+      var turn = 0;
+      final coach = FakeCoachRepository();
+      // Each send answers with ITS OWN reply: a fake returning one canned line
+      // three times would render a transcript no user could ever see.
+      coach.onSendMessage = (call) async => CoachReply(
+        kind: CoachReplyKind.reply,
+        text: turns[turn++].$2,
+        remaining: CoachRemaining(daily: 12 - turn, monthly: 300),
+      );
+      final mirrors = FakeEntitlementRepository(
+        initialMirrors: {
+          _coupleId: CoupleEntitlement(
+            entitled: true,
+            expiresAt: _pairedNow.add(const Duration(days: 30)),
+          ),
+        },
+      );
+      final auth = FakeAuthRepository(initialUser: _user);
+      final profiles = FakeProfileRepository(
+        initialProfiles: {
+          _ownUid: RelationshipProfile(
+            status: RelationshipStatus.married,
+            contentLanguage: language,
+            register: ContentRegister.respectful,
+            coupleId: _coupleId,
+          ),
+        },
+      );
+      addTearDown(mirrors.dispose);
+      addTearDown(auth.dispose);
+      addTearDown(profiles.dispose);
+
+      await pumpGolden(
+        tester,
+        const CoachScreen(uid: _ownUid, coupleId: _coupleId),
+        locale: locale,
+        direction: TextDirection.ltr,
+        overrides: [
+          coachRepositoryProvider.overrideWith((ref) => coach),
+          entitlementRepositoryProvider.overrideWith((ref) => mirrors),
+          authRepositoryProvider.overrideWith((ref) => auth),
+          profileRepositoryProvider.overrideWith((ref) => profiles),
+          purchasesRepositoryProvider.overrideWith(
+            (ref) => FakePurchasesRepository(),
+          ),
+          // Disclaimer already acknowledged: the store shot is the working
+          // surface, not the one-time consent panel that sits in front of it.
+          localFlagStoreProvider.overrideWithValue(
+            FakeLocalFlagStore(initial: {coachDisclaimerAckKey(_ownUid)}),
+          ),
+          soloClockProvider.overrideWith(
+            (ref) =>
+                () => _pairedNow,
+          ),
+        ],
+      );
+      await tester.pumpAndSettle();
+
+      // REAL sends, so the transcript is a genuine round trip through the
+      // screen's own send path rather than hand-placed bubbles.
+      for (final (ask, _) in turns) {
+        await tester.enterText(find.byType(TextField), ask);
+        await tester.pump();
+        await tester.tap(
+          find.widgetWithText(FilledButton, l10nFor(locale).coachSend),
+        );
+        await tester.pumpAndSettle();
+      }
+
+      await writeSurfacePng(tester, out(tag, '05-coach'));
+    });
+  });
+
+  // ---- 6. It stays private: PIN + biometrics ----
+  _locales.forEach((tag, locale) {
+    testWidgets('06 lock $tag', (tester) async {
+      final record = lockRecord(
+        biometricEnabled: true,
+        enrollment: 'enrollment-v1',
+      );
+      final auth = FakeAuthRepository(initialUser: _user);
+      addTearDown(auth.dispose);
+
+      await pumpGolden(
+        tester,
+        const LockScreen(),
+        locale: locale,
+        direction: TextDirection.ltr,
+        overrides: [
+          pinLockStoreProvider.overrideWithValue(
+            FakePinLockStore(initial: record),
+          ),
+          initialLockSnapshotProvider.overrideWithValue(
+            PinLockSnapshot(record: record),
+          ),
+          biometricAuthenticatorProvider.overrideWithValue(
+            FakeBiometricAuthenticator(enrollment: 'enrollment-v1'),
+          ),
+          authRepositoryProvider.overrideWith((ref) => auth),
+          soloClockProvider.overrideWith(
+            (ref) =>
+                () => _pairedNow,
+          ),
+        ],
+      );
+      await tester.pumpAndSettle();
+
+      await writeSurfacePng(tester, out(tag, '06-lock'));
+    });
+  });
+}

--- a/app/screenshots/flutter_test_config.dart
+++ b/app/screenshots/flutter_test_config.dart
@@ -1,0 +1,20 @@
+import 'dart:async';
+
+import '../test/flutter_test_config.dart' as suite;
+
+/// Font loading for the screenshot lane, DELEGATED to the suite's config.
+///
+/// `flutter_test_config.dart` is discovered by walking up from the test file's
+/// own directory, so `test/flutter_test_config.dart` — which loads the real
+/// Rubik / Noto TTFs — is invisible to anything outside `test/`. Without this
+/// file the lane renders every glyph as the flutter_test placeholder box, and
+/// the failure is silent in the worst way: the images are the right size, the
+/// right colours and the right layout, and the run is green. The first render
+/// of this lane produced exactly that.
+///
+/// Delegated rather than copied ON PURPOSE. A second font list would drift from
+/// the suite's the first time a weight or a fallback family is added, and the
+/// symptom would be store screenshots whose typography no golden has ever
+/// checked — which is the one guarantee this lane exists to keep.
+Future<void> testExecutable(FutureOr<void> Function() testMain) =>
+    suite.testExecutable(testMain);

--- a/app/test/support/golden/golden_harness.dart
+++ b/app/test/support/golden/golden_harness.dart
@@ -1,4 +1,8 @@
+import 'dart:io';
+import 'dart:ui' show ImageByteFormat;
+
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show RenderRepaintBoundary;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hayati_app/core/design_system/hayati_theme.dart';
@@ -45,8 +49,52 @@ const naturalCells = <GoldenCell>[
 String goldenFile(String screen, String state, String cell) =>
     'goldens/$screen/$state.$cell.png';
 
+/// The env var that re-sizes the golden surface, as `WIDTHxHEIGHT@DPR`.
+///
+/// UNSET IS THE ONLY THING CI EVER SEES: every committed golden is 390×844 @1x
+/// and stays byte-identical. The override exists so the App Store screenshot
+/// lane can render the SAME states, from the SAME fakes, at 1290×2796 @3 —
+/// re-deriving those states in a parallel file would let the marketing images
+/// and the tested product drift apart, which is the one thing a screenshot must
+/// not do.
+const goldenSurfaceVar = 'APPSTORE_SCREENSHOT_SURFACE';
+
+/// Key on the [RepaintBoundary] wrapping everything [pumpGolden] pumps.
+///
+/// Always present, including on the 1x golden path, so the two paths render the
+/// identical widget tree — a boundary that existed only under the screenshot
+/// env would make the store assets a render of something the goldens never
+/// prove. It changes layer structure, not layout or paint.
+const goldenSurfaceKey = ValueKey<String>('golden-surface');
+
+/// Resolves the golden surface from [env] (defaults to the process env).
+///
+/// THROWS on a malformed value rather than falling back to the default. A typo
+/// that silently produced 390×844 would hand the founder a folder of
+/// plausible-looking PNGs that App Store Connect rejects at upload, hours
+/// later, with no clue pointing back to the typo — the failure has to happen
+/// here, where the cause is on screen.
+({Size size, double dpr}) goldenSurface([Map<String, String>? env]) {
+  final raw = (env ?? Platform.environment)[goldenSurfaceVar]?.trim();
+  if (raw == null || raw.isEmpty) {
+    return (size: const Size(390, 844), dpr: 1.0);
+  }
+  final parsed = RegExp(r'^(\d+)x(\d+)@(\d+(?:\.\d+)?)$').firstMatch(raw);
+  if (parsed == null) {
+    throw ArgumentError.value(
+      raw,
+      goldenSurfaceVar,
+      'must look like WIDTHxHEIGHT@DPR, e.g. 1290x2796@3.0',
+    );
+  }
+  return (
+    size: Size(double.parse(parsed.group(1)!), double.parse(parsed.group(2)!)),
+    dpr: double.parse(parsed.group(3)!),
+  );
+}
+
 /// Pumps [home] inside the branded app on a fixed 390×844 @1x surface for a
-/// deterministic golden.
+/// deterministic golden — or on the surface [goldenSurfaceVar] names.
 ///
 /// The [Directionality] override lives INSIDE the MaterialApp so the cell's
 /// [direction] wins regardless of [locale] — that decoupling is the six-cell
@@ -59,36 +107,69 @@ Future<void> pumpGolden(
   List<Override> overrides = const [],
   double textScale = 1.0,
 }) async {
-  tester.view.physicalSize = const Size(390, 844);
-  tester.view.devicePixelRatio = 1.0;
+  final surface = goldenSurface();
+  tester.view.physicalSize = surface.size;
+  tester.view.devicePixelRatio = surface.dpr;
   addTearDown(tester.view.resetPhysicalSize);
   addTearDown(tester.view.resetDevicePixelRatio);
 
   await tester.pumpWidget(
-    ProviderScope(
-      overrides: overrides,
-      child: MaterialApp(
-        debugShowCheckedModeBanner: false,
-        locale: locale,
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        theme: hayatiTheme(languageCode: locale.languageCode),
-        home: Builder(
-          builder: (context) {
-            final directed = Directionality(
-              textDirection: direction,
-              child: home,
-            );
-            if (textScale == 1.0) return directed;
-            return MediaQuery(
-              data: MediaQuery.of(
-                context,
-              ).copyWith(textScaler: TextScaler.linear(textScale)),
-              child: directed,
-            );
-          },
+    RepaintBoundary(
+      key: goldenSurfaceKey,
+      child: ProviderScope(
+        overrides: overrides,
+        child: MaterialApp(
+          debugShowCheckedModeBanner: false,
+          locale: locale,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: hayatiTheme(languageCode: locale.languageCode),
+          home: Builder(
+            builder: (context) {
+              final directed = Directionality(
+                textDirection: direction,
+                child: home,
+              );
+              if (textScale == 1.0) return directed;
+              return MediaQuery(
+                data: MediaQuery.of(
+                  context,
+                ).copyWith(textScaler: TextScaler.linear(textScale)),
+                child: directed,
+              );
+            },
+          ),
         ),
       ),
     ),
   );
+}
+
+/// Writes the pumped surface to [path] as a PNG at the surface's DPR.
+///
+/// WHY THIS EXISTS RATHER THAN `matchesGoldenFile`. Measured: with the view at
+/// 1290×2796 @3, `matchesGoldenFile` writes a **430×932** file. Its capture is
+/// at the LOGICAL size and ignores `devicePixelRatio` entirely — correct for a
+/// golden (a diff wants layout, not pixels) and useless for a store asset,
+/// which App Store Connect rejects unless it is exactly 1290×2796. So the
+/// screenshot lane captures the boundary itself and passes the DPR explicitly.
+///
+/// `runAsync` is required, not decorative: `toImage` hands work to the engine,
+/// and the fake-async zone a widget test runs in never lets that future
+/// complete — without it this hangs until the test times out.
+Future<void> writeSurfacePng(WidgetTester tester, String path) async {
+  final surface = goldenSurface();
+  final boundary =
+      tester.renderObject(find.byKey(goldenSurfaceKey))
+          as RenderRepaintBoundary;
+  final bytes = await tester.runAsync(() async {
+    final image = await boundary.toImage(pixelRatio: surface.dpr);
+    final data = await image.toByteData(format: ImageByteFormat.png);
+    image.dispose();
+    return data!.buffer.asUint8List();
+  });
+
+  final file = File(path);
+  file.parent.createSync(recursive: true);
+  file.writeAsBytesSync(bytes!);
 }

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -72,6 +72,44 @@ empty-URL ratchet (see below). `tool/store_metadata_lint_test.dart` mutation-che
 every rule class. Both run in the ubuntu `quality`/`preflight` jobs, before
 `pub get`, like the content validator.
 
+### Screenshots — rendered from the app, on Linux, at Apple's exact size
+
+`deliver(skip_screenshots: true)` still holds: nothing here uploads them. But
+they are no longer a manual job on somebody's phone.
+
+```sh
+tool/ci/appstore_screenshots.sh          # → app/build/appstore/screenshots/{tr,en}/
+```
+
+Twelve PNGs at **1290×2796** — six screens × the two listing locales — which is
+the whole iPhone requirement: App Store Connect takes the 6.9" set and scales
+every smaller device down from it, and the app is iPhone-only since #179, so
+there is no 13" iPad set to produce.
+
+**No Mac, no simulator, no device.** `flutter test` rasterises widgets on the
+host, so `app/screenshots/appstore_screenshots_test.dart` renders real pixels of
+real screens from the same fakes and the same shipped question packs the goldens
+use — the surface size comes from `APPSTORE_SCREENSHOT_SURFACE`, which
+`golden_harness.dart` reads and which is UNSET everywhere else, so the 390×844
+goldens stay byte-identical. The store listing and the tested product cannot
+drift apart, because they are renders of one widget tree.
+
+Three things this lane learned the hard way, all pinned in code:
+
+- **`matchesGoldenFile` cannot produce a store asset.** With the view at
+  1290×2796 @3 it writes a **430×932** file — it captures at the logical size
+  and ignores `devicePixelRatio`. Right for a diff, useless for Apple. Hence
+  `writeSurfacePng`, which captures the boundary at an explicit DPR.
+- **`flutter_test_config.dart` is found by walking up from the TEST file.** A
+  generator outside `test/` never sees the suite's font loader, and the failure
+  is silent in the worst way: right size, right colours, right layout, green
+  run — and every glyph an empty box. `screenshots/flutter_test_config.dart`
+  delegates to the suite's rather than copying its font list.
+- **The generator's exit code proves nothing about the pixels.** It is a widget
+  test; it goes green whenever it does not throw, including if the surface
+  override were ignored entirely. The script re-reads every PNG's IHDR and fails
+  on a wrong size or an empty output directory.
+
 ### Native review: PENDING
 
 **Every store string in both locales is AI-drafted and awaits native review by

--- a/tool/ci/appstore_screenshots.sh
+++ b/tool/ci/appstore_screenshots.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Render the App Store screenshot set from the app's own widgets.
+#
+# OPERATOR-RUN, not CI-run. It lives under tool/ci/ for one reason: that is the
+# directory ci.yml shellchecks, and a release-facing shell script with no static
+# check is the ADR-024 lesson this repo already paid for once. Nothing in
+# ci.yml calls it.
+#
+# WHAT IT IS NOT: a simulator, a device farm, or a Mac. `flutter test` renders
+# widgets on the host with a software rasterizer, so this produces real pixels
+# of real screens on Linux, at exactly the size App Store Connect demands.
+#
+# Usage:  tool/ci/appstore_screenshots.sh
+# Output: app/build/appstore/screenshots/{tr,en}/*.png
+set -euo pipefail
+
+# 6.9" iPhone (16/15 Pro Max class). App Store Connect's iPhone slot takes
+# 1290x2796 or 1320x2868 and scales every smaller device down from it, so this
+# single set is the whole iPhone requirement. The app is iPhone-only since
+# #179, so there is no iPad set to render.
+SURFACE="${APPSTORE_SCREENSHOT_SURFACE:-1290x2796@3.0}"
+EXPECTED_W="${SURFACE%x*}"
+rest="${SURFACE#*x}"
+EXPECTED_H="${rest%@*}"
+
+cd "$(dirname "$0")/../../app"
+
+echo "rendering at ${SURFACE} ..."
+rm -rf build/appstore
+APPSTORE_SCREENSHOT_SURFACE="$SURFACE" \
+  flutter test screenshots/appstore_screenshots_test.dart
+
+# VERIFY THE PIXELS, not the exit code. The generator is a widget test: it goes
+# green whenever it does not throw, including if the surface override were
+# silently ignored and every file came out 390x844. App Store Connect would
+# then reject the upload hours later with nothing pointing back here. Reading
+# the PNG's own IHDR is the only check that cannot agree with a wrong
+# assumption — and an empty output directory must fail too, not pass vacuously.
+python3 - "$EXPECTED_W" "$EXPECTED_H" <<'PY'
+import pathlib
+import struct
+import sys
+
+want = (int(sys.argv[1]), int(sys.argv[2]))
+root = pathlib.Path("build/appstore/screenshots")
+files = sorted(root.rglob("*.png"))
+if not files:
+    sys.exit(f"FAIL: no PNGs under {root} — the generator wrote nothing")
+
+bad = []
+for f in files:
+    with f.open("rb") as fh:
+        got = struct.unpack(">II", fh.read(24)[16:24])
+    flag = "ok " if got == want else "BAD"
+    if got != want:
+        bad.append(f"{f}: {got[0]}x{got[1]}")
+    print(f"  {flag} {got[0]}x{got[1]}  {f}")
+
+print(f"\n{len(files)} screenshots at {want[0]}x{want[1]}")
+if bad:
+    sys.exit("FAIL: wrong size — " + "; ".join(bad))
+PY
+
+echo
+echo "upload from: app/build/appstore/screenshots/{tr,en}/"


### PR DESCRIPTION

`deliver(skip_screenshots: true)` and no screenshots anywhere in the repo: the
listing's twelve images were an unstarted manual job on somebody's phone.

    tool/ci/appstore_screenshots.sh   ->  app/build/appstore/screenshots/{tr,en}/

Twelve PNGs at 1290x2796 — six screens x the two locales `fastlane/metadata/`
actually carries. That is the whole iPhone requirement: App Store Connect scales
every smaller device down from the 6.9" set, and #179 made the app iPhone-only,
so there is no 13" iPad set to produce.

**No Mac, no simulator, no device.** `flutter test` rasterises widgets on the
host. The generator renders the SAME states its golden tests render, from the
same fakes and the same shipped question packs — the store listing and the
tested product cannot drift apart, because they are renders of one widget tree.
What is deliberately not shared is the SELECTION: the goldens capture every
state including `error` and `loading`; this curates the six that tell the story.

Three things this cost, each now pinned in code rather than in someone's memory:

**`matchesGoldenFile` cannot produce a store asset.** Measured: with the view at
1290x2796 @3 it writes a 430x932 file. It captures at the LOGICAL size and
ignores `devicePixelRatio` entirely — correct for a diff, useless for Apple.
Hence `writeSurfacePng`, which captures the boundary at an explicit DPR.

**`flutter_test_config.dart` is discovered by walking up from the TEST file.** A
generator outside `test/` never sees the suite's font loader, and the first run
proved how badly that fails: right size, right colours, right layout, green run
— and every glyph an empty Ahem box. `screenshots/flutter_test_config.dart`
delegates to the suite's rather than copying its font list, so a weight added
later cannot leave the store images rendering type no golden has checked.

**The generator's exit code proves nothing about the pixels.** It is a widget
test: green whenever it does not throw, including if the surface override were
ignored and every file came out 390x844 — a rejection at upload, hours later,
with nothing pointing back. The script re-reads every PNG's IHDR and fails on a
wrong size OR an empty output directory. Mutation-checked: rendering with the
override unset makes it exit 1 naming 12/12 wrong.

**One product finding, not fixed here.** At 6.9" the ritual-preview and
pack-selection screens leave most of the canvas empty — they were designed and
goldened at 390x844 only, and nothing has ever looked at them taller.
Pack-selection was the first choice for shot 5 and was replaced by the coach
transcript for exactly this reason. Worth a look before the public listing.

Surface size comes from `APPSTORE_SCREENSHOT_SURFACE`, read by
`golden_harness.dart` and UNSET everywhere else, so all 359 goldens stay
byte-identical — verified, along with the added `RepaintBoundary`, by the full
suite: 1639 tests green.

`app/screenshots` joins the `dart format` gate. That list is an explicit
allow-list, so anything added outside it is skipped forever and silently —
`flutter analyze` reads the whole package and would have kept passing.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)