### PR TITLE
feat(push): the daily question at 08:00 and the nudge at 16:00 — ADR-042 D3/D4

### DIFF
--- a/docs/adr/012-reveal-trigger-streak-and-push-policy.md
+++ b/docs/adr/012-reveal-trigger-streak-and-push-policy.md
@@ -1,6 +1,6 @@
 # ADR-012: Reveal trigger design, streak/grace semantics, and push payload policy
 
-- **Status:** Accepted
+- **Status:** Accepted — **AMENDED by [ADR-042](042-push-token-lifecycle-and-the-two-hours-the-founder-asked-for.md) (2026-08-06)**: its D1 discharges the "nothing writes it yet" token deferral below; its D3 adds a **fourth** push kind (`dailyQuestion`) and a third sweep pass at local hour 8; its D4 moves the at-risk push from hour **20** to hour **16** and drops its `streak.count > 0` gate. **The one-couples-read-per-sweep constraint below is NOT amended** and is preserved by construction. Amended passages are marked inline.
 - **Date:** 2026-07-11
 - **Deciders:** Session 014 (per `docs/resume-prompt.md` M3.4 "decide + document" mandates)
 - **Related:** [ADR-011](011-rollover-pack-source-and-scheduling.md) (day-doc shape, hourly sweep, dayKey contract — its metadata-only day-doc posture is **amended** here); [ADR-005](005-couple-scoped-data-model.md); `docs/architecture.md` §3–§4, §10; `docs/prd.md` F3 (streak + mercy day), F6 (discreet mode); `docs/test-suite.md` §1
@@ -145,6 +145,37 @@ APNs/on-device delivery remains operator-expected item 4):
   in the hour-20 bucket only. Best-effort by design (no dedup state; the
   hourly cadence makes double-sends structurally absent, not guarded).
 
+  > **AMENDED by ADR-042 D4 (2026-08-06).** The hour is **16**, not 20, and
+  > **the `streak.count > 0` gate is gone.** This stopped being a streak
+  > feature: the founder asked for *"If you did not reply the question as of
+  > 16.00 you need to be notified so that your partner dont get angry"*,
+  > which protects a **relationship** and must fire for a couple with **no
+  > streak at all** — most couples in week one, and every couple that ever
+  > broke one. Re-pointed rather than duplicated, because the 16:00
+  > population is a strict superset of the 20:00 one and a second afternoon
+  > hour would give a couple with a streak two pushes in one evening, which
+  > the no-dedup-state posture above cannot prevent.
+  >
+  > **The cost claim widened and is restated rather than left to drift.** It
+  > was *"one extra day-doc read per couple, once per day, in the hour-20
+  > bucket, **for couples with a streak**"*. It is now *"one day-doc read
+  > **plus one `getAll` of the two answer docs** per eligible couple, once
+  > per day, in the hour-16 bucket, **unconditionally**"* — eligibility can
+  > no longer be decided from the couple document already in the bucket.
+  > Single-digit reads per day at current scale; recorded because a cost
+  > claim that quietly widened is exactly the drift this ADR exists to
+  > prevent.
+
+- **Daily question** (sweep) — **ADDED by ADR-042 D3 (2026-08-06).** A
+  **fourth** `PushKind`, `dailyQuestion`, and a third pass on the run where a
+  bucket's couple-local hour is **8**: the couple's day doc for that local
+  date exists and is unrevealed, and the announcement goes to whichever
+  members have not already answered. **It iterates the SAME `CoupleBuckets`
+  the assignment and at-risk passes share, so it adds ZERO couples reads** —
+  the hard constraint in this decision is preserved by construction, not by
+  promise. Per-couple cost is the same shape as the nudge: one day-doc read
+  plus one `getAll` of two answer docs, once per day, hour-8 bucket only.
+
 **Payload policy is a pure, unit-tested function** with two axes:
 
 - **Quiet hours:** 22:00–08:00 in the couple's STORED timezone → the push is
@@ -152,6 +183,15 @@ APNs/on-device delivery remains operator-expected item 4):
   this session; the at-risk push at 20:xx local is outside the window by
   construction. Suppress-vs-delay is revisitable when a real notification
   backlog exists.
+
+  > **ADR-042 D3 note (2026-08-06).** The window is **right-open at 08:00**,
+  > so hour 8 is the FIRST legal hour of the day and the new `dailyQuestion`
+  > push is the first thing this policy allows. That is elegant and it is
+  > **fragile**: moving either boundary by one silently suppresses the whole
+  > feature while every unrelated test stays green. Both directions are
+  > mutation-checked (`daily-question.test.ts`), because a feature that fails
+  > by going quiet cannot be noticed by its absence. The nudge at 16:xx is
+  > comfortably clear of both edges.
 - **Discreet-text mode** (PRD F6, privacy posture): **no payload, in ANY
   mode, ever contains question or answer text** — lock screens are not
   couple-private. Non-discreet payloads may name the partner and the event
@@ -163,11 +203,21 @@ APNs/on-device delivery remains operator-expected item 4):
   and reads through the same resolver seam.
 
 **Token storage:** recipients resolve through `users/{uid}.fcmTokens`
-(string array). Nothing writes it yet — the app-side capture is
+(string array). ~~Nothing writes it yet~~ — the app-side capture is
 platform-channel work needing APNs and is **deferred to the on-device slice**
 (recorded loudly: operator-expected item 4 / M6). Absent or empty tokens →
 the send is skipped and counted loudly in the trigger/sweep summary; the
 Functions half is fully emulator-proven against the port.
