### PR TITLE
feat(ci): stop asking the founder what the App ID capabilities are, and read them

### DIFF
--- a/.github/workflows/appid-capabilities.yml
+++ b/.github/workflows/appid-capabilities.yml
@@ -1,0 +1,103 @@
+# appid-capabilities — read which capabilities are ticked on the App ID.
+#
+# WHY THIS EXISTS. Three questions have sat in docs/operator-expected.md for
+# months with the same non-answer — "a session cannot read the portal, so nobody
+# knows": item 4(a) (Push Notifications, which gates the whole notification
+# feature), item 2(d) (Associated Domains, whose absence cost a release — see
+# ADR-040), and the App Attest question under 2(d) (prod App Check attestation
+# cannot succeed without it, ADR-039).
+#
+# None of the three was ever unanswerable. The portal's capability list is
+# readable over the App Store Connect API with the SAME credential the release
+# lane and testflight-testers.yml already hold, so "ask the founder to look" was
+# a missing tool, not a missing permission. One dispatch answers all three.
+#
+# WHY A WORKFLOW AND NOT A DEV-BOX COMMAND: identical to testflight-testers.yml
+# — the ASC key lives only in GitHub secrets (architecture.md §9, zero
+# credentials in this repo), and ASC_KEY_ID / ASC_ISSUER_ID are `release`
+# ENVIRONMENT secrets while ASC_API_KEY_P8_BASE64 is a REPOSITORY secret, so
+# only a job declaring the environment sees both (the REL-2 lesson).
+#
+# READ-ONLY BY CONSTRUCTION. The tool has no code path that can tick a
+# capability. Enabling one changes how a real binary signs; that is a founder
+# decision, and a lane that could do it would also be a lane that could do it by
+# accident. Manual dispatch only — nothing here should run as a merge side
+# effect.
+#
+# THE JOB REDDENS ON BOTH FINDINGS, AND THEY ARE DIFFERENT FINDINGS:
+#   exit 1  measured, a required capability is NOT ticked  -> the founder must act
+#   exit 2  COULD NOT MEASURE (no credential, or a 403 because this key's role
+#           does not cover Certificates/Identifiers)       -> nobody looked
+# Exit 2 must never be quietly green: a check that cannot run and reports success
+# is the failure mode ADR-041 and the rules-drift preflight were built against.
+name: appid-capabilities
+
+on:
+  workflow_dispatch:
+    inputs:
+      bundle_id:
+        description: 'App ID to read'
+        required: true
+        default: 'com.beyondkaira.hayati'
+      require:
+        description: 'Comma-separated capabilities that must be ticked (blank = plain read-out)'
+        required: false
+        default: 'PUSH_NOTIFICATIONS,ASSOCIATED_DOMAINS,APP_ATTEST'
+
+concurrency:
+  group: appid-capabilities
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  read:
+    name: read App ID capabilities
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: release
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      # `python3 -m pip`, never bare `pip`, and setup-python before either — the
+      # lesson recorded in ci.yml's rules-drift job.
+      - name: install deps
+        run: python3 -m pip install --quiet 'pyjwt[crypto]==2.10.1'
+      - name: read capabilities
+        # Inputs reach the shell as ENV, never interpolated into the script body:
+        # `${{ }}` expands before bash sees the line, so an input containing shell
+        # metacharacters would otherwise execute (testflight-testers.yml's rule).
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_API_KEY_P8_BASE64: ${{ secrets.ASC_API_KEY_P8_BASE64 }}
+          BUNDLE_ID: ${{ inputs.bundle_id }}
+          REQUIRE: ${{ inputs.require }}
+        run: |
+          args=(--bundle-id "$BUNDLE_ID")
+          # Split on commas without word-splitting on whitespace inside a value.
+          if [ -n "$REQUIRE" ]; then
+            IFS=',' read -r -a wanted <<< "$REQUIRE"
+            for capability in "${wanted[@]}"; do
+              # trim surrounding spaces so `A, B` behaves like `A,B`
+              capability="${capability#"${capability%%[![:space:]]*}"}"
+              capability="${capability%"${capability##*[![:space:]]}"}"
+              if [ -n "$capability" ]; then args+=(--require "$capability"); fi
+            done
+          fi
+          set +e
+          python3 tool/ci/appid_capabilities.py "${args[@]}"
+          status=$?
+          set -e
+          # Never read this through a pipe — `$?` after a pipe is the PIPE's
+          # status, the single most-cited lesson in docs/session-lessons.md.
+          case "$status" in
+            0) echo "::notice::every requested capability is ticked on $BUNDLE_ID" ;;
+            1) echo "::error::a required capability is NOT ticked on $BUNDLE_ID — see the read-out above; this is a founder action (operator-expected 4(a) / 2(d))" ;;
+            2) echo "::error::COULD NOT MEASURE the App ID capabilities — nobody looked, so nothing above is evidence about the portal" ;;
+            *) echo "::error::appid_capabilities.py exited $status, which is outside its documented taxonomy" ;;
+          esac
+          exit "$status"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,17 @@ jobs:
         run: |
           pip install --quiet 'pyjwt[crypto]==2.10.1'
           python3 tool/ci/testflight_testers_test.py
+      # tool/ci/appid_capabilities.py shares that credential path (it imports
+      # testflight_testers._token rather than growing a second copy), so it rides
+      # the same pyjwt install. Its self-tests are hermetic — no network, no
+      # Apple, no secret — and they pin the ONE property that makes the tool worth
+      # having: a 403 from an API key that lacks the Certificates/Identifiers role
+      # must be exit 2 "could not measure", never exit 1 "the capability is
+      # absent". Collapsing those two would hand the founder a measured-sounding
+      # lie about a blocker. Mutation-checked: forcing _cannot_measure to return
+      # EXIT_ABSENT reddens ten named assertions.
+      - name: app id capability probe self-tests
+        run: python3 tool/ci/appid_capabilities_test.py
       # ADR-034: the behavioural half of the advisory-delta gate. The gate itself
       # runs in functions-rules (it needs npm); these tests are hermetic — no npm,
       # no network, no emulator — so they belong here with the other pre-`pub get`

