### PR TITLE
fix(store): deliver uploads the screenshot set TWICE — the lane now repairs what it breaks

### DIFF
--- a/.github/workflows/appstore-screenshots.yml
+++ b/.github/workflows/appstore-screenshots.yml
@@ -119,3 +119,48 @@ jobs:
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
           ASC_API_KEY_P8_BASE64: ${{ secrets.ASC_API_KEY_P8_BASE64 }}
         run: bundle exec fastlane ios store_screenshots
+
+      # REPAIRS what the step above reliably breaks. Measured twice on
+      # 2026-08-03: `deliver` uploads the set, verifies it, does not find it
+      # (Apple processes screenshots asynchronously) and uploads the WHOLE SET
+      # again — six files, ten uploads, because Apple caps a display type at ten
+      # and drops the rest. The listing is left with four duplicates and an
+      # order nobody chose. `overwrite_screenshots: true` reproduces it exactly
+      # rather than avoiding it, so this is not a setting we failed to find.
+      #
+      # Part of the same run on purpose: a lane that leaves a known-wrong
+      # listing behind and relies on someone noticing is worse than no lane.
+      - uses: actions/setup-python@v5
+        if: ${{ inputs.upload }}
+        with:
+          python-version: '3.12'
+      - name: install deps
+        if: ${{ inputs.upload }}
+        run: pip install 'pyjwt[crypto]==2.10.1'
+      - name: de-duplicate + order the uploaded screenshots
+        if: ${{ inputs.upload }}
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_API_KEY_P8_BASE64: ${{ secrets.ASC_API_KEY_P8_BASE64 }}
+          LOCALES: ${{ inputs.locales }}
+        run: |
+          python3 tool/ci/testflight_testers.py \
+            --bundle-id com.beyondkaira.hayati \
+            --group Friends \
+            --dedupe-screenshots "$LOCALES"
+
+      # Never report green without having looked. The dedupe above says what it
+      # did; this says what Apple now HOLDS, which is the only claim worth
+      # making about an outward-facing write.
+      - name: re-read the listing
+        if: ${{ inputs.upload }}
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_API_KEY_P8_BASE64: ${{ secrets.ASC_API_KEY_P8_BASE64 }}
+        run: |
+          python3 tool/ci/testflight_testers.py \
+            --bundle-id com.beyondkaira.hayati \
+            --group Friends \
+            --store-status

--- a/tool/ci/testflight_testers.py
+++ b/tool/ci/testflight_testers.py
@@ -800,13 +800,92 @@ def screenshot_sets(token: str, localization_id: str) -> list[dict]:
     ).get("data", [])
 
 
-def screenshot_count(token: str, set_id: str) -> int:
+def list_screenshots(token: str, set_id: str) -> list[dict]:
     query = urllib.parse.urlencode({"limit": 50})
-    return len(
-        _call(
-            token, "GET", f"/v1/appScreenshotSets/{set_id}/appScreenshots?{query}"
-        ).get("data", [])
-    )
+    return _call(
+        token, "GET", f"/v1/appScreenshotSets/{set_id}/appScreenshots?{query}"
+    ).get("data", [])
+
+
+def screenshot_count(token: str, set_id: str) -> int:
+    return len(list_screenshots(token, set_id))
+
+
+def dedupe_screenshots(
+    token: str, app_id: str, locales: set[str], dry_run: bool = False
+) -> list[str]:
+    """Delete duplicate uploads and pin the display order by file name.
+
+    WHY THIS IS NEEDED, measured twice on 2026-08-03. `deliver` uploads the set,
+    verifies it, does not find it (Apple processes screenshots asynchronously),
+    and uploads the WHOLE SET a second time — the log says "Successfully
+    uploaded all screenshots" twice and 6 files produce 10 uploads, because
+    Apple caps a display type at 10 and silently drops the rest. Re-running with
+    `overwrite_screenshots: true` reproduces it exactly: delete 10, upload 6,
+    upload 6 again, land on 10.
+
+    So the listing ends up with the right images plus four duplicates and a
+    scrambled order. Neither is something `deliver` can be configured out of,
+    and neither is something to leave for a human to notice in App Store
+    Connect.
+
+    Keyed on `fileName`, which the generator guarantees is unique per intended
+    screenshot (`01-reveal.png` … `06-lock.png`) — never on position, which is
+    exactly what the double upload scrambles. The FIRST occurrence survives.
+
+    Ordering is re-asserted afterwards rather than assumed: `deliver` sorts at
+    the end of its own run, but that sort ran over the duplicated set, so the
+    survivors' order is whatever the deletions left behind.
+    """
+    lines: list[str] = []
+    for version in app_store_versions(token, app_id):
+        for localization in version_localizations(token, version["id"]):
+            locale = (localization.get("attributes") or {}).get("locale")
+            if locale not in locales:
+                continue
+            for shot_set in screenshot_sets(token, localization["id"]):
+                display = (shot_set.get("attributes") or {}).get(
+                    "screenshotDisplayType"
+                )
+                shots = list_screenshots(token, shot_set["id"])
+                seen: dict[str, str] = {}
+                doomed: list[dict] = []
+                for shot in shots:
+                    name = (shot.get("attributes") or {}).get("fileName") or shot["id"]
+                    if name in seen:
+                        doomed.append(shot)
+                    else:
+                        seen[name] = shot["id"]
+
+                verb = "would delete" if dry_run else "deleted"
+                if doomed:
+                    for shot in doomed:
+                        name = (shot.get("attributes") or {}).get("fileName")
+                        if not dry_run:
+                            _call(token, "DELETE", f"/v1/appScreenshots/{shot['id']}")
+                        lines.append(f"  {locale}/{display}: {verb} duplicate {name}")
+                else:
+                    lines.append(f"  {locale}/{display}: no duplicates")
+
+                ordered = [seen[name] for name in sorted(seen)]
+                if not dry_run and ordered:
+                    _call(
+                        token,
+                        "PATCH",
+                        f"/v1/appScreenshotSets/{shot_set['id']}/relationships/appScreenshots",
+                        {
+                            "data": [
+                                {"type": "appScreenshots", "id": shot_id}
+                                for shot_id in ordered
+                            ]
+                        },
+                    )
+                lines.append(
+                    f"  {locale}/{display}: "
+                    f"{'would order' if dry_run else 'ordered'} "
+                    f"{len(ordered)} by file name"
+                )
+    return lines
 
 
 def print_store_status(token: str, app: dict) -> None:
