### PR TITLE
fix(ci): Apple refuses `limit` on the bundleIdCapabilities relationship — the first live run said so

### DIFF
--- a/tool/ci/appid_capabilities.py
+++ b/tool/ci/appid_capabilities.py
@@ -195,11 +195,24 @@ def find_bundle_id(call, identifier: str) -> str:
 def list_capabilities(call, bundle_key: str) -> list[str]:
     """Every capabilityType ticked on the App ID, sorted.
 
+    NO QUERY PARAMETERS, and that is Apple's rule rather than a preference. The
+    first live dispatch of this tool sent `?limit=200` and got:
+
+        HTTP 400  PARAMETER_ERROR.ILLEGAL
+        "The parameter 'limit' can not be used with this request :
+         This relationship does not support this parameter."
+
+    Only the vendor can refute a vendor API shape. The `/v1/bundleIds`
+    COLLECTION does accept `filter[...]` and `limit`; this RELATIONSHIP does
+    not, so the fix must not be over-applied to the lookup — a lookup without
+    its filter would fetch every App ID in the team.
+
     Fails CLOSED on a paginated response: holding page one only means the
-    enabled set is PARTIAL, and a partial set can produce a false absence.
+    enabled set is PARTIAL, and a partial set can produce a false absence. That
+    guard matters MORE now that no page size can be requested, since the page
+    size is entirely Apple's to choose.
     """
-    query = urllib.parse.urlencode({"limit": 200})
-    payload = call("GET", f"/v1/bundleIds/{bundle_key}/bundleIdCapabilities?{query}")
+    payload = call("GET", f"/v1/bundleIds/{bundle_key}/bundleIdCapabilities")
     if not isinstance(payload, dict):
         raise AscError("unexpected bundleIdCapabilities response shape (not an object)")
     entries = payload.get("data")

--- a/tool/ci/appid_capabilities_test.py
+++ b/tool/ci/appid_capabilities_test.py
@@ -90,14 +90,18 @@ def check_not_in(label: str, needle: str, haystack: str) -> None:
 BUNDLE_PK = "ABCDE12345"
 
 
-def fake_transport(pages: dict[str, object]):
+def fake_transport(pages: dict[str, object], seen: list[str] | None = None):
     """A transport over a canned {path_prefix: response} map.
 
     Matching is by prefix so a test does not have to reproduce Apple's exact
     query-string ordering, which is an implementation detail of urlencode.
+    `seen` collects every path requested, so a test can assert the MECHANISM
+    (which URL was actually built) and not only the outcome.
     """
 
     def call(method: str, path: str) -> dict:
+        if seen is not None:
+            seen.append(path)
         for prefix, response in pages.items():
             if path.startswith(prefix):
                 if isinstance(response, Exception):
@@ -340,6 +344,68 @@ def test_missing_credentials_is_cannot_measure() -> None:
     report = ac.probe_or_explain(None, "com.beyondkaira.hayati", ["PUSH_NOTIFICATIONS"])
     check("no transport/credential -> exit 2", report.exit_code, ac.EXIT_CANNOT_MEASURE)
     check("no credential is not absence", report.absent, [])