+
+> **DISCHARGED by ADR-042 D1 (2026-08-06).** `fcmTokens` now has writers —
+> the `registerPushToken` / `unregisterPushToken` callables — and is frozen
+> against clients in `firestore.rules` at create **and** update. The
+> deferral above stood for three weeks and was the reason **no notification
+> had ever been delivered to anyone** while this ADR's Functions half was
+> fully tested and `implementation-plan.md` ticked M3.4 ✅ (lesson 79).
+> What remains deferred is only the **device** half — the plugin, the
+> entitlement, the APNs surface — which is blocked on the Push Notifications
+> capability, **measured absent** on the App ID 2026-08-06 (issue #188).
 
 ## Consequences
 

--- a/docs/adr/042-push-token-lifecycle-and-the-two-hours-the-founder-asked-for.md
+++ b/docs/adr/042-push-token-lifecycle-and-the-two-hours-the-founder-asked-for.md
@@ -1,6 +1,6 @@
 # ADR-042: The FCM token lifecycle, and the two clock hours the founder asked for
 
-- **Status:** Accepted (rev 2 — folds the pre-code adversarial design review. 36 findings raised across 5 lenses; **2 confirmed** and fixed in place, 7 re-adjudicated 3-lens after the first round's verifiers ran against a worktree that did not contain this file. See the review record at the end.)
+- **Status:** Accepted — **D1, D3, D4, D5 IMPLEMENTED** (S062 shipped D1 in #187; S063 shipped D3/D4 in #190). **D2 and D6 remain deferred** on the App ID capability measured absent 2026-08-06 (issue #188). (rev 2 — folds the pre-code adversarial design review. 36 findings raised across 5 lenses; **2 confirmed** and fixed in place, 7 re-adjudicated 3-lens after the first round's verifiers ran against a worktree that did not contain this file. See the review record at the end.)
 - **Date:** 2026-08-06 (Session 062)
 - **Deciders:** founder (the three notification behaviours, verbatim, 2026-08-05); session agent (the measurement that found none of them can fire, and the slice order)
 - **Amends:** **ADR-012 Decision 3** — its push-kind vocabulary (three kinds becomes four), its token-storage deferral (*"nothing writes it yet"* is discharged), its sweep-pass inventory (two passes becomes four), and its at-risk eligibility rule (`streak.count > 0` at hour 20 becomes unconditional at hour 16). ADR-012's hard cost constraint — **one couples read per sweep** — is **not** amended and is preserved by construction.
@@ -333,8 +333,25 @@ remainder deferred into prose is a remainder that gets lost):
   the iOS project at all), nor whether its method swizzling works with this
   app's **scene-based** `FlutterSceneDelegate` architecture. Both are marked
   UNVERIFIED rather than assumed.
-* **D3 and D4** — the fourth kind and the two sweep hours. Pure Functions logic,
-  fully emulator-provable, and the next session's objective.
+* ~~**D3 and D4** — the fourth kind and the two sweep hours.~~ **SHIPPED in S063**
+  (#190). Two corrections the implementation forced, recorded because both were
+  decisions this ADR should have made and did not:
+
+  1. **D4 needed new copy, not just a new hour.** The ADR said "the streak count
+     still tunes the copy when a streak exists, so nothing about the existing
+     message is lost." True, and incomplete: the count-FREE variant that already
+     existed read *"Your streak together is still alive"*, which is **false for
+     exactly the population D4 exists to reach** — couples with no streak. A
+     separate relationship nudge was written (`unansweredNudgeNormal`), because
+     telling someone their streak is alive when they have none is worse than
+     saying nothing. Dropping a gate changed who reads the message, and the
+     message had to change with it.
+  2. **The daily-question pass skips members who already answered**, which the
+     ADR did not specify. At local 08:00 the day doc is eight hours old and in
+     the ordinary case nobody has answered — but announcing a question to
+     someone who already answered it is the small wrongness that makes an app
+     feel inattentive. Costs one `getAll` of two answer docs per eligible
+     couple; recorded in ADR-012 §10 rather than absorbed silently.
 
 **Four consequences recorded now, because each will be someone's surprise later:**
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -58,11 +58,19 @@ M3.4 ~~✅~~ **⚠️ CORRECTED 2026-08-06 (Session 062) — see the note at the
 >
 > **S062 lands the writer** (ADR-042 D1: `registerPushToken` /
 > `unregisterPushToken`, `fcmTokens` frozen in `firestore.rules` at create AND
-> update, the Flutter lifecycle behind a `PushTokenSource` port). **It still does
-> not deliver a push**, because `PUSH_NOTIFICATIONS` is **measured absent** on the
-> App ID (2026-08-06, run 31054773143) and a build claiming the entitlement would
-> fail at codesign. M3.4 stays open until a push reaches a device and somebody
-> sees it.
+> update, the Flutter lifecycle behind a `PushTokenSource` port). **S063 lands the
+> two behaviours the founder actually asked for** (ADR-042 D3/D4): a fourth
+> `PushKind` `dailyQuestion` on a new couple-local hour-8 pass, and the afternoon
+> nudge re-pointed 20:00 → **16:00** with its `streak.count > 0` gate dropped, so
+> it reaches couples who have no streak at all. All three passes still ride **one**
+> couples read per sweep.
+>
+> **It still does not deliver a push**, because `PUSH_NOTIFICATIONS` is **measured
+> absent** on the App ID (2026-08-06, run 31054773143) and a build claiming the
+> entitlement would fail at codesign. Every layer above the device is now built,
+> tested and composed; what is missing is one portal checkbox and the plugin
+> behind it (#188). **M3.4 stays open until a push reaches a device and somebody
+> sees it.**
 
 ## M4 — Paywall & entitlements (3 sessions)
 

--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -15,7 +15,7 @@
 > when the list around it shrinks. Read top-to-bottom for priority. Numbers that
 > have closed but are still cited by code are listed at the very bottom.
 
-_Last refreshed: **2026-08-06** (Session 062). The 2026-08-05 refresh re-measured
+_Last refreshed: **2026-08-06** (Sessions 062–063). The 2026-08-05 refresh re-measured
 every line against Apple, GitHub, Google and your live site; S062 added the one
 thing that refresh could only ask you to report._
 
@@ -55,7 +55,7 @@ decision from you before a session can finish them.
 
 | Question | Where it stands | What is left |
 |---|---|---|
-| **Is the MVP built?** | **~97%** — M1→M6.3 all merged. **M3.4's notification half has still never delivered a single push.** Session 062 built the missing piece underneath it — the app can now record which phone to notify, and only the server can write it — but **the phone still has no way to receive a push**, because that needs the portal tick below. The plan's ✅ on M3.4 has been struck through and dated. | **4(a)**, then one session's build work. |
+| **Is the MVP built?** | **~97%** — M1→M6.3 all merged. **No notification has still ever been delivered.** Sessions 062–063 built everything above the device: the app records which phone to notify (server-writable only), and all three notifications you asked for — 08:00 question, partner-answered, 16:00 reminder — are composed and routed. **The phone still has no way to RECEIVE one**, and that is the portal tick below. The plan's ✅ on M3.4 stays struck through until a push actually arrives. | **4(a)** — one checkbox and one key. |
 | **Can people install it?** | **100%** — done. Build 113 is approved and live. `Friends` holds eight: you `INSTALLED`, **two anonymous public-link installs**, one emailed tester `INSTALLED`, four `INVITED` (emailed, not yet opened). | Nothing. Ship **114+** so they stop testing three-week-old code. |
 | **Could this go on the public App Store?** | **~55%** — the honest number. The build is ready; the business and legal surface around it is not. | **0(a)** (purchases take money and do not unlock Premium), **0(b)** (the paid loop has never been run end to end), **9** (legal: three blanks, unreviewed, one KVKK filing), **1** and **★** (native TR/AR review — the biggest quality risk, and the crisis lexicon is a safety gate), **8(c)/(d)/(e)**, and **analytics** (Gates 2 and 3 are unfalsifiable without it). |
 
@@ -196,8 +196,20 @@ place in the system to find out, because our iOS CI check builds
 4. **only then** does a session add the plugin and the entitlement, in one commit.
 
 **What you get once it is done:** a question every morning at 08:00, a nudge when
-your partner answers, and a reminder in the afternoon if you have not. Those are
-the three you asked for.
+your partner answers, and a reminder at 16:00 if you have not. Those are the three
+you asked for.
+
+> ### ✅ All three are now BUILT — they are waiting on this checkbox and nothing else
+>
+> As of 2026-08-06 the server composes and routes all three: the 08:00 question, the
+> partner-answered nudge, and the 16:00 reminder. The 16:00 one deliberately fires
+> **even if you have no streak** — you asked for it so your partner does not get
+> angry, not to protect a counter.
+>
+> **There is no engineering left between you and a notification.** The app knows
+> which phone to notify and only the server can write that. What is missing is the
+> tick above, the key below, and the one plugin that cannot be added until the tick
+> exists — because a build that claims push without it **fails to sign**.
 
 **What already exists while you do it.** The server composes the "your partner
 answered" push correctly today and hands it to the send seam — that half has been

--- a/docs/past-prompts.md
+++ b/docs/past-prompts.md
@@ -2331,3 +2331,46 @@ And the freeze matters more than the usual server-owned field. *"Self-only via `
 * **The app icon** (priority 1 in S062's prompt) and **`tr` screenshots** (priority 3) were not started. The objective was the session, and it was more than one session's work; the prompt said to take the first coherent slice and record what was left. This is that record.
 
 **M3.4's ✅ is corrected in the same commit as the code** (criterion 4, lesson 79): strikethrough + dated note, the way ADR-026 D3 was corrected. **M3.4 stays open until a push reaches a device and somebody sees it.**
+
+## Session 063 — 2026-08-06 — **the daily question at 08:00 and the nudge at 16:00: all three founder behaviours now exist** *(first-hand, continues S062 in the same sitting)*
+
+**Objective:** #189 / ADR-042 D3+D4 — the two notification behaviours the founder asked for that S062 deferred. Chosen over #188 (the device half) because #188 is founder-blocked on a capability measured absent, and D3/D4 are pure Functions logic blocked by nothing.
+
+**Shipped: #190.**
+
+### What exists now that did not
+
+`PushKind` gains **`dailyQuestion`** (TR/AR/EN + discreet), announced by a new **hour-8** pass; the afternoon nudge moved **20:00 → 16:00** with its `streak.count > 0` gate **dropped**. All three passes ride **one** couples read — ADR-012 D3's hard constraint preserved by construction, and its §10 cost model **amended in the same diff** rather than left to drift (the day-doc read widened from "hour-20, couples with a streak" to "hour-16, unconditionally, plus one `getAll` of two answer docs").
+
+**All three behaviours the founder named on 2026-08-05 are now composed and routed.** None has reached a phone. `PUSH_NOTIFICATIONS` is still absent from the App ID, so #188 remains the whole remaining distance.
+
+### The two things the ADR did not decide, and the code forced
+
+1. **D4 needed new copy, not just a new hour.** The ADR said the count-free variant meant "nothing about the existing message is lost". True of the code, false of the product: that variant read *"Your streak together is still alive"* — **false for exactly the population D4 exists to reach.** A separate relationship nudge was written. → **lesson 83.**
+2. **The daily-question pass skips members who already answered.** Unspecified by the ADR; costs one `getAll` per eligible couple. Announcing a question to someone who already answered it is the small wrongness that makes an app feel inattentive.
+
+Both folded back into ADR-042 as recorded corrections rather than absorbed silently.
+
+### The tripwire, disarmed correctly
+
+S062's ADR predicted this exact red: `payload-policy.test.ts` asserted **both** "exactly three kinds" **and** `not.toContain('coupleEnded')`. The count moved to four; **the `coupleEnded` assertion was not touched**, and the test now states in its own comment which half is the ADR-019 DV safety invariant and which is a change detector. The prediction was worth writing down — meeting that red cold, the obvious move is to relax the whole test.
+
+Similarly, the **two zero-streak at-risk tests were inverted rather than deleted** when their rule reversed, so the case stays covered with the opposite expectation. Mutation M5 (restoring the gate) reddens exactly those three, which is what proves the drop is covered and not vacuously passing.
+
+### Mutation-checked, both directions, each anchor unique (lesson 82 applied)
+
+| Mutation | Reddened |
+|---|---|
+| quiet window `< 9` | 8 assertions — **the silent-death mutation**: hour 8 sits *on* the right-open boundary |
+| quiet window `>= 23` | "hour 22 IS quiet" + both boundary tables |
+| `DAILY_QUESTION_LOCAL_HOUR` 8→7 | 8 |
+| `AT_RISK_LOCAL_HOUR` 16→20 | 8 |
+| streak gate restored | exactly the 3 inverted tests |
+
+### A bounded refactor, stated rather than smuggled
+
+Recipient resolution, the quiet guard and the per-token error boundary moved to `sweep-push.ts`. Two passes differing only in couple selection and kind would have kept two copies of **the code that decides whether a lock screen leaks**, and only one would get the next fix.
+
+**Functions 1067 tests / 54 files, 97.45% stmts.** Typecheck caught a test-only type error vitest's esbuild transpile runs straight past — the `npm run typecheck` step earns its place.
+
+**Not done:** the app icon and `tr` screenshots, again. Both are unblocked and both keep losing to the objective; S064's prompt puts the icon first.

--- a/docs/resume-prompt.md
+++ b/docs/resume-prompt.md
@@ -1,4 +1,4 @@
-# Resume Prompt — Session 063
+# Resume Prompt — Session 064
 
 > **This file contains ONE objective. That objective is the session; nothing else is.**
 > (`project-rules.md` #1, `session-rules.md` §1.)
@@ -6,13 +6,15 @@
 > Before starting, read the two companions:
 > * **`session-context.md`** — toolchain, machine, review discipline, binding
 >   invariants, and the never-without-asking list.
-> * **`session-lessons.md`** — the institutional lessons, numbered to **82**. Cited
+> * **`session-lessons.md`** — the institutional lessons, numbered to **83**. Cited
 >   below by number.
 >
 > Re-derive the session number from `git log`; a session on another machine can consume it.
 
-**Objective: make a push actually arrive — build the daily-question kind and the
-two clock hours the founder asked for (#189, ADR-042 D3/D4).**
+**Objective: ship the app icon the founder chose, and get a build to the testers.**
+
+Both are unblocked. Both have lost to the push objective for two sessions running.
+The founder has asked about the icon once and about testers' builds twice.
 
 ---
 
@@ -20,132 +22,83 @@ two clock hours the founder asked for (#189, ADR-042 D3/D4).**
 
 | | State |
 |---|---|
-| **`users.fcmTokens`** | **Has a writer and a lock as of S062** (#187). `registerPushToken` / `unregisterPushToken`, frozen in `firestore.rules` at create AND update, mutation-proven both ways. |
-| **A push reaching a phone** | **Still never happened.** The device half is #188 and is founder-blocked. |
-| **App ID capabilities** | **Measured** 2026-08-06, run `31054773143`: `APPLE_ID_AUTH` + `IN_APP_PURCHASE` ticked. **`PUSH_NOTIFICATIONS`, `ASSOCIATED_DOMAINS`, `APP_ATTEST` all ABSENT.** |
+| **Push, server side** | **DONE.** All three founder behaviours compose and route: `dailyQuestion` at couple-local 08:00, `partnerAnswered` on the reveal trigger, the unanswered nudge at 16:00. `fcmTokens` has writers and a rules lock. |
+| **Push, device side** | **Nothing has ever arrived.** #188, blocked on the App ID tick. |
+| **App ID capabilities** | Measured 2026-08-06 (run `31054773143`): `APPLE_ID_AUTH` + `IN_APP_PURCHASE` ticked; **`PUSH_NOTIFICATIONS`, `ASSOCIATED_DOMAINS`, `APP_ATTEST` ABSENT.** Re-dispatch `appid-capabilities.yml` — it is one command and it decides whether #188 is live. |
 | **Build 113** | Apple-approved, `IN_BETA_TESTING`, 8 in `Friends` (2 anonymous public-link installs). |
-| **Build 114** | Uploaded 2026-08-02, **`READY_FOR_BETA_SUBMISSION` — never submitted.** Everyone is still testing 113. |
-| **Screenshots** | en-US: 6 live since 2026-08-03. `tr` never uploaded (needs its version localization first). |
-| **#115 webhook** | still HTML 403. |
-
-**Re-derive all of it.** The capability line is one `gh workflow run
-appid-capabilities.yml` away and is the single most decision-changing fact on this page.
+| **Build 114** | Uploaded 2026-08-02, **`READY_FOR_BETA_SUBMISSION` — never submitted.** Everyone is still on 113. |
+| **`firestore.rules`** | **Changed in S062 and NOT deployed** — prod/dev differ from `main` until `deploy-rules.yml` runs, which needs `FIREBASE_SERVICE_ACCOUNT` (operator 2(e)(iii)). **The `fcmTokens` freeze is not live yet.** |
+| **Screenshots** | en-US: 6 live since 2026-08-03. `tr` never uploaded. |
 
 ---
 
-## 2. THE OBJECTIVE — #189, the fourth kind and the two hours
+## 2. THE OBJECTIVE
 
-The founder, verbatim 2026-08-05:
+### Part 1 — the app icon (decided, just not executed)
 
-> app does not sent notificaiton. It needs to be send new questions at 08.00 TSI with a
-> question. And when your partner answers your question you need to be notified. If you
-> did not reply the question as of 16.00 you need to be notified so that your partner
-> dont get angry.
+The founder was shown the candidates and chose
+**`brandkit/branding-assets/icons/hayati-appicon-ios-1024.png`**, the pre-redesign
+mark. **Execute that; do not re-open the choice.**
 
-**"Partner answered" is already built.** These are the other two, and **both are pure
-Functions logic, fully emulator-provable — no plugin, no Mac, no APNs key.** Nothing
-blocks this session. That is why it is the objective and #188 is not.
+⚠️ **`git revert` is the wrong instrument** (lesson **80**). `git log --follow` on
+`Icon-App-1024x1024@1x.png` returns exactly two commits, and the earlier one is the
+**default blue Flutter logo** from the m0.1 scaffold. The chosen file has never been
+in that path's history.
 
-### D3 — a fourth push kind, on the SAME single couples read
+⚠️ **There is no `flutter_launcher_icons`.** The 15 iOS PNGs and 5 Android
+`mipmap-*/ic_launcher.png` are hand-produced. Generate them deliberately and
+**verify every size actually changed** (lesson **66** — a generator that silently
+skips a size leaves a stale icon at exactly one scale factor, which is the one a
+tester's device will use).
 
-`PushKind` gains **`dailyQuestion`**, TR/AR/EN across the registers plus the discreet
-variant, under the standing invariant that **no payload in any mode carries question or
-answer text** — which `composePush` guarantees structurally by having no question
-parameter, not by copy review.
+⚠️ **Leave `AppIconDiscreet` alone.** `redesign/icons/README.md` §5 is explicit, and
+it is load-bearing for the on-device check at operator 4(3).
 
-The hour-8 pass iterates the **same `CoupleBuckets`** the assignment and at-risk passes
-already share (`question-rollover.ts:72-82`). **ADR-012 D3's hard constraint is ONE
-couples read per sweep and it is NOT amended** — a third pass is one more argument to the
-existing `bucket(db)`, never a second read.
+### Part 2 — ship a build
 
-⚠️ **08:00 sits exactly on the quiet-hours boundary.** `isQuietLocalHour` is
-`hour >= 22 || hour < 8` — right-open, so hour 8 is the first legal hour of the day and
-the daily push is the first thing allowed. Elegant, and an off-by-one **in either
-direction silently suppresses the entire feature with every test green.**
+113 predates #169 (the founder's own *"Something went wrong"*), #170, #173, #179,
+and now the entire push slice. All merged, built into 114, and reached nobody.
 
-### D4 — the 16:00 nudge REPLACES the 20:00 one
+```sh
+gh workflow run release.yml --ref main
+gh workflow run testflight-testers.yml -f dry_run=false -f assign_latest_build=true -f submit_for_review=true
+```
 
-Not the same push with a different number. Today's protects a **streak**
-(`at-risk.ts:202`: `streak.count > 0` or skip). The founder's protects a
-**relationship** — *"so that your partner dont get angry"* — and must fire for a couple
-with **no streak at all**, which is most couples in week one and every couple that ever
-broke one.
-
-**Decided in ADR-042 D4: re-point, do not duplicate.** `AT_RISK_LOCAL_HOUR` 20 → **16**,
-and the `streak.count > 0` gate is **dropped**. The 16:00 population is a strict superset
-of the 20:00 one, so re-pointing loses no couple. Keeping both would give a couple with a
-streak two pushes in one evening, and ADR-012 D3 deliberately has no dedup state.
-
-### ⚠️ The tripwire — read this before you meet the red test
-
-`payload-policy.test.ts:44-57` asserts **two** things: that the `PushKind` union is
-**exactly three kinds**, and that the source `not.toContain('coupleEnded')`.
-
-**Adding `dailyQuestion` will turn it red, on purpose.** The correct response updates the
-expected union to four and **leaves the `coupleEnded` assertion completely alone.** That
-assertion is ADR-019 D3's no-push-on-deletion invariant — a proactive real-time ping to a
-possibly-abusive partner at the deleting victim's moment of escape. The "exactly N" clause
-is a change-detector; **the `coupleEnded` absence is the safety property.** A session that
-meets the red and relaxes the test wholesale deletes a DV control while believing it fixed
-a test. (ADR-042 D5 says this too, in the ADR, for the same reason.)
-
-`at-risk.test.ts:98-99` (pins hour 20) and `:202-214` (pins the streak gate) both change
-**by design** — update them inside the TDD cycle, do not relax them.
+⚠️ **Ask the founder before dispatching `release.yml`.** (`session-context.md`
+never-without-asking list.)
+⚠️ **Never infer delivery from a green release** — read the assignment step's log or
+re-run `-f status_only=true`. It has failed silently twice, and Apple refuses a
+second beta submission with a message that prints as "already submitted — no-op"
+and exits **0**.
 
 ### Acceptance criteria
 
-1. **Tests first** (`session-rules.md` §2 — Functions logic may not skip TDD).
-2. **Mutation-check the hour boundaries in BOTH directions** — 8 must not be quiet, 22
-   must be, 16 must not. Report **which named assertions moved** (lesson **75**), and
-   **anchor each mutation on text unique to the line you mean** (lesson **82** — S062 had
-   a first-occurrence replace hit the wrong guard and report a false all-green).
-3. **Prove the ONE-couples-read constraint holds**, by construction rather than by
-   promise. If it cannot be asserted, say so rather than claiming it.
-4. **Amend ADR-012 §10's cost model in the same diff.** The day-doc read was "one per
-   couple per day, hour-20 bucket, **for couples with a streak**"; it becomes "hour-16
-   bucket, **unconditionally**", because eligibility can no longer be decided from the
-   couple document already in the bucket. Single-digit reads/day at current scale —
-   recorded because a cost claim that quietly widened is the drift ADRs exist to prevent.
-5. **Do not claim delivery you have not seen** (lessons **69**, **78**). The honest close
-   is *"composed, routed and provably handed to the port; never delivered to a device,
-   because `PUSH_NOTIFICATIONS` is not ticked."*
-6. **#136 becomes live the moment a push lands** (Arabic push bodies interpolate a partner
-   name with no bidi isolation). Composing a fourth Arabic body is the moment to decide
-   it — ADR-033 isolates **at render only**, and a push body is composed on the server and
-   rendered by iOS.
+1. Every icon size regenerated and **diffed** — assert on the bytes, not on the
+   generator's exit code.
+2. `AppIconDiscreet` byte-identical before and after.
+3. The build dispatched only after the founder says yes, and its TestFlight
+   assignment **read back from the API**, not inferred.
+4. If the founder is unavailable, land the icon and **say plainly that the build
+   was not dispatched and why** — do not dispatch it to avoid an awkward handoff.
 
 ---
 
 ## 3. Then, in priority order
 
-**1 — The app icon. DECIDED, unblocked, and S062 did not get to it.**
-The founder chose **`brandkit/branding-assets/icons/hayati-appicon-ios-1024.png`**, the
-pre-redesign mark. Execute it; do not re-open the choice.
-⚠️ **The literal git-previous is the default blue Flutter logo** — `git log --follow` on
-the 1024 icon returns exactly two commits and that is the other one, so **`git revert` is
-the wrong instrument** (lesson **80**). There is **no `flutter_launcher_icons`**: the 15
-iOS PNGs and 5 Android `mipmap-*/ic_launcher.png` are hand-produced — generate them
-deliberately and **verify every size actually changed** (lesson **66**). **Leave
-`AppIconDiscreet` alone** (`redesign/icons/README.md` §5).
+**1 — `tr` screenshots.** en-US is **done and live**; tell the founder, they asked
+again only because nobody told them. **TestFlight has no screenshot field**
+(measured, PR #181). `tr` needs its App Store **version localization** to exist
+first: read with `tool/ci/testflight_testers.py --store-status`; if `tr` exists,
+dispatch `appstore-screenshots.yml -f upload=true -f locales=en-US,tr`. If not, it
+is a founder action already on the operator page.
 
-**2 — Ship a build.** 113 predates #169 (the founder's own *"Something went wrong"*),
-#170, #173, #179 — all merged, built into 114, and reached nobody.
-```sh
-gh workflow run release.yml --ref main
-gh workflow run testflight-testers.yml -f dry_run=false -f assign_latest_build=true -f submit_for_review=true
-```
-⚠️ **Ask the founder before dispatching `release.yml`.** ⚠️ **Never infer delivery from a
-green release** — read the assignment step's log or re-run `-f status_only=true`.
+**2 — #188, the device half — ONLY if the capability probe returns exit 0.** Run it
+first; it is one command. If it still returns 1, say so and move on rather than
+building around it. Everything above the device is done and waiting.
 
-**3 — Screenshots (`tr` only).** en-US is **done and live** — tell the founder, they asked
-again only because nobody told them. **TestFlight has no screenshot field** (measured, PR
-#181). `tr` needs its App Store **version localization** to exist first: read with
-`tool/ci/testflight_testers.py --store-status`; if `tr` exists, dispatch
-`appstore-screenshots.yml -f upload=true -f locales=en-US,tr`. If not, founder action.
-
-**4 — The rest.** Re-derive from `gh issue list`. **#188** (the device half — blocked on
-4(a)) · **#176** (Rubik Light declared, not bundled) · **#175** (10 of 14 raised cards
-render flat) · **#174** (no `liveRegion` — the reveal is never announced) · **#166**
+**3 — The rest.** Re-derive from `gh issue list`. **#176** (Rubik Light declared,
+not bundled — the cheapest real bug here) · **#175** (10 of 14 raised cards render
+flat) · **#174** (no `liveRegion` — the reveal is never announced) · **#166**
 (measurement-first; may honestly close as unanswerable) · **#137** · **#129/#121**.
 
 ---
@@ -155,21 +108,16 @@ render flat) · **#174** (no `liveRegion` — the reveal is never announced) · 
 | What | Blocked on | Why a session cannot take it alone |
 |---|---|---|
 | **operator 4(a)** — APNs key + Push Notifications tick | founder | **MEASURED ABSENT 2026-08-06.** Gates #188 and every actual delivery. The `.p8` half is console-only and unmeasurable. |
-| **operator 2(d)** — Associated Domains | founder | **MEASURED ABSENT.** Same portal page as 4(a) — one visit does both. Not blocking (ADR-040). |
+| **operator 2(d)** — Associated Domains | founder | **MEASURED ABSENT.** Same portal page as 4(a) — one visit does both. |
 | **`tr` App Store version localization** | founder | Screenshots cannot upload into a locale that does not exist |
+| **operator 2(e)(iii)** | founder | `FIREBASE_SERVICE_ACCOUNT`. **Now also blocks the S062 rules freeze from going live.** |
 | **operator 2(e)(iv) / #165** | founder | One read-only SA + `gh secret set`. Until then `rules-drift` is SKIPPED **by design** |
 | **operator 2(e)(ii)** | founder | The controller's legal name. Blocks `/privacy`, `/terms`, the listing |
-| **operator 2(e)(iii)** | founder | `FIREBASE_SERVICE_ACCOUNT`. Blocks CI site deploys and `deploy-rules.yml` |
 | **#115** | founder | Making a prod endpoint world-reachable is a security decision on a live system |
 | **#41** | founder | Live billing identity — *clean change* vs *migration* |
 | **#48**, **#15**, **#136** | the device | On-device observation nobody has made — **and four testers have it installed** |
 | **#13** | M6.5 | Android, Gate-3 gated (ADR-006) |
 | **#63**, **#71** | founder | Brandkit revisions |
-
-⚠️ **`firestore.rules` changed in S062.** Prod and dev now differ from `main` until
-`deploy-rules.yml` runs, which needs `FIREBASE_SERVICE_ACCOUNT` (operator 2(e)(iii)).
-**The freeze is not live yet.** Re-measure with `tool/ci/rules_drift.py` and read the exit
-code directly — **never through a pipe** (`${PIPESTATUS[0]}`, the most-cited lesson here).
 
 ---
 
@@ -179,4 +127,4 @@ Append to `past-prompts.md` → regenerate this file (one objective) → refresh
 `operator-expected.md` → commit + push → verify CI → **watch the post-merge `main` run**
 (`integration-emulator` is main-only) → `codegraph sync`.
 
-**S059–S061 skipped this three times running. S062 ran it. Keep the streak.**
+**S059–S061 skipped this three times. S062 and S063 both ran it. Keep the streak.**

--- a/docs/session-lessons.md
+++ b/docs/session-lessons.md
@@ -38,6 +38,20 @@ something, ask which of these you are standing in:
 
 ### Recent, in full
 
+**83 — Changing an eligibility rule changes WHO reads the message, so the message has to change with it.** *(2026-08-06)*
+ADR-042 D4 dropped the `streak.count > 0` gate so the afternoon nudge would reach
+couples with no streak — that population *was the reason for the change*. The ADR
+noted that the existing copy already had a count-free variant and concluded
+"nothing about the existing message is lost." It was right about the code and
+wrong about the product: that variant read **"Your streak together is still
+alive"**, which is **false for exactly the people the change existed to reach.**
+A gate is not only a filter on delivery; it is a **precondition the copy above it
+was written under**. When you delete one, re-read every string the newly-admitted
+population will now see and ask whether it is still *true* for them — not whether
+it still renders. The bug would have shipped as a working feature with green
+tests, because "the copy degrades gracefully" and "the copy is honest" are
+different properties and only the first one has a test shape.
+
 **82 — A mutation that silently hits the wrong line reports exactly what a covered line reports: green.** *(2026-08-06)*
 S062 mutation-checked `PushTokenSync` by string-replacing a guard, with
 `str.replace(old, new, 1)` — first occurrence only. The anchor `if (_syncedUid == null)

--- a/functions/src/notifications/at-risk.ts
+++ b/functions/src/notifications/at-risk.ts
@@ -1,72 +1,70 @@
-// streak-at-risk push pass — PIGGYBACKED on the hourly questionRollover sweep
-// (ADR-012 Decision 3), never a second scheduled Function. The sweep already
-// lists every couple ONCE and buckets them by stored timezone (rollover-service
-// bucketCouplesByTimezone); this pass reuses that SAME snapshot — the hard
-// constraint is exactly one couples-collection read per production sweep, so the
-// handler threads its single CoupleBuckets into both the assignment pass and this
-// one. On the sweep whose bucket-local hour is 20 (AT_RISK_LOCAL_HOUR), a couple
-// with something to lose (streak.count > 0) whose day doc is still unrevealed gets
-// a nudge to whichever member has not answered. Best-effort by design: no dedup
-// state — the hourly cadence + the once-per-zone hour-20 gate make double-sends
-// structurally absent, not guarded (ADR-012 D3).
+// The unanswered-day nudge — PIGGYBACKED on the hourly questionRollover sweep
+// (ADR-012 Decision 3), never a second scheduled Function. The sweep lists every
+// couple ONCE and buckets them by stored timezone; this pass reuses that SAME
+// snapshot, so it adds zero couples reads.
+//
+// ⚠️ ADR-042 D4 CHANGED WHAT THIS PASS IS FOR, and the file name lags the meaning.
+// It used to protect a STREAK: hour 20, and only couples with `streak.count > 0`.
+// The founder asked for something else — "If you did not reply the question as of
+// 16.00 you need to be notified so that your partner dont get angry" — which
+// protects a RELATIONSHIP and must therefore fire for a couple with NO streak at
+// all. That is most couples in week one and every couple that ever broke one.
+//
+// So: hour 20 → 16, and the streak gate is GONE. The streak count still tunes the
+// copy when a streak exists; when it does not, composePush returns a different
+// message rather than streak copy with the digits removed (payload-policy.ts).
+//
+// Re-pointed rather than duplicated: the 16:00 population is a strict SUPERSET of
+// the 20:00 one, so nothing is lost, and a second afternoon hour would give a
+// couple with a streak two pushes in one evening. ADR-012 D3 deliberately has no
+// dedup state — double-sends are structurally absent, not guarded — so adding an
+// hour would have created exactly the class of duplicate that design avoids.
 import { Firestore } from 'firebase-admin/firestore';
 import { logger } from 'firebase-functions';
 
 import { localDayKey } from '../rollover/day-key';
 import type { CoupleBuckets } from '../rollover/rollover-service';
 import { parseStreak } from '../streak/streak';
-import { isQuietLocalHour, localHour } from './local-hour';
+import { localHour } from './local-hour';
 import type { MessagingPort } from './messaging-port';
-import { composePush } from './payload-policy';
-import {
-  contentLanguageOf,
-  fcmTokensOf,
-  notificationPrivacyOf,
-  resolveDiscreet,
-} from './recipients';
+import { SweepPushOutcome, deliverSweepPush, nonAnswerers } from './sweep-push';
 
-// The couple-LOCAL wall-clock hour the at-risk push fires on (ADR-012 D3): once
-// per zone per day — only the sweep whose bucket-local hour reads 20 pushes. 20 is
-// OUTSIDE the 22:00–08:00 quiet window by construction (deliverAtRiskPush still
-// re-checks, defense in depth). Sub-hour-offset zones (Asia/Kathmandu +05:45) land
-// on the hourly sweep whose local clock reads 20:xx, exactly as their midnight
-// bucket does. DST transitions never occur at 20:xx in practice.
-export const AT_RISK_LOCAL_HOUR = 20;
+// The couple-LOCAL wall-clock hour the nudge fires on (ADR-042 D4, re-pointed from
+// 20): once per zone per day — only the sweep whose bucket-local hour reads 16
+// pushes. 16 is comfortably OUTSIDE the 22:00–08:00 quiet window (deliverSweepPush
+// re-checks anyway, defense in depth), unlike the daily-question pass at hour 8
+// which sits exactly on the boundary. Sub-hour-offset zones (Asia/Kathmandu +05:45)
+// land on the hourly sweep whose local clock reads 16:xx, exactly as their midnight
+// bucket does. DST transitions never occur at 16:xx in practice.
+export const AT_RISK_LOCAL_HOUR = 16;
 
 /** The at-risk sweep counters the handler logs and the tests assert on. */
 export interface AtRiskSummary {
-  /** Eligible couples (streak.count > 0 AND today's day doc exists unrevealed). */
+  /** Eligible couples (today's day doc exists and is unrevealed). Since ADR-042 D4
+   *  there is NO streak precondition — the nudge protects the relationship, not the
+   *  counter, so a couple with no streak is exactly who it is for. */
   checked: number;
   /** At-risk pushes delivered (≥1 token accepted by the port). */
   sent: number;
   /** Recipients with no fcm token — a loud skip (expected pre-on-device capture). */
   skippedNoToken: number;
-  /** Couples with streak > 0 but NO day doc for today (rollover failed earlier —
-   *  nothing to answer, so NOT an at-risk state; counted separately). */
+  /** Couples with NO day doc for today (rollover failed earlier — nothing to
+   *  answer, so NOT an at-risk state; counted separately). */
   skippedNoDay: number;
-  /** Sends dropped by the defense-in-depth quiet-hours check (0 at hour 20 by
+  /** Sends dropped by the defense-in-depth quiet-hours check (0 at hour 16 by
    *  construction; the counter exists so the guard is observable if it ever fires). */
   suppressedQuiet: number;
   /** Per-token send failures + per-couple processing errors, all swallowed. */
   failed: number;
 }
 
-/** Terminal state of one recipient's best-effort send; every field is a summary increment. */
-interface AtRiskPushOutcome {
-  status: 'sent' | 'no-tokens' | 'suppressed-quiet-hours' | 'send-failed';
-  sent: number;
-  skippedNoToken: number;
-  suppressedQuiet: number;
-  failed: number;
-}
-
 /**
- * Resolve one recipient and best-effort send the streak-at-risk push. Mirrors the
- * reveal trigger's deliverPush (reveal-service.ts) but for the sweep: every branch
- * short of a delivered send is a TYPED, LOGGED skip whose numeric fields the caller
- * folds straight into the summary (no per-status switch, so aggregation is
- * branch-free). NOTHING here throws — a push that cannot go out must never fail the
- * sweep. `at` is the sweep instant, used as the clock for the quiet-hours guard.
+ * Thin wrapper over the shared sweep delivery (sweep-push.ts), kept as a named
+ * export because the at-risk suite exercises the delivery branches through it.
+ * The recipient resolution, the defense-in-depth quiet guard and the per-token
+ * error boundary are IDENTICAL across passes and now live in one place — two
+ * copies of the code that decides whether a lock screen leaks would have meant
+ * only one of them getting the next fix.
  */
 export async function deliverAtRiskPush(
   db: Firestore,
@@ -75,84 +73,10 @@ export async function deliverAtRiskPush(
   streakCount: number,
   timezone: string,
   at: Date,
-): Promise<AtRiskPushOutcome> {
-  const base = { sent: 0, skippedNoToken: 0, suppressedQuiet: 0, failed: 0 } as const;
-  try {
-    const userSnap = await db.collection('users').doc(recipientUid).get();
-    // A missing user doc and an empty/junk fcmTokens field collapse to the same
-    // "nothing to send to" skip (ADR-012: fcmTokensOf → [] on absent/malformed).
-    const userData = userSnap.exists ? userSnap.data() : undefined;
-    const tokens = fcmTokensOf(userData);
-    if (tokens.length === 0) {
-      logger.warn('question_rollover: at-risk push skipped, no fcm tokens', { recipientUid });
-      return { ...base, status: 'no-tokens', skippedNoToken: 1 };
-    }
-
-    // Defense in depth: the sweep only calls this for hour-20 buckets, which are
-    // outside quiet hours — but re-check on the SAME instant/zone so the delivery
-    // function can never emit inside 22:00–08:00 regardless of its caller.
-    if (isQuietLocalHour(localHour(at, timezone))) {
-      logger.info('question_rollover: at-risk push suppressed, couple-local quiet hours', { recipientUid });
-      return { ...base, status: 'suppressed-quiet-hours', suppressedQuiet: 1 };
-    }
-
-    const language = contentLanguageOf(userData);
-    // No question/answer text EVER leaves in a payload (ADR-012 F6); discreet mode
-    // defaults ON for AR recipients. streakCount tunes only the non-discreet copy.
-    const payload = composePush({
-      kind: 'streakAtRisk',
-      language,
-      discreet: resolveDiscreet(language, notificationPrivacyOf(userData)),
-      streakCount,
-    });
-
-    let sent = 0;
-    let failed = 0;
-    for (const token of tokens) {
-      try {
-        await messaging.send({ token, title: payload.title, body: payload.body });
-        sent += 1;
-      } catch (error) {
-        failed += 1;
-        logger.error('question_rollover: at-risk push send failed', {
-          recipientUid,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    }
-    return { ...base, status: sent > 0 ? 'sent' : 'send-failed', sent, failed };
-  } catch (error) {
-    // Any unexpected failure resolving the recipient (a corrupt uid path segment,
-    // a read error): the sweep must survive it as a counted noise, never a throw.
-    logger.error('question_rollover: at-risk push delivery errored', {
-      recipientUid,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return { ...base, status: 'send-failed', failed: 1 };
-  }
-}
-
-/**
- * The members of `member` who have NOT answered today (the at-risk recipients).
- * Reads BOTH answer docs in one round trip for an ELIGIBLE couple only (O(1) reads
- * per eligible couple, once per day, hour-20 bucket only — architecture §10 shape
- * unchanged). memberUids is the M2.3 join Function's write (a 2-element uid array);
- * anything else here is corrupt state the caller turns into a per-couple skip.
- */
-async function nonAnswerers(db: Firestore, coupleId: string, memberUids: unknown, dayKey: string): Promise<string[]> {
-  if (!Array.isArray(memberUids) || !memberUids.every((u): u is string => typeof u === 'string')) {
-    throw new Error(`couple ${coupleId}: malformed memberUids`);
-  }
-  const answersCol = db
-    .collection('couples')
-    .doc(coupleId)
-    .collection('days')
-    .doc(dayKey)
-    .collection('answers');
-  const snaps = await db.getAll(...memberUids.map((uid) => answersCol.doc(uid)));
-  // Match by doc id, not array position — getAll order is not a contract to lean on.
-  const answered = new Set(snaps.filter((s) => s.exists).map((s) => s.id));
-  return memberUids.filter((uid) => !answered.has(uid));
+): Promise<SweepPushOutcome> {
+  return deliverSweepPush(db, messaging, recipientUid, 'streakAtRisk', timezone, at, {
+    streakCount,
+  });
 }
 
 /**
@@ -197,11 +121,11 @@ export async function runStreakAtRisk(
 
     for (const member of members) {
       try {
-        // streak rides on the couple doc already read into the bucket — no read here.
+        // streak rides on the couple doc already read into the bucket — no read
+        // here. It no longer GATES anything (ADR-042 D4 dropped `count > 0`); it
+        // only tunes the copy, and a zero/absent streak yields the relationship
+        // nudge instead of streak copy.
         const streak = parseStreak(member.data.streak);
-        if (streak.count <= 0) {
-          continue; // nothing to lose (zero or absent streak) — not at-risk.
-        }
 
         const daySnap = await db
           .collection('couples')
@@ -210,8 +134,8 @@ export async function runStreakAtRisk(
           .doc(dayKey)
           .get();
         if (!daySnap.exists) {
-          // streak > 0 but rollover never assigned today's question for this couple:
-          // there is nothing to answer, so this is NOT an at-risk state (ADR-012 D3).
+          // Rollover never assigned today's question for this couple: there is
+          // nothing to answer, so this is NOT an at-risk state (ADR-012 D3).
           summary.skippedNoDay += 1;
           continue;
         }
@@ -219,7 +143,8 @@ export async function runStreakAtRisk(
           continue; // already mutually revealed today — the healthy case, nothing to nudge.
         }
 
-        // Eligible: streak > 0 AND today's day doc exists unrevealed.
+        // Eligible: today's day doc exists and is unrevealed. No streak clause —
+        // see the file header and ADR-042 D4.
         summary.checked += 1;
         const recipients = await nonAnswerers(db, member.coupleId, member.data.memberUids, dayKey);
         for (const recipientUid of recipients) {

--- a/functions/src/notifications/daily-question.ts
+++ b/functions/src/notifications/daily-question.ts
@@ -1,0 +1,154 @@
+// The daily-question push pass (ADR-042 Decision 3) — the founder's first ask,
+// verbatim: "It needs to be send new questions at 08.00 TSI with a question."
+//
+// PIGGYBACKED on the hourly questionRollover sweep, never a second scheduled
+// Function. The sweep lists every couple ONCE and buckets them by stored timezone;
+// this pass reuses that SAME snapshot, exactly as the at-risk pass does. ADR-012
+// D3's hard constraint is one couples-collection read per production sweep and
+// ADR-042 does NOT amend it — a third pass is one more argument to the handler's
+// existing `bucket(db)`, not a new machine.
+//
+// "08.00 TSİ" is read as 08:00 COUPLE-LOCAL. It is TSİ for the founder couple, and
+// every other time decision in this system runs off the couple's stored timezone
+// rather than a fixed offset (localHour, localDayKey, ADR-011). A literal
+// Europe/Istanbul constant would be correct for exactly one couple and silently
+// wrong for the Gulf-Arabic audience the product is built for.
+import { Firestore } from 'firebase-admin/firestore';
+import { logger } from 'firebase-functions';
+
+import { localDayKey } from '../rollover/day-key';
+import type { CoupleBuckets } from '../rollover/rollover-service';
+import { localHour } from './local-hour';
+import type { MessagingPort } from './messaging-port';
+import { deliverSweepPush, nonAnswerers } from './sweep-push';
+
+/**
+ * The couple-LOCAL wall-clock hour the daily-question push fires on (ADR-042 D3):
+ * once per zone per day — only the sweep whose bucket-local hour reads 8 pushes.
+ *
+ * ⚠️ **8 is the boundary of the quiet window, not a value inside it.**
+ * `isQuietLocalHour` is `hour >= 22 || hour < 8` — right-open at 08:00 — so hour 8
+ * is the FIRST legal hour of the day and this push is the first thing the policy
+ * allows. That is elegant and it is fragile: moving either the window or this
+ * constant by one silently suppresses the entire feature while every unrelated
+ * test stays green. Both directions are asserted in `daily-question.test.ts` and
+ * mutation-checked, because a feature that fails by going quiet cannot be noticed
+ * by its absence.
+ *
+ * Sub-hour-offset zones (Asia/Kathmandu +05:45) land on the hourly sweep whose
+ * local clock reads 08:xx, exactly as their midnight bucket does.
+ */
+export const DAILY_QUESTION_LOCAL_HOUR = 8;
+
+/** The daily-question sweep counters the handler logs and the tests assert on. */
+export interface DailyQuestionSummary {
+  /** Couples with today's day doc present and unrevealed — i.e. something to announce. */
+  checked: number;
+  /** Announcements delivered (≥1 token accepted by the port). */
+  sent: number;
+  /** Recipients with no fcm token — a loud skip (expected until the device slice). */
+  skippedNoToken: number;
+  /** Couples with NO day doc for today: rollover failed at local midnight, eight
+   *  hours before this pass, so there is no question to announce. Counted
+   *  separately because it is an assignment failure surfacing here, not a push one. */
+  skippedNoDay: number;
+  /** Sends dropped by the defense-in-depth quiet-hours check. MUST be 0 at hour 8
+   *  — a non-zero value here means the boundary moved and the feature is dead. */
+  suppressedQuiet: number;
+  /** Per-token send failures + per-couple processing errors, all swallowed. */
+  failed: number;
+}
+
+/**
+ * The daily-question pass over the shared timezone buckets (ADR-042 D3).
+ *
+ * For each bucket whose sweep-local hour is 8, reads today's day doc (one read per
+ * couple) and announces the new question to whichever members have not already
+ * answered it. Every per-couple/per-send problem is a logged skip counted in the
+ * summary; the pass never throws for a single couple.
+ *
+ * **Why non-answerers rather than both members.** At local 08:00 the day doc was
+ * created eight hours earlier at local midnight, so in the ordinary case nobody
+ * has answered and both get it. But an early bird who already answered does not
+ * need to be told a question exists — announcing it to them is the small kind of
+ * wrongness that makes an app feel like it is not paying attention. The cost is
+ * one `getAll` of two answer docs per eligible couple, the same shape the at-risk
+ * pass already pays; recorded in ADR-012 §10.
+ */
+export async function runDailyQuestion(
+  db: Firestore,
+  at: Date,
+  messaging: MessagingPort,
+  coupleBuckets: CoupleBuckets,
+): Promise<DailyQuestionSummary> {
+  const summary: DailyQuestionSummary = {
+    checked: 0,
+    sent: 0,
+    skippedNoToken: 0,
+    skippedNoDay: 0,
+    suppressedQuiet: 0,
+    failed: 0,
+  };
+
+  for (const [timezone, members] of coupleBuckets.buckets) {
+    let hour: number;
+    let dayKey: string;
+    try {
+      hour = localHour(at, timezone);
+      dayKey = localDayKey(at, timezone);
+    } catch {
+      // Corrupt stored zone (non-IANA): the assignment pass already logged+counted
+      // these couples as skips — this pass simply cannot evaluate them.
+      continue;
+    }
+    if (hour !== DAILY_QUESTION_LOCAL_HOUR) {
+      continue; // not this zone's morning sweep — once per zone per day.
+    }
+
+    for (const member of members) {
+      try {
+        const daySnap = await db
+          .collection('couples')
+          .doc(member.coupleId)
+          .collection('days')
+          .doc(dayKey)
+          .get();
+        if (!daySnap.exists) {
+          summary.skippedNoDay += 1;
+          continue;
+        }
+        if (daySnap.get('revealedAt') != null) {
+          // Both answered already — between local midnight and local 08:00, which
+          // is rare but legal. There is nothing new to announce.
+          continue;
+        }
+
+        summary.checked += 1;
+        const recipients = await nonAnswerers(db, member.coupleId, member.data.memberUids, dayKey);
+        for (const recipientUid of recipients) {
+          const outcome = await deliverSweepPush(
+            db,
+            messaging,
+            recipientUid,
+            'dailyQuestion',
+            timezone,
+            at,
+          );
+          summary.sent += outcome.sent;
+          summary.skippedNoToken += outcome.skippedNoToken;
+          summary.suppressedQuiet += outcome.suppressedQuiet;
+          summary.failed += outcome.failed;
+        }
+      } catch (error) {
+        // A single corrupt couple (malformed memberUids, read error) is a logged
+        // skip that never fails the sweep — the per-couple error boundary.
+        summary.failed += 1;
+        logger.error('question_rollover: daily-question couple skipped', {
+          coupleId: member.coupleId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+  return summary;
+}

--- a/functions/src/notifications/payload-policy.ts
+++ b/functions/src/notifications/payload-policy.ts
@@ -11,13 +11,13 @@
 // standing audit of the copy surface, but the type signature is the guarantee.
 //
 // Two axes (ADR-012):
-//   - kind: which event (all three localized in TR/AR/EN by the RECIPIENT's
+//   - kind: which event (all FOUR localized in TR/AR/EN by the RECIPIENT's
 //     users.contentLanguage, resolved upstream in recipients.ts).
 //   - discreet: when ON, the payload is fully generic — no partner name, no
 //     event specifics, no streak digits, title is the app name only. Default is
 //     ON in the AR locale (F6); see resolveDiscreet.
 
-export type PushKind = 'partnerAnswered' | 'reveal' | 'streakAtRisk';
+export type PushKind = 'partnerAnswered' | 'reveal' | 'streakAtRisk' | 'dailyQuestion';
 export type PushLanguage = 'tr' | 'ar' | 'en';
 
 export interface PushPayload {
@@ -87,12 +87,76 @@ function revealNormal(language: PushLanguage): PushPayload {
   }
 }
 
-// streakAtRisk is the hour-20 sweep push (ADR-012) to a couple with count > 0
-// whose day is still unrevealed. INVITATIONAL, never shaming (brandkit §8). The
-// count is degraded to a count-free variant when the caller passes no positive
-// streak, so 'undefined' never reaches the copy. AR numeral-noun agreement is
-// approximated with the tamyiz (accusative) form `يومًا`, the single form that
-// reads acceptably across counts in app microcopy; revisit with native review.
+// dailyQuestion is the hour-8 sweep push (ADR-042 D3) — the founder's first ask,
+// verbatim: "It needs to be send new questions at 08.00 TSI with a question."
+//
+// It announces that a question EXISTS. The question itself never travels, and
+// that is structural rather than a copy rule: composePush has no question
+// parameter, so there is nothing here to leak even by mistake.
+//
+// Name-free and streak-free by design. At the couple's local 08:00 the day doc
+// was created eight hours earlier at local midnight and, in the ordinary case,
+// nobody has answered yet — so there is no partner action to report and no
+// streak state worth putting on a lock screen. A caller that passes partnerName
+// or streakCount for this kind is ignored, which the tests pin.
+function dailyQuestionNormal(language: PushLanguage): PushPayload {
+  switch (language) {
+    case 'en':
+      return {
+        title: "Today's question is here",
+        body: 'A new question is waiting in ikimiz. Answer it whenever today suits you.',
+      };
+    case 'tr':
+      return {
+        title: 'Bugünün sorusu geldi',
+        body: 'ikimiz\'de yeni bir soru seni bekliyor. Bugün sana uyan bir vakitte cevapla.',
+      };
+    case 'ar':
+      return {
+        title: 'وصل سؤال اليوم',
+        body: 'سؤال جديد ينتظرك في ikimiz. أجب عنه في الوقت الذي يناسبك اليوم.',
+      };
+  }
+}
+
+// The no-streak afternoon nudge (ADR-042 D4). D4 drops the streak.count > 0 gate
+// so the 16:00 push reaches couples who have no streak at all — which is most
+// couples in week one and every couple that ever broke one. That population is
+// the REASON for the change, so the copy they receive cannot talk about a streak:
+// "your streak is still alive" is simply FALSE for them, and telling someone
+// their streak is alive when they have none is worse than saying nothing.
+//
+// So this is a different message, not a degraded one. It protects the
+// relationship rather than the counter — the founder's own words were "so that
+// your partner dont get angry" — and it stays invitational, never shaming
+// (brandkit §8): it says the day is still open, not that the reader is late.
+function unansweredNudgeNormal(language: PushLanguage): PushPayload {
+  switch (language) {
+    case 'en':
+      return {
+        title: 'Your partner is waiting',
+        body: "Today's question is still open in ikimiz. There is time before the day ends.",
+      };
+    case 'tr':
+      return {
+        title: 'Partnerin seni bekliyor',
+        body: 'Bugünün sorusu ikimiz\'de hâlâ açık. Gün bitmeden vaktin var.',
+      };
+    case 'ar':
+      return {
+        title: 'شريكك بانتظارك',
+        body: 'سؤال اليوم ما زال مفتوحًا في ikimiz. لديك وقت قبل أن ينتهي اليوم.',
+      };
+  }
+}
+
+// streakAtRisk with a live streak is the hour-16 sweep push (ADR-012 D3, re-pointed
+// from hour 20 by ADR-042 D4) to a couple whose day is still unrevealed.
+// INVITATIONAL, never shaming (brandkit §8). Without a positive count it falls
+// through to unansweredNudgeNormal above rather than to a streak-free variant of
+// streak copy. AR numeral-noun agreement is approximated with the tamyiz
+// (accusative) form `يومًا`, the single form that reads acceptably across counts in
+// app microcopy; revisit with native review.
 function streakAtRiskNormal(language: PushLanguage, streakCount?: number): PushPayload {
   const count =
     typeof streakCount === 'number' && Number.isFinite(streakCount) && streakCount > 0
@@ -108,14 +172,9 @@ function streakAtRiskNormal(language: PushLanguage, streakCount?: number): PushP
         return { title: 'حافِظا على تتابعكما', body: `تتابعكما بلغ ${count} يومًا. أجيبا عن سؤال اليوم في ikimiz قبل منتصف الليل لتحافظا عليه.` };
     }
   }
-  switch (language) {
-    case 'en':
-      return { title: 'Keep your streak going', body: `Your streak together is still alive. Answer today's question in ikimiz before midnight to keep it.` };
-    case 'tr':
-      return { title: 'Serinizi sürdürün', body: 'Seriniz hâlâ sürüyor. Gece yarısından önce ikimiz\'de bugünün sorusunu cevaplayıp devam ettirin.' };
-    case 'ar':
-      return { title: 'حافِظا على تتابعكما', body: 'تتابعكما ما زال مستمرًا. أجيبا عن سؤال اليوم في ikimiz قبل منتصف الليل لتحافظا عليه.' };
-  }
+  // No live streak: a DIFFERENT message, not a streak message with the digits
+  // removed. See unansweredNudgeNormal for why that distinction is load-bearing.
+  return unansweredNudgeNormal(language);
 }
 
 /**
@@ -141,5 +200,9 @@ export function composePush(input: {
       return revealNormal(input.language);
     case 'streakAtRisk':
       return streakAtRiskNormal(input.language, input.streakCount);
+    case 'dailyQuestion':
+      // partnerName and streakCount are deliberately not forwarded: at 08:00
+      // there is no partner action and no streak state worth announcing.
+      return dailyQuestionNormal(input.language);
   }
 }

--- a/functions/src/notifications/sweep-push.ts
+++ b/functions/src/notifications/sweep-push.ts
@@ -1,0 +1,142 @@
+// The delivery half shared by every push pass that rides the hourly sweep
+// (ADR-012 D3, ADR-042 D3/D4). Extracted from at-risk.ts when the daily-question
+// pass arrived: the two passes differ in WHICH couples they select and WHICH kind
+// they compose, and in nothing else. Duplicating the recipient resolution, the
+// quiet-hours guard and the per-token error boundary would have left two copies of
+// the code that decides whether a lock screen leaks — and only one of them would
+// get the next fix.
+//
+// NOTHING here throws. A push that cannot go out must never fail a sweep whose
+// real job is assigning tomorrow's question.
+import { Firestore } from 'firebase-admin/firestore';
+import { logger } from 'firebase-functions';
+
+import { isQuietLocalHour, localHour } from './local-hour';
+import type { MessagingPort } from './messaging-port';
+import { PushKind, composePush } from './payload-policy';
+import {
+  contentLanguageOf,
+  fcmTokensOf,
+  notificationPrivacyOf,
+  resolveDiscreet,
+} from './recipients';
+
+/** Terminal state of one recipient's best-effort send; every field is a summary increment. */
+export interface SweepPushOutcome {
+  status: 'sent' | 'no-tokens' | 'suppressed-quiet-hours' | 'send-failed';
+  sent: number;
+  skippedNoToken: number;
+  suppressedQuiet: number;
+  failed: number;
+}
+
+/**
+ * Resolve one recipient and best-effort send `kind`. Every branch short of a
+ * delivered send is a TYPED, LOGGED skip whose numeric fields the caller folds
+ * straight into its summary (no per-status switch, so aggregation stays
+ * branch-free). `at` is the sweep instant, used as the clock for the quiet-hours
+ * guard.
+ *
+ * The quiet-hours check is DEFENSE IN DEPTH, and it is the reason this function
+ * takes the timezone rather than trusting its caller: each pass already gates on
+ * its own local hour, but the delivery function must be unable to emit inside
+ * 22:00–08:00 no matter who calls it or from which pass. That guard is load-bearing
+ * for the daily-question pass in particular, which fires at hour 8 — the first
+ * legal hour of the day, one hour off the boundary in the direction that would
+ * silently suppress the entire feature.
+ */
+export async function deliverSweepPush(
+  db: Firestore,
+  messaging: MessagingPort,
+  recipientUid: string,
+  kind: PushKind,
+  timezone: string,
+  at: Date,
+  options: { streakCount?: number } = {},
+): Promise<SweepPushOutcome> {
+  const base = { sent: 0, skippedNoToken: 0, suppressedQuiet: 0, failed: 0 } as const;
+  try {
+    const userSnap = await db.collection('users').doc(recipientUid).get();
+    // A missing user doc and an empty/junk fcmTokens field collapse to the same
+    // "nothing to send to" skip (ADR-012: fcmTokensOf → [] on absent/malformed).
+    const userData = userSnap.exists ? userSnap.data() : undefined;
+    const tokens = fcmTokensOf(userData);
+    if (tokens.length === 0) {
+      logger.warn('question_rollover: sweep push skipped, no fcm tokens', { recipientUid, kind });
+      return { ...base, status: 'no-tokens', skippedNoToken: 1 };
+    }
+
+    if (isQuietLocalHour(localHour(at, timezone))) {
+      logger.info('question_rollover: sweep push suppressed, couple-local quiet hours', {
+        recipientUid,
+        kind,
+      });
+      return { ...base, status: 'suppressed-quiet-hours', suppressedQuiet: 1 };
+    }
+
+    const language = contentLanguageOf(userData);
+    // No question/answer text EVER leaves in a payload (ADR-012 F6, structural —
+    // composePush has no such parameter); discreet mode defaults ON for AR.
+    const payload = composePush({
+      kind,
+      language,
+      discreet: resolveDiscreet(language, notificationPrivacyOf(userData)),
+      streakCount: options.streakCount,
+    });
+
+    let sent = 0;
+    let failed = 0;
+    for (const token of tokens) {
+      try {
+        await messaging.send({ token, title: payload.title, body: payload.body });
+        sent += 1;
+      } catch (error) {
+        failed += 1;
+        logger.error('question_rollover: sweep push send failed', {
+          recipientUid,
+          kind,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    return { ...base, status: sent > 0 ? 'sent' : 'send-failed', sent, failed };
+  } catch (error) {
+    // Any unexpected failure resolving the recipient (a corrupt uid path segment,
+    // a read error): the sweep must survive it as counted noise, never a throw.
+    logger.error('question_rollover: sweep push delivery errored', {
+      recipientUid,
+      kind,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { ...base, status: 'send-failed', failed: 1 };
+  }
+}
+
+/**
+ * The members of `memberUids` who have NOT answered on `dayKey`.
+ *
+ * Reads BOTH answer docs in one round trip, for an ELIGIBLE couple only — O(1)
+ * reads per eligible couple per pass. memberUids is the M2.3 join Function's write
+ * (a 2-element uid array); anything else is corrupt state the caller turns into a
+ * per-couple skip.
+ */
+export async function nonAnswerers(
+  db: Firestore,
+  coupleId: string,
+  memberUids: unknown,
+  dayKey: string,
+): Promise<string[]> {
+  if (!Array.isArray(memberUids) || !memberUids.every((u): u is string => typeof u === 'string')) {
+    throw new Error(`couple ${coupleId}: malformed memberUids`);
+  }
+  const answersCol = db
+    .collection('couples')
+    .doc(coupleId)
+    .collection('days')
+    .doc(dayKey)
+    .collection('answers');
+  const snaps = await db.getAll(...memberUids.map((uid) => answersCol.doc(uid)));
+  // Match by doc id, not array position — getAll order is not a contract to lean on.
+  const answered = new Set(snaps.filter((s) => s.exists).map((s) => s.id));
+  return memberUids.filter((uid) => !answered.has(uid));
+}

--- a/functions/src/rollover/question-rollover.ts
+++ b/functions/src/rollover/question-rollover.ts
@@ -13,6 +13,7 @@ import { ScheduledEvent, onSchedule } from 'firebase-functions/v2/scheduler';
 import { FUNCTIONS_REGION } from '../invites/create-invite';
 import { FcmMessagingPort } from '../notifications/fcm-adapter';
 import { AtRiskSummary, runStreakAtRisk } from '../notifications/at-risk';
+import { DailyQuestionSummary, runDailyQuestion } from '../notifications/daily-question';
 import type { MessagingPort } from '../notifications/messaging-port';
 import {
   CoupleBuckets,
@@ -30,13 +31,20 @@ export interface QuestionRolloverDeps {
   bucket?: (db: Firestore) => Promise<CoupleBuckets>;
   /** The assignment pass over the shared buckets (create-if-absent day docs). */
   run?: (db: Firestore, at: Date, buckets: CoupleBuckets) => Promise<RolloverSummary>;
-  /** The at-risk push pass over the shared buckets (hour-20, ADR-012 D3). */
+  /** The unanswered-day nudge over the shared buckets (hour-16 since ADR-042 D4). */
   atRisk?: (
     db: Firestore,
     at: Date,
     buckets: CoupleBuckets,
     messaging: MessagingPort,
   ) => Promise<AtRiskSummary>;
+  /** The daily-question announcement over the shared buckets (hour-8, ADR-042 D3). */
+  dailyQuestion?: (
+    db: Firestore,
+    at: Date,
+    buckets: CoupleBuckets,
+    messaging: MessagingPort,
+  ) => Promise<DailyQuestionSummary>;
   /** The push send seam (FCM has no emulator, so tests inject a fake — ADR-012 D3). */
   messaging?: MessagingPort;
   now?: () => Date;
@@ -51,6 +59,7 @@ export function makeQuestionRolloverHandler(
     // buckets go in the 4th. atRisk forwards the injected messaging port.
     run = (db, at, buckets) => runQuestionRollover(db, at, undefined, buckets),
     atRisk = (db, at, buckets, messaging) => runStreakAtRisk(db, at, messaging, buckets),
+    dailyQuestion = (db, at, buckets, messaging) => runDailyQuestion(db, at, messaging, buckets),
     messaging = new FcmMessagingPort(),
     now = () => new Date(),
   } = deps;
@@ -92,10 +101,29 @@ export function makeQuestionRolloverHandler(
       throw error;
     }
 
-    // At-risk push pass (ADR-012 D3, piggybacked): fully ISOLATED and best-effort —
-    // a failure here must never fail the assignment run (a missed nudge is recovered
-    // next day; an unassigned question is not). Per-couple/per-send failures are
-    // logged+counted inside; a systemic throw is swallowed with a loud log.
+    // The two push passes (ADR-012 D3, ADR-042 D3/D4), piggybacked on the SAME
+    // buckets: hour-8 announces the new question, hour-16 nudges an unanswered day.
+    // Both are fully ISOLATED and best-effort — a failure in either must never fail
+    // the assignment run (a missed push is recovered tomorrow; an unassigned
+    // question is not) and must not stop the other from running.
+    //
+    // They are mutually exclusive in practice — a bucket reads either 8 or 16, never
+    // both — so running both every sweep costs one no-op iteration over the buckets,
+    // not a second set of reads. Gating one on the other's hour would move the hour
+    // policy out of the passes that own it and into the handler.
+    try {
+      const dailySummary = await dailyQuestion(db, at, buckets, messaging);
+      logger.info('question_rollover: daily-question sweep complete', {
+        at: at.toISOString(),
+        ...dailySummary,
+      });
+    } catch (error) {
+      logger.error('question_rollover: daily-question sweep failed (isolated)', {
+        at: at.toISOString(),
+        error: errorMessage(error),
+      });
+    }
+
     try {
       const atRiskSummary = await atRisk(db, at, buckets, messaging);
       logger.info('question_rollover: at-risk sweep complete', { at: at.toISOString(), ...atRiskSummary });

--- a/functions/test/emulator/at-risk.test.ts
+++ b/functions/test/emulator/at-risk.test.ts
@@ -1,8 +1,16 @@
-// M3.4 streak-at-risk push pass against the firestore emulator (docs/resume-prompt
-// Session 014, ADR-012 Decision 3). Proven at the SERVICE level (the M3.2 pattern):
-// the hour-20 gate (once per zone per day, sub-hour zones included), the
-// eligibility rule (streak > 0 AND today's day doc unrevealed), non-answerer
-// recipient selection, and the best-effort send policy behind the injected port.
+// The unanswered-day nudge against the firestore emulator (ADR-012 D3, RE-POINTED
+// by ADR-042 D4). Proven at the SERVICE level (the M3.2 pattern): the hour gate
+// (once per zone per day, sub-hour zones included), the eligibility rule,
+// non-answerer recipient selection, and the best-effort send policy behind the
+// injected port.
+//
+// ⚠️ ADR-042 D4 changed two things this suite used to pin, on purpose:
+//   * the hour moved 20 → 16, because the founder asked for 16:00;
+//   * the `streak.count > 0` gate is GONE, because the nudge now protects a
+//     RELATIONSHIP rather than a streak and must reach couples who have neither.
+// The tests that asserted the old rules were not relaxed — they were INVERTED to
+// assert the new ones, so the zero-streak case is still covered, just with the
+// opposite expectation.
 //
 // The pass is driven off the SAME timezone bucketing the assignment pass uses
 // (bucketCouplesByTimezone) — that shared read is the ADR-012 D3 hard constraint,
@@ -31,12 +39,12 @@ const UID_B = 'uid-b';
 const TZ = 'Europe/Istanbul';
 const DAY_KEY = '20260710';
 
-// 2026-07-10T17:00:00Z: Istanbul (+03) reads 20:00 → the at-risk sweep fires;
-// New York (EDT −04) reads 13:00 at the SAME instant → it does not.
-const AT = new Date('2026-07-10T17:00:00Z');
-// Asia/Kathmandu is +05:45: 15:00Z reads 20:45 → the sub-hour zone catches its
-// hour-20 sweep on the same run its local clock crosses 20:xx.
-const KTM_AT = new Date('2026-07-10T15:00:00Z');
+// 2026-07-10T13:00:00Z: Istanbul (+03) reads 16:00 → the nudge fires;
+// New York (EDT −04) reads 09:00 at the SAME instant → it does not.
+const AT = new Date('2026-07-10T13:00:00Z');
+// Asia/Kathmandu is +05:45: 11:00Z reads 16:45 → the sub-hour zone catches its
+// hour-16 sweep on the same run its local clock crosses 16:xx.
+const KTM_AT = new Date('2026-07-10T11:00:00Z');
 // Istanbul 23:00 — inside the 22:00–08:00 quiet window (defense-in-depth check).
 const QUIET_AT = new Date('2026-07-10T20:00:00Z');
 
@@ -94,12 +102,12 @@ beforeEach(async () => {
   await clearNoTriggerFirestore();
 });
 
-describe('runStreakAtRisk — hour-20 gate (ADR-012 D3)', () => {
-  it('AT_RISK_LOCAL_HOUR is 20', () => {
-    expect(AT_RISK_LOCAL_HOUR).toBe(20);
+describe('runStreakAtRisk — hour-16 gate (ADR-042 D4)', () => {
+  it('AT_RISK_LOCAL_HOUR is 16 — the hour the founder asked for, not the streak hour', () => {
+    expect(AT_RISK_LOCAL_HOUR).toBe(16);
   });
 
-  it('fires ONLY for the bucket at couple-local hour 20; a same-instant off-20 zone and a corrupt zone are untouched', async () => {
+  it('fires ONLY for the bucket at couple-local hour 16; a same-instant off-16 zone and a corrupt zone are untouched', async () => {
     await seedCouple('ist', { timezone: 'Europe/Istanbul', streak: streakOf(3) });
     await seedDay('ist');
     await seedUser(UID_A);
@@ -128,19 +136,19 @@ describe('runStreakAtRisk — hour-20 gate (ADR-012 D3)', () => {
     expect(port.sent.map((m) => m.token).sort()).toEqual([`tok-${UID_A}`, `tok-${UID_B}`]);
   });
 
-  it('a sub-hour-offset zone (Asia/Kathmandu +05:45) fires at its 20:45 sweep, not at a 22:45 one', async () => {
+  it('a sub-hour-offset zone (Asia/Kathmandu +05:45) fires at its 16:45 sweep', async () => {
     await seedCouple('ktm', { timezone: 'Asia/Kathmandu', streak: streakOf(4) });
     await seedDay('ktm');
     await seedUser(UID_A);
     await seedUser(UID_B);
     const buckets = await bucketCouplesByTimezone(db);
 
-    // At AT (17:00Z) Kathmandu is 22:45 (hour 22) → nothing.
+    // At AT (13:00Z) Kathmandu is 18:45 (hour 18) → nothing.
     const offSummary = await runStreakAtRisk(db, AT, new FakeMessagingPort(), buckets);
     expect(offSummary.checked).toBe(0);
     expect(offSummary.sent).toBe(0);
 
-    // At KTM_AT (15:00Z) Kathmandu is 20:45 (hour 20) → fires.
+    // At KTM_AT (11:00Z) Kathmandu is 16:45 (hour 16) → fires.
     const port = new FakeMessagingPort();
     const summary = await runStreakAtRisk(db, KTM_AT, port, buckets);
     expect(summary.checked).toBe(1);
@@ -199,34 +207,74 @@ describe('runStreakAtRisk — eligibility & recipient selection', () => {
     expect(port.sent).toHaveLength(0);
   });
 
-  it('a zero-count streak has nothing to lose → nothing', async () => {
+  // ADR-042 D4 INVERTED these two. They used to assert that a couple with no
+  // streak gets nothing — "nothing to lose". That was the streak feature's rule.
+  // The founder's nudge protects the relationship, so a couple with no streak is
+  // precisely who it is for: week-one couples, and every couple that ever broke
+  // one. The tests were not deleted when the rule flipped; they were flipped, so
+  // the case stays covered with the opposite expectation.
+  it('a zero-count streak is STILL nudged — the nudge protects the relationship, not the counter', async () => {
     await seedCouple('ist', { streak: { count: 0, lastMutualDate: null, graceTokens: 1 } });
     await seedDay('ist');
     await seedUser(UID_A);
+    await seedUser(UID_B);
 
     const buckets = await bucketCouplesByTimezone(db);
     const port = new FakeMessagingPort();
     const summary = await runStreakAtRisk(db, AT, port, buckets);
 
-    expect(summary.checked).toBe(0);
-    expect(summary.sent).toBe(0);
-    expect(port.sent).toHaveLength(0);
+    expect(summary.checked).toBe(1);
+    expect(summary.sent).toBe(2);
   });
 
-  it('an absent streak field reads as zero → nothing', async () => {
+  it('an absent streak field is STILL nudged (a week-one couple has no streak field at all)', async () => {
     await seedCouple('ist'); // no streak field
     await seedDay('ist');
     await seedUser(UID_A);
+    await seedUser(UID_B);
 
     const buckets = await bucketCouplesByTimezone(db);
     const port = new FakeMessagingPort();
     const summary = await runStreakAtRisk(db, AT, port, buckets);
 
-    expect(summary.checked).toBe(0);
-    expect(summary.sent).toBe(0);
+    expect(summary.checked).toBe(1);
+    expect(summary.sent).toBe(2);
   });
 
-  it('streak > 0 but NO day doc → a SEPARATE skippedNoDay skip (rollover failed earlier), nothing sent', async () => {
+  // The copy consequence of dropping the gate: a streakless couple must not be
+  // told their streak is alive. composePush owns this; asserted here end-to-end
+  // because the wrong copy is the failure a user would actually see.
+  it('a streakless couple gets the relationship copy, never a streak claim', async () => {
+    await seedCouple('ist'); // no streak
+    await seedDay('ist');
+    await seedUser(UID_A);
+    await seedUser(UID_B);
+
+    const buckets = await bucketCouplesByTimezone(db);
+    const port = new FakeMessagingPort();
+    await runStreakAtRisk(db, AT, port, buckets);
+
+    expect(port.sent).not.toHaveLength(0);
+    for (const message of port.sent) {
+      expect(message.body.toLowerCase()).not.toContain('streak');
+      expect(message.title.toLowerCase()).not.toContain('streak');
+    }
+  });
+
+  it('a couple WITH a streak still gets the streak copy — nothing was lost', async () => {
+    await seedCouple('ist', { streak: streakOf(7) });
+    await seedDay('ist');
+    await seedUser(UID_A);
+    await seedUser(UID_B);
+
+    const buckets = await bucketCouplesByTimezone(db);
+    const port = new FakeMessagingPort();
+    await runStreakAtRisk(db, AT, port, buckets);
+
+    expect(port.sent[0].body).toContain('7');
+  });
+
+  it('NO day doc → a SEPARATE skippedNoDay skip (rollover failed earlier), nothing sent', async () => {
     await seedCouple('ist', { streak: streakOf(3) }); // no day doc seeded
     await seedUser(UID_A);
 

--- a/functions/test/emulator/daily-question.test.ts
+++ b/functions/test/emulator/daily-question.test.ts
@@ -1,0 +1,317 @@
+// The hour-8 daily-question push pass (ADR-042 D3) — the founder's first ask:
+// "It needs to be send new questions at 08.00 TSI with a question."
+//
+// Two things this suite exists to pin, beyond the ordinary eligibility rules:
+//
+//   1. **08:00 sits exactly on the quiet-hours boundary.** `isQuietLocalHour` is
+//      `hour >= 22 || hour < 8` — right-open, so hour 8 is the FIRST legal hour of
+//      the day and this push is the first thing allowed. An off-by-one in either
+//      direction silently suppresses the entire feature with every other test
+//      green, so the boundary is asserted here in both directions and
+//      mutation-checked in the session log.
+//   2. **Zero additional couples reads.** The pass iterates the SAME CoupleBuckets
+//      the assignment pass used. ADR-012 D3's hard constraint is one couples read
+//      per sweep and ADR-042 does not amend it.
+import { Firestore, Timestamp } from 'firebase-admin/firestore';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  DAILY_QUESTION_LOCAL_HOUR,
+  runDailyQuestion,
+} from '../../src/notifications/daily-question';
+import { isQuietLocalHour } from '../../src/notifications/local-hour';
+import type { BucketedCouple, CoupleBuckets } from '../../src/rollover/rollover-service';
+import { FakeMessagingPort } from '../support/fake-messaging-port';
+import { clearNoTriggerFirestore, noTriggerFirestore } from '../support/admin';
+
+const db: Firestore = noTriggerFirestore();
+
+const TZ = 'Europe/Istanbul';
+const CID = 'dq-couple';
+const UID_A = 'dq-a';
+const UID_B = 'dq-b';
+
+// 2026-07-09T05:00:00Z is 08:00 in Europe/Istanbul (UTC+3) — the hour under test.
+const AT_08 = new Date('2026-07-09T05:00:00Z');
+// 07:00 local — one hour EARLIER, and inside quiet hours. If the boundary ever
+// moves the wrong way this is the instant that starts delivering.
+const AT_07 = new Date('2026-07-09T04:00:00Z');
+// 09:00 local — one hour later, legal but not this pass's hour.
+const AT_09 = new Date('2026-07-09T06:00:00Z');
+const DAY_KEY = '20260709';
+
+// The buckets are built by hand exactly as bucketCouplesByTimezone would produce
+// them, then handed in — the same posture the at-risk suite uses, and the reason
+// this pass can be proven to add zero couples reads.
+function bucketed(coupleId: string, memberUids: unknown): BucketedCouple {
+  return {
+    coupleId,
+    packId: 'solo_tr',
+    data: { memberUids } as BucketedCouple['data'],
+  } as BucketedCouple;
+}
+
+function buckets(entries: Array<[string, BucketedCouple[]]>): CoupleBuckets {
+  return { buckets: new Map(entries), skips: [] };
+}
+
+const oneCouple = (timezone = TZ) =>
+  buckets([[timezone, [bucketed(CID, [UID_A, UID_B])]]]);
+
+async function seedUser(uid: string, extra: Record<string, unknown> = {}): Promise<void> {
+  await db.collection('users').doc(uid).set({ fcmTokens: [`token-${uid}`], ...extra });
+}
+
+async function seedDay(fields: Record<string, unknown> = {}): Promise<void> {
+  await db
+    .collection('couples')
+    .doc(CID)
+    .collection('days')
+    .doc(DAY_KEY)
+    .set({ questionId: 'q1', ...fields });
+}
+
+async function seedAnswer(uid: string): Promise<void> {
+  await db
+    .collection('couples')
+    .doc(CID)
+    .collection('days')
+    .doc(DAY_KEY)
+    .collection('answers')
+    .doc(uid)
+    .set({ text: 'x' });
+}
+
+beforeEach(async () => {
+  await clearNoTriggerFirestore();
+  await seedUser(UID_A);
+  await seedUser(UID_B);
+});
+
+describe('the 08:00 boundary — the thing most likely to silently kill this feature', () => {
+  it('DAILY_QUESTION_LOCAL_HOUR is 8', () => {
+    expect(DAILY_QUESTION_LOCAL_HOUR).toBe(8);
+  });
+
+  // The two assertions that matter, stated as the policy rather than as arithmetic.
+  it('hour 8 is NOT quiet, and hour 7 IS — the push sits one minute inside the legal day', () => {
+    expect(isQuietLocalHour(DAILY_QUESTION_LOCAL_HOUR)).toBe(false);
+    expect(isQuietLocalHour(DAILY_QUESTION_LOCAL_HOUR - 1)).toBe(true);
+  });
+
+  it('hour 22 IS quiet — the other end of the window, so a widening cannot pass unnoticed', () => {
+    expect(isQuietLocalHour(22)).toBe(true);
+    expect(isQuietLocalHour(21)).toBe(false);
+  });
+
+  it('fires at the couple-local 08:00 sweep', async () => {
+    await seedDay();
+    const port = new FakeMessagingPort();
+
+    const summary = await runDailyQuestion(db, AT_08, port, oneCouple());
+
+    expect(summary.sent).toBe(2);
+    expect(port.sent).toHaveLength(2);
+  });
+
+  it('does NOT fire at 07:00 — and if the boundary ever moves, the quiet guard still catches it', async () => {
+    await seedDay();
+    const port = new FakeMessagingPort();
+
+    const summary = await runDailyQuestion(db, AT_07, port, oneCouple());
+
+    expect(summary.sent).toBe(0);
+    expect(port.sent).toHaveLength(0);
+  });
+
+  it('does NOT fire at 09:00 — once per zone per day, not every legal hour', async () => {
+    await seedDay();
+    const port = new FakeMessagingPort();
+
+    const summary = await runDailyQuestion(db, AT_09, port, oneCouple());
+
+    expect(summary.sent).toBe(0);
+  });
+
+  it('a same-instant off-8 zone is untouched, and a corrupt zone is skipped not thrown', async () => {
+    await seedDay();
+    const port = new FakeMessagingPort();
+
+    // At AT_08, Istanbul reads 08:00 and London reads 06:00.
+    const summary = await runDailyQuestion(
+      db,
+      AT_08,
+      port,
+      buckets([
+        [TZ, [bucketed(CID, [UID_A, UID_B])]],
+        ['Europe/London', [bucketed('other', ['x', 'y'])]],
+        ['Not/AZone', [bucketed('corrupt', ['p', 'q'])]],
+      ]),
+    );
+
+    expect(summary.sent).toBe(2);
+  });
+
+  it('a sub-hour-offset zone (Asia/Kathmandu +05:45) fires on its 08:45 sweep', async () => {
+    await seedDay();
+    const port = new FakeMessagingPort();
+    // 03:00Z is 08:45 in Kathmandu.
+    const summary = await runDailyQuestion(
+      db,
+      new Date('2026-07-09T03:00:00Z'),
+      port,
+      oneCouple('Asia/Kathmandu'),
+    );
+
+    expect(summary.sent).toBe(2);
+  });
+});
+
+describe('eligibility and recipient selection', () => {
+  it('nobody answered → announces to BOTH members', async () => {
+    await seedDay();
+    const port = new FakeMessagingPort();
+
+    const summary = await runDailyQuestion(db, AT_08, port, oneCouple());
+
+    expect(summary.checked).toBe(1);
+    expect(summary.sent).toBe(2);
+    expect(port.sent.map((m) => m.token).sort()).toEqual([`token-${UID_A}`, `token-${UID_B}`]);
+  });
+
+  // An early bird who already answered does not need to be told a question exists.
+  it('one already answered → announces ONLY to the other', async () => {
+    await seedDay();
+    await seedAnswer(UID_A);
+    const port = new FakeMessagingPort();
+
+    const summary = await runDailyQuestion(db, AT_08, port, oneCouple());
+
+    expect(summary.sent).toBe(1);
+    expect(port.sent[0].token).toBe(`token-${UID_B}`);
+  });
+
+  it('an already-revealed day announces nothing', async () => {
+    await seedDay({ revealedAt: Timestamp.now() });
+    const port = new FakeMessagingPort();
+
+    const summary = await runDailyQuestion(db, AT_08, port, oneCouple());
+
+    expect(summary.sent).toBe(0);
+    expect(summary.checked).toBe(0);
+  });
+
+  // Rollover runs at local midnight and this pass at local 08:00, so a missing day
+  // doc means assignment failed eight hours earlier. There is no question to
+  // announce — a separate, countable state, never a push about nothing.
+  it('NO day doc → a counted skippedNoDay, and nothing sent', async () => {
+    const port = new FakeMessagingPort();
+
+    const summary = await runDailyQuestion(db, AT_08, port, oneCouple());
+
+    expect(summary.skippedNoDay).toBe(1);
+    expect(summary.sent).toBe(0);
+  });
+
+  it('unlike the at-risk pass, a couple with NO streak still gets it', async () => {
+    await seedDay();
+    const port = new FakeMessagingPort();
+
+    // No streak field anywhere — the daily question is not a streak feature.
+    const summary = await runDailyQuestion(db, AT_08, port, oneCouple());
+
+    expect(summary.sent).toBe(2);
+  });
+});
+
+describe('failure isolation — a sweep must survive every couple', () => {
+  it('a recipient with no fcm token is a loud skippedNoToken', async () => {
+    await seedDay();
+    await db.collection('users').doc(UID_A).set({});
+    const port = new FakeMessagingPort();
+
+    const summary = await runDailyQuestion(db, AT_08, port, oneCouple());
+
+    expect(summary.skippedNoToken).toBe(1);
+    expect(summary.sent).toBe(1);
+  });
+
+  it('a corrupt couple (malformed memberUids) is a counted failure, never a throw', async () => {
+    await seedDay();
+    const port = new FakeMessagingPort();
+
+    const summary = await runDailyQuestion(
+      db,
+      AT_08,
+      port,
+      buckets([[TZ, [bucketed(CID, 'not-an-array')]]]),
+    );
+
+    expect(summary.failed).toBe(1);
+    expect(summary.sent).toBe(0);
+  });
+
+  it('one couple failing does not stop the next couple in the same bucket', async () => {
+    await seedDay();
+    await db
+      .collection('couples')
+      .doc('dq-couple-2')
+      .collection('days')
+      .doc(DAY_KEY)
+      .set({ questionId: 'q2' });
+    await seedUser('dq-c');
+    await seedUser('dq-d');
+    const port = new FakeMessagingPort();
+
+    const summary = await runDailyQuestion(
+      db,
+      AT_08,
+      port,
+      buckets([
+        [TZ, [bucketed(CID, 'not-an-array'), bucketed('dq-couple-2', ['dq-c', 'dq-d'])]],
+      ]),
+    );
+
+    expect(summary.failed).toBe(1);
+    expect(summary.sent).toBe(2);
+  });
+
+  it('every token failing is swallowed and counted, never thrown', async () => {
+    await seedDay();
+    const port = new FakeMessagingPort();
+    port.failOn(`token-${UID_A}`);
+    port.failOn(`token-${UID_B}`);
+
+    const summary = await runDailyQuestion(db, AT_08, port, oneCouple());
+
+    expect(summary.sent).toBe(0);
+    expect(summary.failed).toBe(2);
+  });
+});
+
+describe('the read budget (ADR-012 D3 — not amended by ADR-042)', () => {
+  it('reads NO couples collection at all — it rides the buckets it was handed', async () => {
+    await seedDay();
+    const port = new FakeMessagingPort();
+    let couplesCollectionReads = 0;
+    const spied = new Proxy(db, {
+      get(target, prop, receiver) {
+        if (prop === 'collection') {
+          return (path: string) => {
+            if (path === 'couples') couplesCollectionReads += 1;
+            return (target as Firestore).collection(path);
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    }) as Firestore;
+
+    await runDailyQuestion(spied, AT_08, port, oneCouple());
+
+    // `collection('couples')` is used to REACH a known couple's day doc by id,
+    // which is a document read; what must never happen is a .get() on the
+    // collection itself. The pass takes its couple list from the buckets.
+    expect(couplesCollectionReads).toBeGreaterThan(0);
+    expect(await db.collection('couples').get().then((s) => s.size)).toBe(0);
+  });
+});

--- a/functions/test/emulator/question-rollover-handler.test.ts
+++ b/functions/test/emulator/question-rollover-handler.test.ts
@@ -16,7 +16,10 @@ import { FakeMessagingPort } from '../support/fake-messaging-port';
 // 2026-07-10T17:00:00Z reads 20:00 in Istanbul — the couple-local hour the
 // piggybacked at-risk pass fires on (ADR-012 D3). SCHEDULE_TIME (02:00Z, 05:00
 // local) is off-hour, so the existing sweeps above never trip the at-risk pass.
-const AT_RISK_TIME = '2026-07-10T17:00:00Z';
+// 13:00Z is 16:00 in Europe/Istanbul — the nudge hour since ADR-042 D4 (was 20).
+const AT_RISK_TIME = '2026-07-10T13:00:00Z';
+// 05:00Z is 08:00 in Europe/Istanbul — the daily-question hour (ADR-042 D3).
+const DAILY_QUESTION_TIME = '2026-07-10T05:00:00Z';
 
 const db = adminFirestore();
 const couples = db.collection('couples');
@@ -108,7 +111,7 @@ describe('makeQuestionRolloverHandler', () => {
     await expect(handler(scheduledEvent(SCHEDULE_TIME))).rejects.toThrow('couples unlistable');
   });
 
-  it('drives both passes off one couples read: logs the assignment AND at-risk summaries, sends at-risk pushes at hour 20', async () => {
+  it('drives all three passes off ONE couples read: logs every summary, and nudges at hour 16', async () => {
     // A couple mid-streak with today's day doc still unrevealed and no answers yet
     // → both members are at-risk recipients. No answer docs are seeded, so the live
     // answerReveal trigger never fires here.
@@ -143,6 +146,72 @@ describe('makeQuestionRolloverHandler', () => {
       'question_rollover: at-risk sweep complete',
       expect.objectContaining({ checked: 1, sent: 2 }),
     );
+    // The third pass ran too and found nothing to do at 16:00 — ADR-012 D3's ONE
+    // couples read is shared by all three, so a pass that has no work still logs.
+    expect(infoSpy).toHaveBeenCalledWith(
+      'question_rollover: daily-question sweep complete',
+      expect.objectContaining({ checked: 0, sent: 0 }),
+    );
+    infoSpy.mockRestore();
+  });
+
+  // ADR-042 D3. Same shared buckets, different hour, different kind.
+  it('announces the daily question at hour 8, off the SAME single couples read', async () => {
+    await couples.doc('ist').set({
+      memberUids: ['uid-a', 'uid-b'],
+      timezone: 'Europe/Istanbul',
+      createdAt: Timestamp.now(),
+    });
+    await couples.doc('ist').collection('days').doc('20260710').set({
+      questionId: 'solo_tr_001',
+      packId: 'solo_tr',
+      packVersion: 1,
+      assignedAt: Timestamp.now(),
+    });
+    await db.collection('users').doc('uid-a').set({ contentLanguage: 'en', fcmTokens: ['tok-a'] });
+    await db.collection('users').doc('uid-b').set({ contentLanguage: 'en', fcmTokens: ['tok-b'] });
+
+    const port = new FakeMessagingPort();
+    const infoSpy = vi.spyOn(logger, 'info');
+    const handler = makeQuestionRolloverHandler({ messaging: port });
+
+    await handler(scheduledEvent(DAILY_QUESTION_TIME));
+
+    expect(port.sent.map((m) => m.token).sort()).toEqual(['tok-a', 'tok-b']);
+    expect(infoSpy).toHaveBeenCalledWith(
+      'question_rollover: daily-question sweep complete',
+      expect.objectContaining({ checked: 1, sent: 2 }),
+    );
+    // And the nudge pass, sharing the same buckets, correctly did nothing at 08:00.
+    expect(infoSpy).toHaveBeenCalledWith(
+      'question_rollover: at-risk sweep complete',
+      expect.objectContaining({ checked: 0, sent: 0 }),
+    );
+    infoSpy.mockRestore();
+  });
+
+  it('isolates a daily-question failure from BOTH the assignment run and the nudge pass', async () => {
+    await seedCouple('ist', 'Europe/Istanbul');
+    const errorSpy = vi.spyOn(logger, 'error');
+    const infoSpy = vi.spyOn(logger, 'info');
+    const handler = makeQuestionRolloverHandler({
+      dailyQuestion: async () => {
+        throw new Error('daily boom');
+      },
+    });
+
+    await expect(handler(scheduledEvent(DAILY_QUESTION_TIME))).resolves.toBeUndefined();
+    expect((await couples.doc('ist').collection('days').doc('20260710').get()).exists).toBe(true);
+    expect(errorSpy).toHaveBeenCalledWith(
+      'question_rollover: daily-question sweep failed (isolated)',
+      expect.objectContaining({ error: 'daily boom' }),
+    );
+    // The nudge pass still ran — one push pass throwing must not silence the other.
+    expect(infoSpy).toHaveBeenCalledWith(
+      'question_rollover: at-risk sweep complete',
+      expect.anything(),
+    );
+    errorSpy.mockRestore();
     infoSpy.mockRestore();
   });
 

--- a/functions/test/unit/payload-policy.test.ts
+++ b/functions/test/unit/payload-policy.test.ts
@@ -10,7 +10,7 @@ import { composePush, type PushKind, type PushLanguage } from '../../src/notific
 // enforced by the type signature (composePush has no such parameter) and
 // re-asserted here as a guardrail on the API surface.
 
-const KINDS: readonly PushKind[] = ['partnerAnswered', 'reveal', 'streakAtRisk'];
+const KINDS: readonly PushKind[] = ['partnerAnswered', 'reveal', 'streakAtRisk', 'dailyQuestion'];
 const LANGUAGES: readonly PushLanguage[] = ['tr', 'ar', 'en'];
 
 // Placeholder artifacts that a template bug would leak into the copy.
@@ -38,10 +38,20 @@ describe('composePush', () => {
   });
 
   // ADR-019 D3: the coupleEnded partner-notification is field + in-app notice
-  // only — deliberately NO push. This pins that no fourth PushKind slipped in:
-  // the union is exactly the three shipped kinds (a string-audit on the source,
-  // so a new kind cannot be added without this test going red).
-  it('the PushKind union is unchanged — exactly three kinds, no coupleEnded push (ADR-019 D3)', async () => {
+  // only — deliberately NO push, because it would deliver a proactive real-time
+  // ping to a possibly-abusive partner at the deleting victim's moment of escape.
+  //
+  // THIS TEST CARRIES TWO DIFFERENT THINGS, and they are not equally negotiable.
+  //   * `not.toContain('coupleEnded')` IS the ADR-019 safety invariant. It does
+  //     not change when the vocabulary grows. Do not touch it.
+  //   * the exact-union pin is a CHANGE DETECTOR. It is supposed to redden when a
+  //     kind is added, so that a human reads the line above before proceeding.
+  //
+  // S063 added `dailyQuestion` (ADR-042 D3) and updated the detector to four,
+  // deliberately, having read the invariant. A session that meets this red and
+  // relaxes the test wholesale deletes a DV control while believing it fixed a
+  // test (ADR-042 D5 names this exact hazard).
+  it('the PushKind union is exactly the four shipped kinds, and no coupleEnded push exists (ADR-019 D3)', async () => {
     const { readFileSync } = await import('node:fs');
     const { fileURLToPath } = await import('node:url');
     const source = readFileSync(
@@ -49,11 +59,103 @@ describe('composePush', () => {
       'utf8',
     );
     expect(source).toContain(
-      "export type PushKind = 'partnerAnswered' | 'reveal' | 'streakAtRisk';",
+      "export type PushKind = 'partnerAnswered' | 'reveal' | 'streakAtRisk' | 'dailyQuestion';",
     );
+    // The invariant, not the detector.
     expect(source).not.toContain('coupleEnded');
-    expect(KINDS).toHaveLength(3);
-    expect([...KINDS].sort()).toEqual(['partnerAnswered', 'reveal', 'streakAtRisk']);
+    expect(KINDS).toHaveLength(4);
+    expect([...KINDS].sort()).toEqual([
+      'dailyQuestion',
+      'partnerAnswered',
+      'reveal',
+      'streakAtRisk',
+    ]);
+  });
+
+  // ADR-042 D3. The founder's first ask: "It needs to be send new questions at
+  // 08.00 TSI with a question." The push announces that a question EXISTS; the
+  // question itself never travels — composePush has no question parameter, so
+  // this is structural rather than a copy rule.
+  describe('dailyQuestion (ADR-042 D3)', () => {
+    it('is distinct copy in every language — not a reused streak or reveal body', () => {
+      for (const language of LANGUAGES) {
+        const daily = composePush({ kind: 'dailyQuestion', language, discreet: false });
+        const atRisk = composePush({ kind: 'streakAtRisk', language, discreet: false, streakCount: 3 });
+        const reveal = composePush({ kind: 'reveal', language, discreet: false });
+        expectClean(daily);
+        expect(daily.body).not.toBe(atRisk.body);
+        expect(daily.body).not.toBe(reveal.body);
+        expect(daily.title).not.toBe(atRisk.title);
+      }
+    });
+
+    it('never claims the partner did anything — nobody has answered yet at 08:00', () => {
+      for (const language of LANGUAGES) {
+        const daily = composePush({
+          kind: 'dailyQuestion',
+          language,
+          discreet: false,
+          // A caller passing these must not be able to leak them into this kind.
+          partnerName: 'Fahad',
+          streakCount: 12,
+        });
+        expect(daily.title.includes('Fahad')).toBe(false);
+        expect(daily.body.includes('Fahad')).toBe(false);
+        expect(daily.body.includes('12')).toBe(false);
+      }
+    });
+
+    it('is generic in discreet mode like every other kind', () => {
+      for (const language of LANGUAGES) {
+        const discreet = composePush({ kind: 'dailyQuestion', language, discreet: true });
+        const otherDiscreet = composePush({ kind: 'reveal', language, discreet: true });
+        expect(discreet).toEqual(otherDiscreet);
+      }
+    });
+  });
+
+  // ADR-042 D4. The 16:00 nudge fires for a couple with NO streak — that is the
+  // whole point of dropping the streak gate. The count-free copy therefore may
+  // not talk about a streak: "Your streak together is still alive" is FALSE for
+  // the population this change exists to reach, and telling someone their streak
+  // is alive when they have none is worse than saying nothing.
+  describe('streakAtRisk with no streak — the relationship nudge (ADR-042 D4)', () => {
+    it('never mentions a streak when there is no streak', () => {
+      const streakWords = ['streak', 'seri', 'تتابع'];
+      for (const language of LANGUAGES) {
+        const noStreak = composePush({ kind: 'streakAtRisk', language, discreet: false });
+        expectClean(noStreak);
+        for (const word of streakWords) {
+          expect(noStreak.title.toLowerCase().includes(word)).toBe(false);
+          expect(noStreak.body.toLowerCase().includes(word)).toBe(false);
+        }
+      }
+    });
+
+    it('still uses the streak copy when a streak exists — nothing is lost', () => {
+      for (const language of LANGUAGES) {
+        const withStreak = composePush({
+          kind: 'streakAtRisk',
+          language,
+          discreet: false,
+          streakCount: 5,
+        });
+        expect(withStreak.body.includes('5')).toBe(true);
+      }
+    });
+
+    it('a zero or negative count takes the no-streak copy, not a "0-day streak"', () => {
+      for (const count of [0, -3]) {
+        const payload = composePush({
+          kind: 'streakAtRisk',
+          language: 'en',
+          discreet: false,
+          streakCount: count,
+        });
+        expect(payload.body.includes(String(count))).toBe(false);
+        expect(payload.body.toLowerCase().includes('streak')).toBe(false);
+      }
+    });
   });
 
   describe('discreet mode leaks nothing event-specific', () => {


### PR DESCRIPTION
**The two notification behaviours the founder asked for, closing #189 and ADR-042 D3/D4.**

> "It needs to be send new questions at 08.00 TSI with a question. […] If you did not reply the question as of 16.00 you need to be notified so that your partner dont get angry."

The third ask — *"when your partner answers your question you need to be notified"* — has been built since M3.4. **All three are now composed and routed. None of them has reached a phone**, and #188 says why: `PUSH_NOTIFICATIONS` is measured absent on the App ID.

## D3 — a fourth push kind, on the same single couples read

`PushKind` gains **`dailyQuestion`** (TR/AR/EN, plus the discreet variant). A new hour-8 pass iterates the **same `CoupleBuckets`** the assignment and at-risk passes already share, so it adds **zero couples reads** — ADR-012 D3's hard constraint is preserved by construction, not by promise.

It announces to members who have **not already answered**: an early bird does not need telling that a question exists.

**"08.00 TSİ" is read as 08:00 couple-local.** It *is* TSİ for the founder couple, and a literal `Europe/Istanbul` constant would be correct for exactly one couple and silently wrong for the Gulf-Arabic audience the product is built for.

## D4 — the 16:00 nudge replaces the 20:00 one

Hour 20 → **16**, and the `streak.count > 0` gate is **gone**. This stopped being a streak feature: the founder's nudge protects a *relationship* and must fire for a couple with **no streak at all** — most couples in week one, and every couple that ever broke one.

Re-pointed rather than duplicated: the 16:00 population is a strict **superset** of the 20:00 one, and a second afternoon hour would give a couple with a streak two pushes in one evening, which the deliberate no-dedup-state posture cannot prevent.

## Two things the ADR did not decide, and the implementation forced

1. **D4 needed new copy, not just a new hour.** The ADR said the count-free variant meant *"nothing about the existing message is lost."* True and incomplete — that variant read **"Your streak together is still alive"**, which is **false for exactly the population D4 exists to reach**. Telling someone their streak is alive when they have none is worse than saying nothing, so a separate relationship nudge was written. Dropping a gate changed *who reads the message*; the message had to change with it.
2. **The daily-question pass skips members who already answered** — unspecified by the ADR. Costs one `getAll` of two answer docs per eligible couple.

Both are folded back into ADR-042 as corrections rather than absorbed silently.

## The tripwire was disarmed correctly

`payload-policy.test.ts` asserted **two** things: *"exactly three kinds"* and `not.toContain('coupleEnded')`. Adding a fourth kind reddens it **by design**.

The count moved to four; **the `coupleEnded` assertion is untouched**. The test now states in its own comment which of its two halves is the ADR-019 DV safety invariant (no push to a possibly-abusive partner at the deleting victim's moment of escape) and which is merely a change detector. ADR-042 D5 predicted this exact red and warned that relaxing it wholesale would delete a safety property while looking like a test fix.

## Mutation-checked, both directions, every mutation anchored uniquely

Lesson 82 from the last session: a mutation that silently hits the wrong line reports exactly what a covered line reports.

| Mutation | Result |
|---|---|
| quiet window widened to `< 9` | **8 assertions red**, incl. *"hour 8 is NOT quiet, and hour 7 IS"* and every delivery test. **This is the silent-death mutation** — hour 8 sits *on* the right-open boundary, so an off-by-one here suppresses the whole feature with every unrelated test green. |
| quiet window narrowed to `>= 23` | *"hour 22 IS quiet"* + both local-hour boundary tables |
| `DAILY_QUESTION_LOCAL_HOUR` 8 → 7 | 8 assertions red |
| `AT_RISK_LOCAL_HOUR` 16 → 20 | 8 assertions red |
| streak gate restored | **exactly the three tests that were inverted** rather than deleted when the rule flipped — proving the gate drop is genuinely covered, not vacuously passing |

The two old zero-streak tests were **not removed** when their rule reversed. They were flipped to assert the new behaviour, so the case stays covered with the opposite expectation.

## ADR-012 §10's cost model is amended in this diff

It said *"one extra day-doc read per couple, once per day, in the hour-20 bucket, **for couples with a streak**"*. It is now *"one day-doc read **plus one `getAll` of two answer docs** per eligible couple, once per day, in the hour-16 bucket, **unconditionally**"* — eligibility can no longer be decided from the couple document already in the bucket.

Single-digit reads/day at current scale, recorded because **a cost claim that quietly widened is exactly the drift ADRs exist to prevent**. ADR-012's Status line now names its amendment, and its *"nothing writes `fcmTokens` yet"* paragraph is struck through as discharged by S062.

## Refactor, deliberate and bounded

Recipient resolution, the defense-in-depth quiet guard and the per-token error boundary moved to `sweep-push.ts`. Two passes differing only in couple selection and push kind would otherwise have kept **two copies of the code that decides whether a lock screen leaks** — and only one of them would get the next fix. `deliverAtRiskPush` stays a named export so its suite still exercises the delivery branches.

## Verification

Functions **1067 tests / 54 files** green, coverage **97.45%** statements, lint + typecheck clean. Typecheck caught a test-only type error that vitest's esbuild transpile runs straight past.

Closes #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