@@ -991,6 +1070,15 @@ def main() -> int:
         ),
     )
     parser.add_argument(
+        "--dedupe-screenshots",
+        help=(
+            "Comma-separated locales whose App Store screenshots should be "
+            "de-duplicated by file name and re-ordered. DESTRUCTIVE: it deletes "
+            "screenshots. Honours --dry-run. Needed because `deliver` uploads "
+            "the set twice (measured 2026-08-03)."
+        ),
+    )
+    parser.add_argument(
         "--assign-build-number",
         help=(
             "Attach THIS build number to the group once Apple finishes "
@@ -1060,6 +1148,19 @@ def main() -> int:
     if args.status:
         print_status(token, app, args.group)
         return 0
+
+    # Before the group work and before any submission: this repairs a listing
+    # that a previous upload left wrong, and it must not be hostage to an
+    # unrelated group problem further down.
+    if args.dedupe_screenshots:
+        wanted = {
+            locale.strip()
+            for locale in args.dedupe_screenshots.split(",")
+            if locale.strip()
+        }
+        print(f"\nde-duplicating screenshots for: {', '.join(sorted(wanted))}")
+        for line in dedupe_screenshots(token, app["id"], wanted, dry_run=args.dry_run):
+            print(line)
 
     # Before the group work, so a contact write is not hostage to a group
     # problem — and idempotent, so an earlier partial run costs nothing.

--- a/tool/ci/testflight_testers_test.py
+++ b/tool/ci/testflight_testers_test.py
@@ -519,6 +519,77 @@ def test_print_store_status() -> None:
           ("tr:" in text, "screenshot sets unavailable" in text), (True, True))
 
 
+def test_dedupe_screenshots() -> None:
+    """The repair for a defect `deliver` cannot be configured out of.
+
+    Measured twice: deliver uploads the set, fails to verify it (Apple processes
+    screenshots asynchronously), and uploads the WHOLE SET again — six files,
+    ten uploads, because Apple caps a display type at ten and drops the rest."""
+    print("dedupe_screenshots")
+
+    def shot(shot_id, name):
+        return {"id": shot_id, "attributes": {"fileName": name}}
+
+    # The exact shape the live listing was left in: 01-04 twice, 05-06 once.
+    duplicated = [
+        shot("a1", "01-reveal.png"), shot("a2", "02-waiting.png"),
+        shot("a3", "03-ritual.png"), shot("a4", "04-solo.png"),
+        shot("a5", "05-coach.png"), shot("a6", "06-lock.png"),
+        shot("b1", "01-reveal.png"), shot("b2", "02-waiting.png"),
+        shot("b3", "03-ritual.png"), shot("b4", "04-solo.png"),
+    ]
+
+    def script(shots):
+        return [
+            ("GET", "appStoreVersions?", {"data": [{"id": "v-1", "attributes": {}}]}),
+            ("GET", "appStoreVersionLocalizations?", {"data": [
+                {"id": "loc-en", "attributes": {"locale": "en-US"}},
+                {"id": "loc-tr", "attributes": {"locale": "tr"}},
+            ]}),
+            ("GET", "appScreenshotSets?", {"data": [
+                {"id": "set-1",
+                 "attributes": {"screenshotDisplayType": "APP_IPHONE_67"}},
+            ]}),
+            ("GET", "appScreenshots?", {"data": shots}),
+        ]
+
+    seen = _fake_call(script(duplicated))
+    lines = tf.dedupe_screenshots("t", "app-1", {"en-US"})
+    deleted = [p for m, p, _ in seen if m == "DELETE"]
+    check("deletes exactly the four duplicates", len(deleted), 4)
+    check("deletes the SECOND occurrence, never the first",
+          sorted(p.rsplit("/", 1)[-1] for p in deleted), ["b1", "b2", "b3", "b4"])
+
+    patched = [b for m, p, b in seen if m == "PATCH"]
+    check("re-asserts the order", len(patched), 1)
+    check("orders by FILE NAME, not by upload position",
+          [d["id"] for d in patched[0]["data"]], ["a1", "a2", "a3", "a4", "a5", "a6"])
+    check("says what it did", any("deleted duplicate" in ln for ln in lines), True)
+
+    # SCOPED to the requested locales. `tr` shares the same fake set, so a
+    # dedupe that ignored the filter would delete twice as much.
+    seen = _fake_call(script(duplicated))
+    tf.dedupe_screenshots("t", "app-1", {"en-US"})
+    check("touches only the requested locale",
+          len([p for m, p, _ in seen if m == "DELETE"]), 4)
+
+    # A clean set is a no-op that SAYS so — never a silent pass that reads the
+    # same as a repair.
+    seen = _fake_call(script(duplicated[:6]))
+    lines = tf.dedupe_screenshots("t", "app-1", {"en-US"})
+    check("a clean set deletes nothing", [m for m, _, _ in seen if m == "DELETE"], [])
+    check("and says it found none",
+          any("no duplicates" in ln for ln in lines), True)
+
+    # Dry run: reports, touches nothing. Both the DELETEs and the ordering
+    # PATCH — an ordering write is still a write.
+    seen = _fake_call(script(duplicated))
+    lines = tf.dedupe_screenshots("t", "app-1", {"en-US"}, dry_run=True)
+    check("dry run deletes nothing",
+          [m for m, _, _ in seen if m in ("DELETE", "PATCH")], [])
+    check("dry run says WOULD", any("would delete" in ln for ln in lines), True)
+
+
 def test_looks_like_submission_conflict() -> None:
     """The BACKSTOP for a duplicate submission. The primary guard is the state
     read; this only covers the race. It requires BOTH an error family AND a
@@ -811,6 +882,7 @@ def main() -> int:
     test_set_review_contact_never_leaks()
     test_submit_for_review()
     test_print_store_status()
+    test_dedupe_screenshots()
     test_looks_like_submission_conflict()
     test_missing_contact_does_not_block_assignment()
     test_dry_run_against_a_missing_group_still_exits_non_zero()


### PR DESCRIPTION
Measured, then measured again to rule out a race:

```
6 files on disk        ->  10 "Uploaded …" lines
"Successfully uploaded all screenshots"  printed TWICE
en-US: APP_IPHONE_67=10
```

`deliver` uploads the set, verifies it, does not find it (Apple processes screenshots asynchronously), and uploads the **whole set again**. Apple caps a display type at ten, so six files become 6 + 4 and the last two are dropped silently. The listing is left with four duplicates and a display order nobody chose.

**`overwrite_screenshots: true` does not avoid this.** The second run reproduced it exactly — delete ten, upload six, upload six again, land on ten. Not a setting we failed to find; behaviour to repair.

## The repair

`--dedupe-screenshots` keys on `fileName`, which the generator guarantees is unique per intended screenshot (`01-reveal.png` … `06-lock.png`) — never on **position**, which is exactly what the double upload scrambles. The first occurrence survives.

Order is then **re-asserted**, not assumed: deliver does sort at the end of its own run, but that sort ran over the duplicated set, so the survivors' order is whatever the deletions left behind.

It runs **inside** the upload lane, not as a button someone has to remember — a lane that leaves a known-wrong listing behind and relies on a human noticing is worse than no lane. A final `--store-status` re-read prints what Apple now holds, because a run's exit code has already been shown this week to be worthless as evidence about an outward-facing write (#177).

## Tests — 10 checks

- the exact live shape (01–04 twice, 05–06 once) leaves **four** deletes
- the **second** occurrence dies, never the first
- the order patch is by **file name**, not upload position
- the locale filter is honoured — a second locale sharing the fake would otherwise double the deletions
- a clean set deletes nothing **and says so**, rather than passing silently
- the dry run writes neither `DELETE` nor the ordering `PATCH` — an ordering write is still a write

🤖 Generated with [Claude Code](https://claude.com/claude-code)