+
+
+# --------------------------------------------------------------------------
+# the request Apple actually accepts
+
+
+def test_capabilities_request_carries_no_query_parameters() -> None:
+    """Apple REFUSES `limit` on this relationship, and only Apple could have
+    told us that.
+
+    The first live dispatch of this tool returned:
+
+        GET /v1/bundleIds/Q344R7M7MY/bundleIdCapabilities?limit=200 -> HTTP 400
+        "code" : "PARAMETER_ERROR.ILLEGAL"
+        "detail" : "The parameter 'limit' can not be used with this request :
+                    This relationship does not support this parameter."
+
+    The prefix-matching fakes were blind to it: every canned response matched
+    with or without the query string, so the outcome assertions all passed while
+    the real request was rejected. That is the shape of a test satisfied three
+    layers from the property it names — so this one asserts the MECHANISM, the
+    exact path built, which no amount of luck can satisfy.
+
+    (The tool behaved correctly under the failure: it reported exit 2, COULD NOT
+    MEASURE, rather than inventing an absence. The bug was the request, not the
+    taxonomy.)
+    """
+    seen: list[str] = []
+    call = fake_transport(
+        {
+            "/v1/bundleIds?": bundle_page(),
+            f"/v1/bundleIds/{BUNDLE_PK}/bundleIdCapabilities": caps_page(["PUSH_NOTIFICATIONS"]),
+        },
+        seen=seen,
+    )
+    ac.probe(call, "com.beyondkaira.hayati", ["PUSH_NOTIFICATIONS"])
+    caps_requests = [p for p in seen if "bundleIdCapabilities" in p]
+    check("exactly one capabilities request", len(caps_requests), 1)
+    check(
+        "and it carries NO query string at all",
+        caps_requests[0],
+        f"/v1/bundleIds/{BUNDLE_PK}/bundleIdCapabilities",
+    )
+
+
+def test_the_bundle_id_lookup_still_filters_server_side() -> None:
+    """The /v1/bundleIds COLLECTION does accept filter+limit — only the
+    capabilities RELATIONSHIP refuses them. Pinned so the fix for one is not
+    over-applied to the other, which would make the lookup fetch every App ID in
+    the team and match client-side."""
+    seen: list[str] = []
+    call = fake_transport(
+        {
+            "/v1/bundleIds?": bundle_page(),
+            f"/v1/bundleIds/{BUNDLE_PK}/bundleIdCapabilities": caps_page(["PUSH_NOTIFICATIONS"]),
+        },
+        seen=seen,
+    )
+    ac.probe(call, "com.beyondkaira.hayati", ["PUSH_NOTIFICATIONS"])
+    lookup = [p for p in seen if p.startswith("/v1/bundleIds?")][0]
+    check_in("the lookup filters by identifier", "filter%5Bidentifier%5D", lookup)
+    check_in("the lookup carries the identifier value", "com.beyondkaira.hayati", lookup)
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
The probe's first live dispatch ([run 31053135662](https://github.com/aytekXR/hayati-mobile-app/actions/runs/31053135662)) resolved the App ID fine — `com.beyondkaira.hayati` → `Q344R7M7MY`, so **the credential and the key's role are both good** — and then died on the second call:

```
GET /v1/bundleIds/Q344R7M7MY/bundleIdCapabilities?limit=200 -> HTTP 400
  "code"   : "PARAMETER_ERROR.ILLEGAL"
  "detail" : "The parameter 'limit' can not be used with this request :
              This relationship does not support this parameter."
```

`limit` was copied from the `/v1/bundleIds` **collection** call, where it is legal. On the capabilities **relationship** it is not. Only the vendor can refute a vendor API shape, and it took the vendor to refute this one.

## The taxonomy held under the failure

This is the part worth recording. The tool printed:

```
COULD NOT MEASURE (exit 2) — nothing below is evidence about the portal.
This is NOT a finding. Nobody looked; the capabilities are unknown.
```

A tool that mapped an unexpected HTTP error to *"the capability is absent"* would have reported, **on its very first run**, that Push Notifications is not ticked — a measured-sounding lie about the one fact the entire notification objective is blocked on. The bug was in the request; the 0/1/**2** taxonomy did exactly its job.

## Why the 24 existing assertions did not catch it

The fakes match by path **prefix**, so every canned response matched with or without a query string. 24 outcome assertions passed while the real request was being rejected — a test satisfied three layers from the property it names.

The new test asserts the **mechanism** — the exact path built, collected by the transport — which no amount of luck can satisfy:

```python
check("and it carries NO query string at all", caps_requests[0],
      f"/v1/bundleIds/{BUNDLE_PK}/bundleIdCapabilities")
```

Mutation-checked: re-adding `?limit=200` reddens **exactly that named assertion and nothing else**.

A second test pins the other direction, because the obvious over-fix is to strip query parameters everywhere: `/v1/bundleIds` must keep its `filter[identifier]`, or the lookup fetches every App ID in the team and matches client-side.

The pagination fail-closed guard matters **more** now, not less: with no page size requestable, the page size is entirely Apple's to choose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)