### PR TITLE
fix(store): the screenshot lane's ruby step had nothing to infer a version from

### DIFF
--- a/.github/workflows/appstore-screenshots.yml
+++ b/.github/workflows/appstore-screenshots.yml
@@ -96,10 +96,21 @@ jobs:
             exit 1
           fi
 
+      # MIRRORS release.yml's proven block, deliberately, down to the pinned
+      # version and the separate `bundle install`. The first draft used
+      # `bundler-cache: true` with no `ruby-version` and died on
+      # "input ruby-version needs to be specified if no .ruby-version or
+      # .tool-versions file exists" — this repo has neither, so the action has
+      # nothing to infer from. Copying the block that already works beats
+      # re-deriving one, and if a `.ruby-version` ever lands both lanes should
+      # change together.
       - uses: ruby/setup-ruby@v1
         if: ${{ inputs.upload }}
         with:
-          bundler-cache: true
+          ruby-version: '3.3'
+      - name: bundle install
+        if: ${{ inputs.upload }}
+        run: bundle install
 
       - name: fastlane store_screenshots
         if: ${{ inputs.upload }}


### PR DESCRIPTION
First real `upload: true` dispatch ([run 30774214335](https://github.com/aytekXR/hayati-mobile-app/actions/runs/30774214335)) died before fastlane:

```
Error: input ruby-version needs to be specified if no .ruby-version
       or .tool-versions file exists
```

`ruby/setup-ruby@v1` with `bundler-cache: true` and no `ruby-version` infers from a `.ruby-version` or `.tool-versions` file. This repo has neither.

Fixed by **mirroring release.yml's block** rather than re-deriving one — pinned `ruby-version: '3.3'` plus a separate `bundle install`, exactly as the lane already shipping builds to TestFlight does.

What did **not** go wrong is the part that was designed for: render → IHDR size verification → artifact → locale filter all ran and passed, and the failure landed on the step after them. Nothing outward-facing was attempted, and the `upload: false` dispatch had already proven the whole cheap half end to end in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)