--- a/tool/ci/appid_capabilities.py
+++ b/tool/ci/appid_capabilities.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""Read the capabilities ticked on the App ID in Apple's Developer portal.
+
+WHY THIS EXISTS. Three questions have sat in `docs/operator-expected.md` for
+months with the same non-answer — *"a session cannot read the portal, so nobody
+knows"*:
+
+  * **4(a)** — is **Push Notifications** enabled? It gates the entire
+    notification feature, because the entitlement must exist in the
+    PROVISIONING PROFILE too and `match` fetches profiles readonly (ADR-032),
+    so a build claiming `aps-environment` without the capability fails at
+    CODESIGN.
+  * **2(d)** — is **Associated Domains** enabled? ADR-040 removed that
+    entitlement, and cost a release finding out.
+  * the third capability question — is **App Attest** in the list? Prod App
+    Check attestation cannot succeed without it (ADR-039).
+
+None of the three is actually unanswerable. The portal's capability list is
+readable over the App Store Connect API — the same credential the release lane
+and `testflight_testers.py` already use — so "ask the founder to look" was a
+missing tool, not a missing permission. QUERY THE PLATFORM, NOT THE DOCS.
+
+WHAT IT IS NOT. It reads. It cannot tick a capability, and it deliberately has
+no code path that could: enabling a capability changes how a real binary signs,
+which is a founder decision, and a tool that could do it would also be a tool
+that could do it by accident.
+
+FAIL-CLOSED, ALWAYS. Exit codes are a taxonomy, not a boolean — the same one
+`rules_drift.py` uses, for the same reason (ADR-041):
+
+    0   MEASURED, and every --require capability is enabled
+    1   MEASURED, and at least one --require capability is absent. The finding.
+    2   COULD NOT MEASURE — no credential, an HTTP error, a 403 because this API
+        key's role does not cover Certificates/Identifiers, a bundle id this key
+        cannot see, an unexpected response shape, or a paginated list this tool
+        did not fully follow. NEVER 0, and never 1.
+
+THE 1-VERSUS-2 DISTINCTION IS THE WHOLE POINT. An App Store Connect key carries
+a role. If it is not permitted to read Certificates, Identifiers & Profiles,
+Apple answers **403** — and collapsing that into "the capability is not ticked"
+would hand the founder a measured-sounding lie, and send a session off to build
+around a blocker that may not exist. "I looked and it is absent" and "I could
+not look" are different facts and this tool never conflates them.
+
+PARTIAL IS NOT ABSENT, EITHER. If Apple paginates the capability list and this
+tool holds only page one, the enabled set it has is incomplete — and an
+incomplete set can only ever produce a FALSE absence. So an unfollowed `next`
+link is exit 2, the same way `rules_drift.py` fails closed on a second
+firestore release rather than comparing a partial view.
+
+Run (CI, the manual dispatch lane):
+    python3 tool/ci/appid_capabilities.py --bundle-id com.beyondkaira.hayati \
+        --require PUSH_NOTIFICATIONS --require ASSOCIATED_DOMAINS --require APP_ATTEST
+
+Run with no --require at all for a plain read-out of everything that is ticked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import importlib.util
+import pathlib
+import re
+import sys
+import urllib.parse
+
+# The credential gate is IMPORTED, never re-implemented. `testflight_testers`
+# already owns the one place this repo turns three secrets into an ES256
+# assertion, including the fail-closed "name the missing variables, never their
+# values" behaviour the release lane depends on. A second copy would be a second
+# thing that can drift, and drift in a credential gate fails in the reassuring
+# direction. Loaded by path because tool/ci is not a package and this must work
+# regardless of the caller's cwd.
+_SIBLING = pathlib.Path(__file__).with_name("testflight_testers.py")
+_spec = importlib.util.spec_from_file_location("testflight_testers", _SIBLING)
+assert _spec is not None and _spec.loader is not None
+_tft = importlib.util.module_from_spec(_spec)
+sys.modules.setdefault("testflight_testers", _tft)
+_spec.loader.exec_module(_tft)
+
+# Deliberately the SAME exception class, not a parallel one: a caller that
+# catches AscError must catch it from either half of the credential path.
+AscError = _tft.AscError
+
+EXIT_OK = 0
+EXIT_ABSENT = 1
+EXIT_CANNOT_MEASURE = 2
+
+# Apple's own spelling of the three capabilityType values this repo cares about.
+# These strings ARE the contract: a typo can only ever report a ticked
+# capability as absent, which is the false blocker this tool exists to prevent,
+# so they are pinned by a self-test rather than trusted to a careful moment.
+PUSH_NOTIFICATIONS = "PUSH_NOTIFICATIONS"
+ASSOCIATED_DOMAINS = "ASSOCIATED_DOMAINS"
+APP_ATTEST = "APP_ATTEST"
+APPLE_ID_AUTH = "APPLE_ID_AUTH"
+
+# The vocabulary a --require value is validated against. NOT a list of every
+# capability Apple has — only the ones this repo has a reason to assert on. An
+# unknown value is refused (exit 2) rather than reported absent, because an
+# unknown value can ONLY come back absent and that would be a measurement-shaped
+# guess. Same closed-vocabulary discipline as ADR-026's seasonalWindow.
+KNOWN_CAPABILITIES = frozenset(
+    {PUSH_NOTIFICATIONS, ASSOCIATED_DOMAINS, APP_ATTEST, APPLE_ID_AUTH}
+)
+
+# The portal click-path, printed with an "absent" verdict so the output is
+# actionable by the person who has to act on it rather than only by CI.
+PORTAL_PATH = (
+    "Apple Developer portal -> Certificates, Identifiers & Profiles -> "
+    "Identifiers -> {bundle_id} -> tick the capability -> Save"
+)
+
+
+def _redact(text: str) -> str:
+    """Strip anything credential-shaped out of text bound for stdout.
+
+    This tool prints Apple's own error bodies, and an HTTP failure raised from
+    a request that carried an `Authorization: Bearer <assertion>` header is
+    exactly where a signed JWT ends up in a public CI log. Same anti-leak
+    sentinel as `slack_notify.sh` and `rules_drift.py`, and asserted by a test
+    that plants a fake secret in an error message.
+    """
+    text = re.sub(r"[Bb]earer\s+\S+", "[redacted-credential]", text)
+    # A bare JWT with no `Bearer` in front of it (a body that echoes the token).
+    text = re.sub(r"eyJ[A-Za-z0-9_\-]{8,}(?:\.[A-Za-z0-9_\-]+){1,2}", "[redacted-jwt]", text)
+    return text
+
+
+@dataclasses.dataclass(frozen=True)
+class Report:
+    """One measurement. `exit_code` is the taxonomy; the lists are the evidence."""
+
+    exit_code: int
+    bundle_id: str
+    #: Every capabilityType the portal reports as ticked, sorted. Empty on a
+    #: could-not-measure, where it means "unknown", NOT "none".
+    enabled: list[str]
+    #: The requested capabilities that ARE ticked, in the order requested.
+    present: list[str]
+    #: The requested capabilities that are NOT ticked, in the order requested.
+    #: ALWAYS empty on a could-not-measure — that is the invariant this whole
+    #: file exists to hold.
+    absent: list[str]
+    #: Why, in one human sentence. Redacted.
+    reason: str
+
+    @property
+    def measured(self) -> bool:
+        return self.exit_code != EXIT_CANNOT_MEASURE
+
+
+def _cannot_measure(bundle_id: str, reason: str) -> Report:
+    return Report(
+        exit_code=EXIT_CANNOT_MEASURE,
+        bundle_id=bundle_id,
+        enabled=[],
+        present=[],
+        absent=[],  # never populated here, by construction
+        reason=_redact(reason),
+    )
+
+
+def find_bundle_id(call, identifier: str) -> str:
+    """The App Store Connect primary key for `identifier`.
+
+    Raises AscError when the key cannot see it — which the caller turns into
+    exit 2, not into an absence: a bundle id this credential cannot resolve
+    means the wrong App ID was read (or none was), never that the right one has
+    no capabilities.
+    """
+    query = urllib.parse.urlencode({"filter[identifier]": identifier, "limit": 200})
+    payload = call("GET", f"/v1/bundleIds?{query}")
+    entries = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(entries, list):
+        raise AscError(f"unexpected /v1/bundleIds response shape for {identifier}")
+    # filter[identifier] is a PREFIX-ish filter on Apple's side for some
+    # resources, so match the attribute exactly rather than taking entries[0].
+    # Taking the first row would happily return `com.beyondkaira.hayati.dev`.
+    for entry in entries:
+        attributes = entry.get("attributes") if isinstance(entry, dict) else None
+        if isinstance(attributes, dict) and attributes.get("identifier") == identifier:
+            key = entry.get("id")
+            if not isinstance(key, str) or not key:
+                raise AscError(f"bundle id {identifier} resolved to an entry with no id")
+            return key
+    raise AscError(
+        f"no App ID with identifier {identifier} is visible to this API key "
+        f"(the key may lack Certificates/Identifiers permission, or the App ID "
+        f"may live in another team)"
+    )
+
+
+def list_capabilities(call, bundle_key: str) -> list[str]:
+    """Every capabilityType ticked on the App ID, sorted.
+
+    Fails CLOSED on a paginated response: holding page one only means the
+    enabled set is PARTIAL, and a partial set can produce a false absence.
+    """
+    query = urllib.parse.urlencode({"limit": 200})
+    payload = call("GET", f"/v1/bundleIds/{bundle_key}/bundleIdCapabilities?{query}")
+    if not isinstance(payload, dict):
+        raise AscError("unexpected bundleIdCapabilities response shape (not an object)")
+    entries = payload.get("data")
+    if not isinstance(entries, list):
+        raise AscError("unexpected bundleIdCapabilities response shape ('data' is not a list)")
+
+    links = payload.get("links")
+    if isinstance(links, dict) and links.get("next"):
+        raise AscError(
+            "bundleIdCapabilities returned a paginated response and this read is "
+            "PARTIAL; a partial capability list can only produce a false absence"
+        )
+
+    capabilities: list[str] = []
+    for entry in entries:
+        attributes = entry.get("attributes") if isinstance(entry, dict) else None
+        capability = attributes.get("capabilityType") if isinstance(attributes, dict) else None
+        if not isinstance(capability, str) or not capability:
+            raise AscError(
+                "a bundleIdCapabilities entry carries no capabilityType; the "
+                "enabled set cannot be established from this response"
+            )
+        capabilities.append(capability)
+    return sorted(set(capabilities))
+
+
+def probe(call, bundle_id: str, required: list[str]) -> Report:
+    """Measure `bundle_id`'s capabilities and judge them against `required`."""
+    unknown = [name for name in required if name not in KNOWN_CAPABILITIES]
+    if unknown:
+        # Refused rather than reported absent: a capability name Apple has never
+        # heard of comes back absent every single time, which is a false blocker
+        # wearing a measurement's clothes.
+        return _cannot_measure(
+            bundle_id,
+            "not a capability name this tool knows: "
+            + ", ".join(unknown)
+            + ". Known: "
+            + ", ".join(sorted(KNOWN_CAPABILITIES)),
+        )
+
+    try:
+        bundle_key = find_bundle_id(call, bundle_id)
+        enabled = list_capabilities(call, bundle_key)
+    except AscError as failure:
+        message = str(failure)
+        hint = ""
+        if "403" in message or "FORBIDDEN" in message.upper():
+            hint = (
+                " -- a 403 here is almost always the API key's permission/role: "
+                "reading Certificates, Identifiers & Profiles needs an Admin or "
+                "App Manager key. This is NOT evidence about the capability."
+            )
+        elif "401" in message:
+            hint = " -- the assertion was rejected; check the key id / issuer id."
+        return _cannot_measure(bundle_id, message + hint)
+    except Exception as failure:  # noqa: BLE001 - any surprise is still "could not look"
+        return _cannot_measure(bundle_id, f"unexpected failure reading the portal: {failure}")
+
+    enabled_set = set(enabled)
+    present = [name for name in required if name in enabled_set]
+    absent = [name for name in required if name not in enabled_set]
+    return Report(
+        exit_code=EXIT_ABSENT if absent else EXIT_OK,
+        bundle_id=bundle_id,
+        enabled=enabled,
+        present=present,
+        absent=absent,
+        reason=(
+            "every requested capability is ticked"
+            if not absent
+            else "absent from the portal's capability list: " + ", ".join(absent)
+        ),
+    )
+
+
+def probe_or_explain(call, bundle_id: str, required: list[str]) -> Report:
+    """`probe`, but a missing transport (i.e. a missing credential) is exit 2.
+
+    The CI-without-secrets case. It is the same fact as a 403 — nobody looked —
+    and it must not read as an absence either.
+    """
+    if call is None:
+        return _cannot_measure(
+            bundle_id,
+            "no App Store Connect credential is available, so the portal was "
+            "never read (see docs/operator-expected.md)",
+        )
+    return probe(call, bundle_id, required)
+
+
+def render(report: Report) -> None:
+    """Print the measurement. Written to be read by the FOUNDER, not only by CI."""
+    print(f"App ID: {report.bundle_id}")
+
+    if not report.measured:
+        # Deliberate wording. A human skimming the log of a 403 run must not come
+        # away believing anything about the capability itself.
+        print("\nCOULD NOT MEASURE (exit 2) — nothing below is evidence about the portal.")
+        print(f"  reason: {report.reason}")
+        print("\nThis is NOT a finding. Nobody looked; the capabilities are unknown.")
+        return
+
+    print("\ncapabilities ticked on this App ID (the portal's own list):")
+    if report.enabled:
+        for capability in report.enabled:
+            print(f"  - {capability}")
+    else:
+        print("  (none)")
+
+    if report.present:
+        print("\nrequested AND ticked:")
+        for capability in report.present:
+            print(f"  ok      {capability}")
+
+    if report.absent:
+        print("\nrequested and ABSENT from that list:")
+        for capability in report.absent:
+            print(f"  MISSING {capability}")
+        print("\nto fix, one visit, one tick each:")
+        print("  " + PORTAL_PATH.format(bundle_id=report.bundle_id))
+        print(
+            "\nUntil a capability is ticked, an entitlement claiming it cannot be "
+            "signed: `match` fetches provisioning profiles READONLY (ADR-032), so "
+            "CI cannot add it, and the build fails at codesign (ADR-040)."
+        )
+    else:
+        print("\nevery requested capability is ticked.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Read the capabilities ticked on an App ID (read-only).",
+    )
+    parser.add_argument("--bundle-id", required=True, help="e.g. com.beyondkaira.hayati")
+    parser.add_argument(
+        "--require",
+        action="append",
+        default=[],
+        dest="required",
+        metavar="CAPABILITY",
+        help=(
+            "Capability that must be ticked; repeatable. Absent -> exit 1. "
+            "Omit entirely for a plain read-out. Known: "
+            + ", ".join(sorted(KNOWN_CAPABILITIES))
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    call = None
+    try:
+        token = _tft._token()
+
+        def call(method: str, path: str) -> dict:  # noqa: F811 - the real transport
+            return _tft._call(token, method, path)
+
+    except AscError as failure:
+        # A missing/partial credential set is exit 2 with the NAMES it is missing
+        # (never the values) — testflight_testers._token already phrases it that
+        # way, so the message is reused rather than restated.
+        report = _cannot_measure(args.bundle_id, str(failure))
+        render(report)
+        return report.exit_code
+
+    report = probe_or_explain(call, args.bundle_id, args.required)
+    render(report)
+    return report.exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tool/ci/appid_capabilities_test.py
+++ b/tool/ci/appid_capabilities_test.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""Self-tests for tool/ci/appid_capabilities.py (repo convention: every tool
+under tool/ carries one, run by ci.yml's quality job).
+
+Hermetic: no network, no Apple, no credential. Every test drives either a pure
+function or an injected fake transport.
+
+WHAT THESE TESTS ARE ACTUALLY DEFENDING. This tool exists to answer a question
+that has been sitting in `operator-expected.md` as "nobody can read the portal
+from a laptop" for months: is a capability ticked on the App ID? The whole
+value of the answer is that it is TRUSTWORTHY, and there is exactly one way for
+it to be worthless — reporting "not enabled" when what really happened is "this
+API key is not allowed to look". Apple answers that case with an HTTP 403, and
+a 403 that maps to exit 1 would hand the founder a measured-sounding lie and
+send a session off to build around a blocker that may not exist.
+
+So the mutation-relevant assertions here are the ones that pin the 0/1/2
+TAXONOMY (ADR-041's, restated), not the ones that prove the happy path:
+
+  * test_forbidden_is_cannot_measure_not_absent   <- the one that matters most
+  * test_unauthorized_is_cannot_measure
+  * test_missing_credentials_is_cannot_measure
+  * test_unknown_bundle_id_is_cannot_measure
+  * test_unexpected_shape_is_cannot_measure
+  * test_paginated_response_fails_closed
+
+Every one of those would pass if `evaluate` returned 2 unconditionally, which
+is why the two directional tests exist alongside them
+(`test_all_required_present_exits_zero` / `test_missing_required_exits_one`):
+together they pin the guard in BOTH directions, which is the standing rule.
+
+`test_bearer_token_is_never_printed` is the anti-leak sentinel, same shape as
+rules_drift_test.py's and slack_notify_test.sh's: a tool that mints a signed
+JWT and prints a report about a security artifact is exactly where a credential
+ends up in a public CI log.
+
+Run: python3 tool/ci/appid_capabilities_test.py
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import pathlib
+import sys
+
+_MODULE_PATH = pathlib.Path(__file__).with_name("appid_capabilities.py")
+_spec = importlib.util.spec_from_file_location("appid_capabilities", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+ac = importlib.util.module_from_spec(_spec)
+# Registered BEFORE exec: the module defines a @dataclass under `from __future__
+# import annotations`, and dataclasses resolves those string annotations through
+# sys.modules[cls.__module__]. A module loaded by path and never registered
+# resolves to None there and the class body raises at import.
+sys.modules["appid_capabilities"] = ac
+_spec.loader.exec_module(ac)
+
+_failures: list[str] = []
+
+
+def check(label: str, actual: object, expected: object) -> None:
+    if actual == expected:
+        print(f"  ok   {label}")
+    else:
+        print(f"  FAIL {label}\n         expected: {expected!r}\n         actual:   {actual!r}")
+        _failures.append(label)
+
+
+def check_in(label: str, needle: str, haystack: str) -> None:
+    if needle.lower() in haystack.lower():
+        print(f"  ok   {label}")
+    else:
+        print(f"  FAIL {label}\n         wanted {needle!r} in: {haystack[:400]!r}")
+        _failures.append(label)
+
+
+def check_not_in(label: str, needle: str, haystack: str) -> None:
+    if needle.lower() not in haystack.lower():
+        print(f"  ok   {label}")
+    else:
+        print(f"  FAIL {label}\n         {needle!r} LEAKED into: {haystack[:400]!r}")
+        _failures.append(label)
+
+
+# --------------------------------------------------------------------------
+# fakes
+
+
+BUNDLE_PK = "ABCDE12345"
+
+
+def fake_transport(pages: dict[str, object]):
+    """A transport over a canned {path_prefix: response} map.
+
+    Matching is by prefix so a test does not have to reproduce Apple's exact
+    query-string ordering, which is an implementation detail of urlencode.
+    """
+
+    def call(method: str, path: str) -> dict:
+        for prefix, response in pages.items():
+            if path.startswith(prefix):
+                if isinstance(response, Exception):
+                    raise response
+                return response
+        raise AssertionError(f"fake transport has no canned response for {method} {path}")
+
+    return call
+
+
+def bundle_page(identifier: str = "com.beyondkaira.hayati") -> dict:
+    return {"data": [{"id": BUNDLE_PK, "attributes": {"identifier": identifier, "name": "ikimiz"}}]}
+
+
+def caps_page(types: list[str], next_link: str | None = None) -> dict:
+    page: dict = {
+        "data": [
+            {"id": f"{BUNDLE_PK}_{t}", "attributes": {"capabilityType": t, "settings": []}}
+            for t in types
+        ]
+    }
+    if next_link is not None:
+        page["links"] = {"next": next_link}
+    return page
+
+
+# --------------------------------------------------------------------------
+# the taxonomy: 0 measured+present, 1 measured+absent, 2 could not measure
+
+
+def test_all_required_present_exits_zero() -> None:
+    call = fake_transport(
+        {
+            "/v1/bundleIds?": bundle_page(),
+            f"/v1/bundleIds/{BUNDLE_PK}/bundleIdCapabilities": caps_page(
+                ["PUSH_NOTIFICATIONS", "ASSOCIATED_DOMAINS", "APPLE_ID_AUTH"]
+            ),
+        }
+    )
+    report = ac.probe(call, "com.beyondkaira.hayati", ["PUSH_NOTIFICATIONS"])
+    check("all required present -> exit 0", report.exit_code, ac.EXIT_OK)
+    check("present list is reported", report.present, ["PUSH_NOTIFICATIONS"])
+    check("absent list is empty", report.absent, [])
+
+
+def test_missing_required_exits_one() -> None:
+    call = fake_transport(
+        {
+            "/v1/bundleIds?": bundle_page(),
+            f"/v1/bundleIds/{BUNDLE_PK}/bundleIdCapabilities": caps_page(["APPLE_ID_AUTH"]),
+        }
+    )
+    report = ac.probe(call, "com.beyondkaira.hayati", ["PUSH_NOTIFICATIONS", "ASSOCIATED_DOMAINS"])
+    check("a required capability absent -> exit 1", report.exit_code, ac.EXIT_ABSENT)
+    check(
+        "both absent capabilities are named",
+        report.absent,
+        ["PUSH_NOTIFICATIONS", "ASSOCIATED_DOMAINS"],
+    )
+    check("the enabled set is still reported", report.enabled, ["APPLE_ID_AUTH"])
+
+
+def test_partial_presence_exits_one_and_separates_the_two() -> None:
+    """The founder is asked for three ticks in one portal visit; a report that
+    collapsed 'two of three' into a single verdict would send them back twice."""
+    call = fake_transport(
+        {
+            "/v1/bundleIds?": bundle_page(),
+            f"/v1/bundleIds/{BUNDLE_PK}/bundleIdCapabilities": caps_page(
+                ["PUSH_NOTIFICATIONS", "APPLE_ID_AUTH"]
+            ),
+        }
+    )
+    report = ac.probe(
+        call, "com.beyondkaira.hayati", ["PUSH_NOTIFICATIONS", "ASSOCIATED_DOMAINS", "APP_ATTEST"]
+    )
+    check("partial presence -> exit 1", report.exit_code, ac.EXIT_ABSENT)
+    check("the ticked one is in present", report.present, ["PUSH_NOTIFICATIONS"])
+    check(
+        "the two unticked ones are in absent",
+        report.absent,
+        ["ASSOCIATED_DOMAINS", "APP_ATTEST"],
+    )
+
+
+def test_no_requirements_reports_and_exits_zero() -> None:
+    """--require is optional: with none given the tool is a pure read-out and
+    must not invent a finding."""
+    call = fake_transport(
+        {
+            "/v1/bundleIds?": bundle_page(),
+            f"/v1/bundleIds/{BUNDLE_PK}/bundleIdCapabilities": caps_page(["APPLE_ID_AUTH"]),
+        }
+    )
+    report = ac.probe(call, "com.beyondkaira.hayati", [])
+    check("read-out with no requirements -> exit 0", report.exit_code, ac.EXIT_OK)
+    check("the enabled set is still reported", report.enabled, ["APPLE_ID_AUTH"])
+
+
+# --------------------------------------------------------------------------
+# THE tests: every "I could not look" is 2, never 1
+
+
+def test_forbidden_is_cannot_measure_not_absent() -> None:
+    """An App Store Connect key carries a ROLE. If it is not permitted to read
+    Certificates, Identifiers & Profiles, Apple answers 403 — and mapping that
+    to 'the capability is not enabled' is the single failure that would make
+    this whole tool worse than not having it."""
+    call = fake_transport({"/v1/bundleIds?": ac.AscError("GET /v1/bundleIds -> HTTP 403: FORBIDDEN")})
+    report = ac.probe(call, "com.beyondkaira.hayati", ["PUSH_NOTIFICATIONS"])
+    check("403 -> exit 2, NOT exit 1", report.exit_code, ac.EXIT_CANNOT_MEASURE)
+    check("403 is not reported as absent", report.absent, [])
+    check_in("the reason names the key's permissions", "permission", report.reason)
+
+
+def test_unauthorized_is_cannot_measure() -> None:
+    call = fake_transport({"/v1/bundleIds?": ac.AscError("GET /v1/bundleIds -> HTTP 401: NOT_AUTHORIZED")})
+    report = ac.probe(call, "com.beyondkaira.hayati", ["PUSH_NOTIFICATIONS"])
+    check("401 -> exit 2", report.exit_code, ac.EXIT_CANNOT_MEASURE)
+    check("401 is not reported as absent", report.absent, [])
+
+
+def test_unknown_bundle_id_is_cannot_measure() -> None:
+    """A bundle id this key cannot see is 'I could not look at the right App
+    ID', not 'that App ID has no capabilities'."""
+    call = fake_transport({"/v1/bundleIds?": {"data": []}})
+    report = ac.probe(call, "com.beyondkaira.hayati", ["PUSH_NOTIFICATIONS"])
+    check("no such bundle id -> exit 2", report.exit_code, ac.EXIT_CANNOT_MEASURE)
+    check("no such bundle id is not reported as absent", report.absent, [])
+    check_in("the reason names the bundle id", "com.beyondkaira.hayati", report.reason)
+
+
+def test_a_near_miss_bundle_id_is_never_accepted() -> None:
+    """Apple's filter[identifier] is not guaranteed to be an exact match, and a
+    team that also owns `com.beyondkaira.hayati.dev` would get that row back.
+    Reading the WRONG App ID's capabilities is the worst outcome available here:
+    it produces a confident, measured, completely inapplicable answer.
+
+    Added because the mutation harness proved this was unasserted — replacing
+    the identifier comparison with `if True:` reddened nothing.
+    """
+    call = fake_transport(
+        {
+            "/v1/bundleIds?": {
+                "data": [
+                    # deliberately FIRST, so entries[0] is the wrong one
+                    {"id": "WRONGPK", "attributes": {"identifier": "com.beyondkaira.hayati.dev"}},
+                    {"id": BUNDLE_PK, "attributes": {"identifier": "com.beyondkaira.hayati"}},
+                ]
+            },
+            "/v1/bundleIds/WRONGPK/bundleIdCapabilities": caps_page(["PUSH_NOTIFICATIONS"]),
+            f"/v1/bundleIds/{BUNDLE_PK}/bundleIdCapabilities": caps_page(["APPLE_ID_AUTH"]),
+        }
+    )
+    report = ac.probe(call, "com.beyondkaira.hayati", ["PUSH_NOTIFICATIONS"])
+    check("the exactly-matching App ID is the one read", report.enabled, ["APPLE_ID_AUTH"])
+    check("so the verdict is the real one -> exit 1", report.exit_code, ac.EXIT_ABSENT)
+
+
+def test_only_a_near_miss_present_is_cannot_measure() -> None:
+    """If the exact identifier is not in the response at all, the answer is 'I
+    could not find the App ID', never 'that App ID has no capabilities'."""
+    call = fake_transport(
+        {
+            "/v1/bundleIds?": {
+                "data": [{"id": "WRONGPK", "attributes": {"identifier": "com.beyondkaira.hayati.dev"}}]
+            },
+            "/v1/bundleIds/WRONGPK/bundleIdCapabilities": caps_page(["PUSH_NOTIFICATIONS"]),
+        }
+    )
+    report = ac.probe(call, "com.beyondkaira.hayati", ["PUSH_NOTIFICATIONS"])
+    check("only a near-miss row -> exit 2", report.exit_code, ac.EXIT_CANNOT_MEASURE)
+    check("a near-miss row is never reported as absence", report.absent, [])
+
+
+def test_capability_call_failure_is_cannot_measure() -> None:
+    """The bundle id resolves and the SECOND call dies: still 'could not look'."""
+    call = fake_transport(
+        {
+            "/v1/bundleIds?": bundle_page(),
+            f"/v1/bundleIds/{BUNDLE_PK}/bundleIdCapabilities": ac.AscError(
+                "GET /v1/bundleIds/X/bundleIdCapabilities -> HTTP 403: FORBIDDEN"
+            ),
+        }
+    )
+    report = ac.probe(call, "com.beyondkaira.hayati", ["PUSH_NOTIFICATIONS"])
+    check("capability read failure -> exit 2", report.exit_code, ac.EXIT_CANNOT_MEASURE)
+    check("capability read failure is not absence", report.absent, [])
+
+
+def test_unexpected_shape_is_cannot_measure() -> None:
+    """Apple changing the response shape must not silently read as 'nothing is
+    enabled' — only the vendor can refute a vendor API shape, so an unparseable
+    body is a measurement failure."""
+    call = fake_transport(
+        {
+            "/v1/bundleIds?": bundle_page(),
+            f"/v1/bundleIds/{BUNDLE_PK}/bundleIdCapabilities": {"data": "not-a-list"},
+        }
+    )
+    report = ac.probe(call, "com.beyondkaira.hayati", ["PUSH_NOTIFICATIONS"])
+    check("unparseable capability payload -> exit 2", report.exit_code, ac.EXIT_CANNOT_MEASURE)
+    check("unparseable payload is not absence", report.absent, [])
+
+
+def test_capability_entry_without_a_type_is_cannot_measure() -> None:
+    call = fake_transport(
+        {
+            "/v1/bundleIds?": bundle_page(),
+            f"/v1/bundleIds/{BUNDLE_PK}/bundleIdCapabilities": {
+                "data": [{"id": "x", "attributes": {"settings": []}}]
+            },
+        }
+    )
+    report = ac.probe(call, "com.beyondkaira.hayati", ["PUSH_NOTIFICATIONS"])
+    check("capability entry with no capabilityType -> exit 2", report.exit_code, ac.EXIT_CANNOT_MEASURE)
+
+
+def test_paginated_response_fails_closed() -> None:
+    """A second page this tool did not follow means the enabled set it holds is
+    PARTIAL, and a partial set can only produce a false 'absent'. Same shape as
+    rules_drift.py failing closed on a second firestore release."""
+    call = fake_transport(
+        {
+            "/v1/bundleIds?": bundle_page(),
+            f"/v1/bundleIds/{BUNDLE_PK}/bundleIdCapabilities": caps_page(
+                ["APPLE_ID_AUTH"], next_link="https://api.appstoreconnect.apple.com/v1/...&cursor=2"
+            ),
+        }
+    )
+    report = ac.probe(call, "com.beyondkaira.hayati", ["PUSH_NOTIFICATIONS"])
+    check("an unfollowed next page -> exit 2", report.exit_code, ac.EXIT_CANNOT_MEASURE)
+    check("a partial page is never reported as absence", report.absent, [])
+    check_in("the reason says the read was partial", "partial", report.reason)
+
+
+def test_missing_credentials_is_cannot_measure() -> None:
+    """No credential is the CI-without-secrets case. It must be 2 and it must
+    name the missing variables, never their values (the release lane's rule)."""
+    report = ac.probe_or_explain(None, "com.beyondkaira.hayati", ["PUSH_NOTIFICATIONS"])
+    check("no transport/credential -> exit 2", report.exit_code, ac.EXIT_CANNOT_MEASURE)
+    check("no credential is not absence", report.absent, [])
+
+
+# --------------------------------------------------------------------------
+# reporting
+
+
+def test_report_prints_the_full_enabled_set_even_when_it_passes() -> None:
+    """One portal visit answers three questions (4(a) Push, 2(d) Associated
+    Domains, App Attest). The read-out must print everything it saw, not only
+    the verdict on what was asked."""
+    call = fake_transport(
+        {
+            "/v1/bundleIds?": bundle_page(),
+            f"/v1/bundleIds/{BUNDLE_PK}/bundleIdCapabilities": caps_page(
+                ["PUSH_NOTIFICATIONS", "APPLE_ID_AUTH", "IN_APP_PURCHASE"]
+            ),
+        }
+    )
+    report = ac.probe(call, "com.beyondkaira.hayati", ["PUSH_NOTIFICATIONS"])
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        ac.render(report)
+    printed = buffer.getvalue()
+    check_in("prints APPLE_ID_AUTH it was never asked about", "APPLE_ID_AUTH", printed)
+    check_in("prints IN_APP_PURCHASE it was never asked about", "IN_APP_PURCHASE", printed)
+    check_in("prints the bundle id", "com.beyondkaira.hayati", printed)
+
+
+def test_absent_report_names_the_portal_path() -> None:
+    """The output is read by the founder, not only by CI: an 'absent' verdict
+    must carry the click-path that fixes it."""
+    call = fake_transport(
+        {
+            "/v1/bundleIds?": bundle_page(),
+            f"/v1/bundleIds/{BUNDLE_PK}/bundleIdCapabilities": caps_page(["APPLE_ID_AUTH"]),
+        }
+    )
+    report = ac.probe(call, "com.beyondkaira.hayati", ["PUSH_NOTIFICATIONS"])
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        ac.render(report)
+    printed = buffer.getvalue()
+    check_in("names Identifiers", "identifiers", printed)
+    check_in("names the missing capability", "PUSH_NOTIFICATIONS", printed)
+
+
+def test_cannot_measure_report_never_says_not_enabled() -> None:
+    """Prose matters as much as the exit code here: a human reading the log of
+    a 403 run must not come away believing the capability is off."""
+    call = fake_transport({"/v1/bundleIds?": ac.AscError("GET /v1/bundleIds -> HTTP 403: FORBIDDEN")})
+    report = ac.probe(call, "com.beyondkaira.hayati", ["PUSH_NOTIFICATIONS"])
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        ac.render(report)
+    printed = buffer.getvalue()
+    check_in("says it could not measure", "could not measure", printed)
+    check_not_in("never claims the capability is not enabled", "is not enabled", printed)
+
+
+def test_bearer_token_is_never_printed() -> None:
+    """The anti-leak sentinel. The report is designed to be pasted into an
+    issue and read by the founder; a signed JWT must never ride along."""
+    secret = "eyJhbGciOiJFUzI1NiJ9.THIS-IS-THE-SECRET.signature"
+    call = fake_transport(
+        {
+            "/v1/bundleIds?": ac.AscError(
+                f"GET /v1/bundleIds -> HTTP 403: FORBIDDEN (Authorization: Bearer {secret})"
+            )
+        }
+    )
+    report = ac.probe(call, "com.beyondkaira.hayati", ["PUSH_NOTIFICATIONS"])
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        ac.render(report)
+    printed = buffer.getvalue()
+    check_not_in("the JWT body never reaches stdout", "THIS-IS-THE-SECRET", printed)
+    check_not_in("no 'Bearer ' prefix reaches stdout", "bearer ", printed)
+
+
+# --------------------------------------------------------------------------
+# the capability vocabulary is asserted, not assumed
+
+
+def test_known_capability_names_are_apple_s_own_spelling() -> None:
+    """These three strings are the whole contract with Apple. A typo turns a
+    real tick into a reported absence, which is the false-blocker this tool
+    exists to prevent — so they are pinned by a test rather than trusted to a
+    careful moment."""
+    check("push", ac.PUSH_NOTIFICATIONS, "PUSH_NOTIFICATIONS")
+    check("associated domains", ac.ASSOCIATED_DOMAINS, "ASSOCIATED_DOMAINS")
+    check("app attest", ac.APP_ATTEST, "APP_ATTEST")
+
+
+def test_requirements_are_validated_against_the_known_vocabulary() -> None:
+    """A --require value Apple has never heard of can only ever report absent,
+    which is a false blocker dressed as a measurement. Refuse it instead."""
+    call = fake_transport(
+        {
+            "/v1/bundleIds?": bundle_page(),
+            f"/v1/bundleIds/{BUNDLE_PK}/bundleIdCapabilities": caps_page(["PUSH_NOTIFICATIONS"]),
+        }
+    )
+    report = ac.probe(call, "com.beyondkaira.hayati", ["PUSH_NOTIFICATION"])  # missing S
+    check("an unknown --require value -> exit 2", report.exit_code, ac.EXIT_CANNOT_MEASURE)
+    check("an unknown --require value is not absence", report.absent, [])
+    check_in("the reason names the typo", "PUSH_NOTIFICATION", report.reason)
+
+
+# --------------------------------------------------------------------------
+
+TESTS = [value for name, value in sorted(globals().items()) if name.startswith("test_")]
+
+if __name__ == "__main__":
+    print(f"appid_capabilities self-tests ({len(TESTS)} cases)\n")
+    for test in TESTS:
+        print(f"{test.__name__}:")
+        test()
+    print()
+    if _failures:
+        print(f"FAILED ({len(_failures)}): " + ", ".join(_failures))
+        raise SystemExit(1)
+    print("all green")


### PR DESCRIPTION
## The non-answer this deletes

`docs/operator-expected.md` has carried the same sentence for months — *"a session cannot read the portal, so nobody knows"* — against three questions that all gate real work:

| Item | Question | What it blocks |
|---|---|---|
| **4(a)** | Is **Push Notifications** ticked? | **The entire notification objective.** The entitlement must exist in the provisioning profile too; `match` fetches profiles readonly (ADR-032), so a build claiming `aps-environment` without the capability **fails at codesign** |
| **2(d)** | Is **Associated Domains** ticked? | ADR-040 removed that entitlement and cost a release finding out |
| — | Is **App Attest** in the list? | Prod App Check attestation cannot succeed without it (ADR-039); it hard-breaks the day enforcement is switched on |

None of the three was ever unanswerable. The portal's capability list is readable over the App Store Connect API with the **same credential the release lane and `testflight-testers.yml` already hold**. "Ask the founder to look" was a missing tool, not a missing permission. One dispatch answers all three, repeatably.

## Exit codes are a taxonomy, not a boolean

ADR-041's, restated:

```
0  MEASURED, every --require capability is ticked
1  MEASURED, at least one is absent — the finding, a founder action
2  COULD NOT MEASURE — never 0, and never 1
```

**The 1-versus-2 distinction is the entire point.** An App Store Connect key carries a **role**. If it is not permitted to read Certificates, Identifiers & Profiles, Apple answers **403** — and collapsing that into *"the capability is not ticked"* would hand the founder a measured-sounding lie and send a session off to build around a blocker that may not exist.

The same applies to a bundle id the key cannot see, an unexpected response shape, and a **paginated** capability list: holding page one only means the enabled set is partial, and a partial set can only ever produce a **false absence** — so an unfollowed `next` link fails closed, exactly as `rules_drift.py` does on a second firestore release.

The job reddens on **both** 1 and 2, with different `::error::` text. Exit 2 is never quietly green — that is the failure mode ADR-041 and the rules-drift preflight were built against.

## Read-only by construction

There is no code path that can tick a capability. Enabling one changes how a real binary signs — a founder decision, and a lane that *could* do it would also be a lane that could do it by accident.

## Mutation-checked, and it found a real hole

Four mutations against the 46 self-test assertions:

| Mutation | Named checks that reddened |
|---|---|
| `_cannot_measure` returns `EXIT_ABSENT` | **10** — every `-> exit 2` assertion plus `says it could not measure` |
| drop the pagination fail-closed | 3 |
| `_redact` becomes the identity function | 2 — the JWT anti-leak sentinel |
| `find_bundle_id` takes `entries[0]` | **0 — vacuous** |

The fourth reddened **nothing**. The exact-identifier match was unasserted, so a team that also owns `com.beyondkaira.hayati.dev` would have had the **wrong App ID's** capabilities read back as a confident answer. Two tests were added (`test_a_near_miss_bundle_id_is_never_accepted`, `test_only_a_near_miss_present_is_cannot_measure`); the same mutation now reddens **3** named checks, and the mutation site is unique (`grep -c` = 1).

## Notes

- The credential gate is **imported** from `testflight_testers`, never re-implemented: a second copy of the three-secret ES256 path is a second thing that can drift, and drift in a credential gate fails in the reassuring direction.
- `--require` values are validated against a closed vocabulary. An unknown name can only ever come back absent, which is a false blocker wearing a measurement's clothes — so it is refused (exit 2) rather than reported.
- `workflow_dispatch` only resolves from the default branch, so this has to land before it can answer anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)