### PR TITLE
feat(push): the device half, everything except the one line that breaks codesign (#188)

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -15,6 +15,7 @@ import 'features/auth/presentation/sign_in_screen.dart';
 import 'features/auth/presentation/state/auth_controller.dart';
 import 'features/coach/presentation/state/coach_transcript.dart';
 import 'features/entitlements/presentation/state/purchases_identity_sync.dart';
+import 'features/notifications/presentation/state/push_token_sync.dart';
 import 'features/pairing/presentation/state/pending_invite.dart';
 import 'features/privacy_lock/presentation/privacy_guard.dart';
 import 'features/privacy_lock/presentation/state/privacy_lock_controller.dart';
@@ -62,6 +63,12 @@ class HayatiApp extends ConsumerWidget {
     // app root is the only always-mounted widget (ADR-014 Decision 2). Lazy by
     // design: a signed-out lifecycle never resolves the purchases seam.
     ref.listen(purchasesIdentitySyncProvider, (_, _) {});
+    // Activate the FCM token sync from the first frame (keepAlive), same mount
+    // precedent and same reason: a warm start's restored session must register
+    // its token without waiting for an auth EVENT that will never come
+    // (ADR-042 D1). Lazy by design — a signed-out lifecycle never resolves the
+    // token source, and a device with no token is a logged no-op, never a frame.
+    ref.listen(pushTokenSyncProvider, (_, _) {});
     // Tear down all coach conversation state on any transition away from a
     // signed-in user (ADR-017 Decision 3). The coach transcript family is
     // keepAlive — it survives route pops BY DESIGN — so a sign-out that only

--- a/app/lib/features/notifications/data/fcm_push_token_source.dart
+++ b/app/lib/features/notifications/data/fcm_push_token_source.dart
@@ -1,0 +1,53 @@
+import 'package:firebase_messaging/firebase_messaging.dart';
+
+import '../domain/push_token_source.dart';
+
+/// The FCM implementation of [PushTokenSource] (ADR-042 D2 step 4).
+///
+/// This is the whole device half of the token lifecycle: one class, because
+/// everything that DECIDES anything — when to register, what to remove at
+/// sign-out, how to survive a rotation — lives above the port in `PushTokenSync`
+/// and is proven on Linux with a fake. That was the point of the seam.
+///
+/// **It is deliberately thin and deliberately untested**, the same trade
+/// `FunctionsDataRightsRepository` documents: an adapter with no branches of its
+/// own has nothing to assert about that a fake would not also satisfy. The one
+/// thing it does carry is the fail-open posture, and that IS tested — through
+/// `PushTokenSync`, which treats a throw or a null from here as a logged no-op.
+///
+/// ## What it is not doing, and why
+///
+/// **It does not request notification permission.** ADR-039 D1 makes the boot
+/// fail-open and D2 bounds every wait on the launch→paired path; a permission
+/// prompt is an indefinite wait on a human and iOS gives one shot per install.
+/// ADR-042 D6 puts the ask after pairing, on a screen that can explain itself —
+/// so it belongs to a UI surface, not to this adapter. Until that ships,
+/// [currentToken] simply returns null on iOS, which is the normal pre-permission
+/// state and exactly what the fail-open path is for.
+///
+/// **It does not assume APNs works.** Without `aps-environment` in the
+/// entitlements — absent by design until the App ID capability is ticked
+/// (measured absent 2026-08-06) — iOS never hands Firebase an APNs token, so
+/// `getToken()` returns null or throws. Both collapse to "no token yet", the
+/// same state as a user who has not granted permission. **This class is
+/// therefore correct and inert today, and becomes live the moment the
+/// entitlement lands, with no code change.**
+class FcmPushTokenSource implements PushTokenSource {
+  FcmPushTokenSource({FirebaseMessaging? messaging})
+    : _messaging = messaging ?? FirebaseMessaging.instance;
+
+  final FirebaseMessaging _messaging;
+
+  @override
+  Future<String?> currentToken() async {
+    // On iOS, getToken() throws rather than returning null when APNs has not
+    // registered — which is the ordinary state before the entitlement and before
+    // permission. PushTokenSync catches it and logs a no-op, so an absent token
+    // never reaches a user as an error; the null here is for the platforms and
+    // paths where the plugin answers politely.
+    return _messaging.getToken();
+  }
+
+  @override
+  Stream<String> tokenRefreshes() => _messaging.onTokenRefresh;
+}

--- a/app/lib/main_dev.dart
+++ b/app/lib/main_dev.dart
@@ -43,8 +43,10 @@ import 'features/entitlements/data/firestore_entitlement_repository.dart';
 import 'features/entitlements/data/rc_purchases_repository.dart';
 import 'features/entitlements/domain/entitlement_repository_provider.dart';
 import 'features/entitlements/domain/purchases_repository_provider.dart';
+import 'features/notifications/data/fcm_push_token_source.dart';
 import 'features/notifications/data/functions_push_token_repository.dart';
 import 'features/notifications/domain/push_token_repository_provider.dart';
+import 'features/notifications/domain/push_token_source_provider.dart';
 import 'features/pairing/data/app_links_deep_link_source.dart';
 import 'features/pairing/data/functions_invite_repository.dart';
 import 'features/pairing/data/http_invite_preview_repository.dart';
@@ -198,13 +200,21 @@ Future<void> main() async {
         dataRightsRepositoryProvider.overrideWith(
           (ref) => FunctionsDataRightsRepository(),
         ),
-        // ADR-042 D1. The repository is real and calls the deployed callables;
-        // pushTokenSourceProvider is deliberately NOT overridden, so nothing
-        // captures a token yet (D2 step 4, blocked on the App ID capability
-        // measured absent 2026-08-06).
+        // ADR-042 D1/D2. Both halves are real now: the repository calls the
+        // deployed callables, and the source is FCM.
+        //
+        // It is INERT until the entitlement lands. `aps-environment` is absent
+        // from Runner.entitlements by design — the Push Notifications capability
+        // is not ticked on the App ID (measured 2026-08-06), and a build claiming
+        // the entitlement without it fails at CODESIGN in the macOS release job
+        // (ADR-040, one capability over). Without it iOS never registers with
+        // APNs, so getToken() yields nothing and PushTokenSync logs a no-op.
+        // Nothing here changes when the tick happens except that tokens start
+        // flowing.
         pushTokenRepositoryProvider.overrideWith(
           (ref) => FunctionsPushTokenRepository(),
         ),
+        pushTokenSourceProvider.overrideWith((ref) => FcmPushTokenSource()),
         // The three device-privacy seams (ADR-018 D2/D1/D6). Bound BY VALUE here
         // and nowhere else, so `flutter test` never touches the Keychain,
         // local_auth, or the hayati/device_privacy channel.

--- a/app/lib/main_prod.dart
+++ b/app/lib/main_prod.dart
@@ -43,8 +43,10 @@ import 'features/entitlements/data/firestore_entitlement_repository.dart';
 import 'features/entitlements/data/rc_purchases_repository.dart';
 import 'features/entitlements/domain/entitlement_repository_provider.dart';
 import 'features/entitlements/domain/purchases_repository_provider.dart';
+import 'features/notifications/data/fcm_push_token_source.dart';
 import 'features/notifications/data/functions_push_token_repository.dart';
 import 'features/notifications/domain/push_token_repository_provider.dart';
+import 'features/notifications/domain/push_token_source_provider.dart';
 import 'features/pairing/data/app_links_deep_link_source.dart';
 import 'features/pairing/data/functions_invite_repository.dart';
 import 'features/pairing/data/http_invite_preview_repository.dart';
@@ -198,13 +200,21 @@ Future<void> main() async {
         dataRightsRepositoryProvider.overrideWith(
           (ref) => FunctionsDataRightsRepository(),
         ),
-        // ADR-042 D1. The repository is real and calls the deployed callables;
-        // pushTokenSourceProvider is deliberately NOT overridden, so nothing
-        // captures a token yet (D2 step 4, blocked on the App ID capability
-        // measured absent 2026-08-06).
+        // ADR-042 D1/D2. Both halves are real now: the repository calls the
+        // deployed callables, and the source is FCM.
+        //
+        // It is INERT until the entitlement lands. `aps-environment` is absent
+        // from Runner.entitlements by design — the Push Notifications capability
+        // is not ticked on the App ID (measured 2026-08-06), and a build claiming
+        // the entitlement without it fails at CODESIGN in the macOS release job
+        // (ADR-040, one capability over). Without it iOS never registers with
+        // APNs, so getToken() yields nothing and PushTokenSync logs a no-op.
+        // Nothing here changes when the tick happens except that tokens start
+        // flowing.
         pushTokenRepositoryProvider.overrideWith(
           (ref) => FunctionsPushTokenRepository(),
         ),
+        pushTokenSourceProvider.overrideWith((ref) => FcmPushTokenSource()),
         // The three device-privacy seams (ADR-018 D2/D1/D6). Bound BY VALUE here
         // and nowhere else, so `flutter test` never touches the Keychain,
         // local_auth, or the hayati/device_privacy channel.

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "78f98c1f9c4dbbd22c2bb7b7f17c4a5c06150e8b2cb791a0947979ad0d3dabd5"
+      sha256: "85c85838ba41c5823ca05ecbc5fc8d85d78e9f945195d1e4d5069abd451916e7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.73"
+    version: "1.3.74"
   analyzer:
     dependency: transitive
     description:
@@ -397,10 +397,10 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: d2625088d8f8836a7a74a7eb94a5372d70ad88382602ba2dcc02805c294d0d16
+      sha256: e744b63446de56d9f72fec870b19e9c6f075fd3da099a3a34535f6e8c4e60823
       url: "https://pub.dev"
     source: hosted
-    version: "4.11.0"
+    version: "4.12.0"
   firebase_core_platform_interface:
     dependency: "direct dev"
     description:
@@ -433,6 +433,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.8.24"
+  firebase_messaging:
+    dependency: "direct main"
+    description:
+      name: firebase_messaging
+      sha256: ae3691770a42741100a33be6fec494b3c88e8fc536e5756fe4e447b8be7cfb4a
+      url: "https://pub.dev"
+    source: hosted
+    version: "16.4.2"
+  firebase_messaging_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_messaging_platform_interface
+      sha256: "7e8dc65dfbd8c97d8f88031bfc0896947ee9cbb47940a5bba5edb343a70919a7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.9.1"
+  firebase_messaging_web:
+    dependency: transitive
+    description:
+      name: firebase_messaging_web
+      sha256: b469facb97b4bc3e362ffcd5118b78fe6008f77faab8da2f41dbe16ea841157f
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.2"
   fixnum:
     dependency: transitive
     description:

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "85c85838ba41c5823ca05ecbc5fc8d85d78e9f945195d1e4d5069abd451916e7"
+      sha256: "6727cf2ced9b104abca9daa278380be2eca2b98ce33d4b46f11708e387dc6b4d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.74"
+    version: "1.3.76"
   analyzer:
     dependency: transitive
     description:
@@ -181,50 +181,50 @@ packages:
     dependency: "direct main"
     description:
       name: cloud_firestore
-      sha256: f0dba6cedc1e1c84bb811c32ce1343cde4f1aa796dc4b5d00344e16a5342aed0
+      sha256: a9667b44b995eb9c642e6460275af9c478f4e72befc61146f2e0f88e6f174705
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.0"
+    version: "6.8.0"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
-      sha256: "07a03c220bc4579418a9e2ef02914a4c86b2b0c21d68a832faa523096bc20a00"
+      sha256: "700d043dfe95fac8a4eea79d21dd41f6e4c8f2360e43d7b669374dedd465f4ba"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.3"
+    version: "8.0.6"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
-      sha256: a75fec71ecf6327f9a657a4c6b4dad5099d77bf578d110e10b233237f6cad3c0
+      sha256: ee86386bb41f6583cc6fc8a75bffe830a6f0128bbd545176c86c18dc5e2c2a7e
       url: "https://pub.dev"
     source: hosted
-    version: "5.6.0"
+    version: "5.7.2"
   cloud_functions:
     dependency: "direct main"
     description:
       name: cloud_functions
-      sha256: "94ed08514607ac591e92b9aab1da67e3c8d99c0a7d0b40d096c62843f026cd52"
+      sha256: "82fa5811d184c4135d2177174507cc03744f032a085cd3be95246c0f1b006e53"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.3"
+    version: "6.3.6"
   cloud_functions_platform_interface:
     dependency: transitive
     description:
       name: cloud_functions_platform_interface
-      sha256: e864765efa9fdfebef126a87941851ed36bc00f325c223eeb4e2140f60b64ed2
+      sha256: "86842d91cd4e83b71aa2dff874fd3554e237aa6e222d8e6e54bb7692fb1bd779"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.3"
+    version: "6.0.6"
   cloud_functions_web:
     dependency: transitive
     description:
       name: cloud_functions_web
-      sha256: "68871283155445b6c99a3b6bfd2762a2daca2fdf605d6c204a0ab4522644b438"
+      sha256: aeca9c8f24838630f28bd75622668725a85044211be83de9f0a2fe07c4c8b643
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.9"
+    version: "5.1.12"
   code_assets:
     dependency: transitive
     description:
@@ -349,114 +349,114 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_app_check
-      sha256: "9d5c79d382a8b87cc0d899294a5234a9f0d15125cd1c97c45ca2faeca6c62918"
+      sha256: d422642d973b0c636e0582127a47319d8ac9140195e7330c71965d3b6b263095
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.5"
+    version: "0.4.6"
   firebase_app_check_platform_interface:
     dependency: transitive
     description:
       name: firebase_app_check_platform_interface
-      sha256: "58248ca4a6be624f17e47d1f18b3846e477cce3dc7f1c08917e3845aa973beb3"
+      sha256: "645ff25c18160a2c6e6b487d3466b247619e0bf09e2b1f641d476b2a72f92106"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.2"
   firebase_app_check_web:
     dependency: transitive
     description:
       name: firebase_app_check_web
-      sha256: "6b34be4bb8aa0bc5c2bbe930dd57035e971144521ee7d52d8e293c6cb1216a66"
+      sha256: "66c938d522c8c325515d222aa55560921b063d06791cf95aa7c405183a3a454f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.6"
   firebase_auth:
     dependency: "direct main"
     description:
       name: firebase_auth
-      sha256: "7996a49c4b4054573eac9124c1c412095ae1406ca367bd2373de1ad2eaba04b8"
+      sha256: "366b8edc0bbce7880a62dbf0f566fadd809ee69e6e345b7e7cae2080443acbfd"
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.4"
+    version: "6.5.7"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
-      sha256: "2975965782c8cc46fe5bafc653882617e6fbdceed4499c97345c980734c50d2e"
+      sha256: "314b7bd0bf8545cbd3e779bad294a811d09de5d25d5c88a00e6e48a6bded6368"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.3"
+    version: "9.0.6"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
-      sha256: b35db5997b32889885dc9b1420b7c81b704f1ec153c3bb2efd228733e1878119
+      sha256: "209f60c3e4bc44ce23b167b2361883bc15a012b027ffcb773ccd81fcaebc718b"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.3"
+    version: "6.2.6"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: e744b63446de56d9f72fec870b19e9c6f075fd3da099a3a34535f6e8c4e60823
+      sha256: "9478ca6700c02d315c6aba37e206e612317f98bb4f335bb1cbd6e0ce67dcf764"
       url: "https://pub.dev"
     source: hosted
-    version: "4.12.0"
+    version: "4.13.0"
   firebase_core_platform_interface:
     dependency: "direct dev"
     description:
       name: firebase_core_platform_interface
-      sha256: "913e7c96ef83a80ad7e1c3f8a059167b3de23b5d5e07fa3ed8f11abe24de98b6"
+      sha256: e28f9afdcb5b0f0a8ea74ea3b322f5a7592c81cb45dd9d189913bdae08a2089a
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "8.1.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: "30ba3ae56f5beb2cea836033201570612c911661889f815eca73b6056c7b55bf"
+      sha256: f471a288b0101a45567548322ac4a5ad31e3ecbf87a576dcc0e424e6a11e04ea
       url: "https://pub.dev"
     source: hosted
-    version: "3.9.0"
+    version: "3.10.0"
   firebase_crashlytics:
     dependency: "direct main"
     description:
       name: firebase_crashlytics
-      sha256: "2d9c791abef1cfd66c2572f5a4e172aa9f43476961af49742b1511dd327611df"
+      sha256: "96c1d85de9eddc07061d3f7e2fb75596e75a45c9cec9c2e3a7cc9f97e6f3a748"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.4"
+    version: "5.2.7"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_crashlytics_platform_interface
-      sha256: cbedfe34081c4ad5c4e0558165383d4fa6b8fd70ae6e696190aad345adbb346c
+      sha256: "47d83b71fd39c580297c696a507a7c2652680ea2045e40c6c4e3c371b0ee7bc6"
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.24"
+    version: "3.8.27"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
-      sha256: ae3691770a42741100a33be6fec494b3c88e8fc536e5756fe4e447b8be7cfb4a
+      sha256: "55cf1000dd72d229ebff3ce6a399bd35705a7675275478b31308afd90ac85751"
       url: "https://pub.dev"
     source: hosted
-    version: "16.4.2"
+    version: "16.5.0"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
-      sha256: "7e8dc65dfbd8c97d8f88031bfc0896947ee9cbb47940a5bba5edb343a70919a7"
+      sha256: e5fbb62bd23a27c983825277877ac91fdfdb6bfb31c6e5399700963ae586e339
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.1"
+    version: "4.9.3"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
-      sha256: b469facb97b4bc3e362ffcd5118b78fe6008f77faab8da2f41dbe16ea841157f
+      sha256: "663d320e90a41fe57d651ec79df2bc831bf29e051bc0c2cd41faf3106eb412d9"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.2"
+    version: "4.2.4"
   fixnum:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -15,7 +15,13 @@ dependencies:
   firebase_auth: ^6.5.4
   firebase_core: ^4.11.0
   firebase_crashlytics: ^5.2.4
-  firebase_messaging: ^16.4.2
+  # FLOOR IS 16.4.3, NOT 16.4.2, AND THAT IS LOAD-BEARING. 16.4.2 declares
+  # `firebase_core_platform_interface: ^7.1.0` while its code uses `FirebasePlugin`,
+  # which exists only in 8.x — so it resolves cleanly, passes `flutter analyze` and
+  # every Linux test, and then fails at Dart compile in the iOS build. 16.4.3 is the
+  # release that corrected the declaration. Found by ios-build-smoke, which is the
+  # only check in this repo that compiles iOS at all.
+  firebase_messaging: ^16.4.3
   flutter:
     sdk: flutter
   flutter_localizations:
@@ -35,7 +41,14 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.7.5
-  firebase_core_platform_interface: ^7.1.0
+  # Pinned as a DIRECT dev dependency only for `firebase_core_platform_interface/test.dart`
+  # (firebase_bootstrap_test.dart). It is not a test-only detail: it constrains the
+  # whole Firebase set, and at ^7.1.0 it silently held firebase_messaging back to
+  # 16.4.2 — a release whose own constraint is WRONG (it declares ^7.1.0 while its
+  # code uses `FirebasePlugin`, which exists only in 8.x). That combination resolves
+  # cleanly and then fails at Dart compile on a real iOS build. 16.4.3 corrected the
+  # declaration to ^8.0.0. Keep this in step with the Firebase set, not behind it.
+  firebase_core_platform_interface: ^8.1.0
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   firebase_auth: ^6.5.4
   firebase_core: ^4.11.0
   firebase_crashlytics: ^5.2.4
+  firebase_messaging: ^16.4.2
   flutter:
     sdk: flutter
   flutter_localizations:


### PR DESCRIPTION
**ADR-042 D2 sanctions exactly this:** *"Build the app half behind the plugin and land the entitlement only once the founder confirms, or in a separate labelled commit that is not merged until then."*

This lands `firebase_messaging`, the FCM adapter, both provider overrides and the app-root activation — and **not** `aps-environment`.

## Why the entitlement is the one thing held back

`PUSH_NOTIFICATIONS` is **not ticked** on the App ID. Measured twice, four hours apart, **exit 1** (absent) and not exit 2 (could not look). `match` fetches provisioning profiles readonly (ADR-032), so CI cannot mint the capability, and a build claiming an entitlement its profile lacks **fails at codesign**.

**That failure would not appear on this PR.** `ios-build-smoke` runs `flutter build ios --no-codesign`, so the entitlement would leave every required check green and detonate in `release.yml`'s macOS sign-upload job — the most expensive place in the system to learn it. ADR-040 is the record of that happening once already, one capability over.

## What this buys, given it cannot deliver a push

It answers the two things ADR-042 marked **UNVERIFIED** because no amount of reasoning on Linux could settle them — and it answers them with a real macOS compile rather than an argument:

1. whether `firebase_messaging` initializes against this project's **pure-Dart `FirebaseOptions`** — there is **no `GoogleService-Info.plist`** in the iOS project at all, re-confirmed here;
2. whether its **method swizzling** coexists with this app's **scene-based `FlutterImplicitEngineDelegate`** AppDelegate.

If either is wrong, it is wrong *now*, on a branch — instead of on the day the founder ticks the box and expects a build.

**It also collapses the remaining work to:** tick the capability → merge one labelled commit adding `aps-environment` → release. No new code.

## Inert by construction, not by being unwired

`pushTokenSourceProvider` **is** overridden and `PushTokenSync` **is** activated from the app root. Without `aps-environment` iOS never registers with APNs, so `getToken()` yields nothing or throws — both of which are the ordinary pre-permission state that `PushTokenSync` already treats as a logged no-op, tested on Linux with a fake.

Behaviour today is unchanged. It becomes live the moment the entitlement lands, with no further code change.

## Not in this PR, each for a named reason

| Held back | Why |
|---|---|
| `aps-environment` | breaks codesign until the tick |
| `UIBackgroundModes: remote-notification` | **this is the event SEC-3 is waiting for.** `secure_storage_pin_lock_store.dart:25-28` records that a locked-device background read of an `unlocked_this_device` Keychain item fails and would hit the fail-open path. Adding background delivery before deciding SEC-3 ships that path unexamined. |
| the permission prompt | ADR-042 D6 puts it after pairing, on a screen that can explain itself. A UI surface, not an adapter concern — and iOS gives one shot per install. |
| a test for `FcmPushTokenSource` | a branchless adapter over a plugin, the same trade `FunctionsDataRightsRepository` documents. Everything that decides anything lives above the port and is already tested. |

## Verification

app: **1653 tests** green, `flutter analyze` clean, `dart format` clean, and the **entrypoint-lockstep sentinel** green (ADR-022 D2 — both entrypoints changed identically). **No file under `app/ios/` is touched by this PR.**

The check that matters is `ios-build-smoke` on macOS: it is the first time this plugin has ever been compiled against this project.

Part of #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)