### PR TITLE
docs(s063): the device half builds — what that proved, and the trap it found

### DIFF
--- a/docs/adr/042-push-token-lifecycle-and-the-two-hours-the-founder-asked-for.md
+++ b/docs/adr/042-push-token-lifecycle-and-the-two-hours-the-founder-asked-for.md
@@ -333,6 +333,34 @@ remainder deferred into prose is a remainder that gets lost):
   the iOS project at all), nor whether its method swizzling works with this
   app's **scene-based** `FlutterSceneDelegate` architecture. Both are marked
   UNVERIFIED rather than assumed.
+
+  > **PARTLY RESOLVED 2026-08-06 (#191).** The plugin, the `FcmPushTokenSource`
+  > adapter and both provider overrides landed **without** `aps-environment`,
+  > which is the ADR-sanctioned "separate labelled commit" route above. That
+  > made `ios-build-smoke` compile the plugin against this project for the first
+  > time, and it answers both UNVERIFIED items **at build level**:
+  >
+  > * `firebase_messaging` **compiles and links against the pure-Dart
+  >   `FirebaseOptions`** with no `GoogleService-Info.plist` present;
+  > * it **coexists with the scene-based `FlutterImplicitEngineDelegate`**
+  >   AppDelegate.
+  >
+  > **Still UNVERIFIED, and narrowed to what it actually is: RUNTIME.** A build
+  > cannot prove that method swizzling behaves correctly on a live device, nor
+  > that the plugin initializes cleanly against a `FirebaseApp` configured from
+  > Dart. Those need a device. They are bounded by ADR-039's fail-open posture —
+  > `PushTokenSync` treats a throw or a null as a logged no-op — but "bounded" is
+  > not "observed", and the first build to reach a tester should be watched.
+  >
+  > **The build also found something no reasoning would have.**
+  > `firebase_messaging` **16.4.2 declares a constraint its own code violates**:
+  > `firebase_core_platform_interface: ^7.1.0`, while using `FirebasePlugin`,
+  > which exists only in 8.x. This repo's **dev-only** pin of that package at
+  > `^7.1.0` — present solely so one test can import
+  > `firebase_core_platform_interface/test.dart` — made 16.4.3+ unsatisfiable
+  > and steered pub onto the one broken release. `pub get`, `analyze`, all 1653
+  > tests and `format` were green; only the iOS kernel snapshot failed. See
+  > lesson **84**.
 * ~~**D3 and D4** — the fourth kind and the two sweep hours.~~ **SHIPPED in S063**
   (#190). Two corrections the implementation forced, recorded because both were
   decisions this ADR should have made and did not:

--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -207,9 +207,15 @@ you asked for.
 > angry, not to protect a counter.
 >
 > **There is no engineering left between you and a notification.** The app knows
-> which phone to notify and only the server can write that. What is missing is the
-> tick above, the key below, and the one plugin that cannot be added until the tick
-> exists — because a build that claims push without it **fails to sign**.
+> which phone to notify and only the server can write that. The Firebase
+> notification plugin is now **installed and building** (2026-08-06), so what is
+> missing is exactly two things from you — the tick above and the key below — plus
+> **one line** we add the moment the tick exists.
+>
+> That one line is an entitlement claiming push. We cannot add it early: a build
+> that claims push before the App ID allows it **fails to sign**, and it fails in
+> the release step rather than in the checks, which is the expensive place to find
+> out. That is not caution — it happened once already, on a different capability.
 
 **What already exists while you do it.** The server composes the "your partner
 answered" push correctly today and hands it to the send seam — that half has been

--- a/docs/resume-prompt.md
+++ b/docs/resume-prompt.md
@@ -23,7 +23,7 @@ The founder has asked about the icon once and about testers' builds twice.
 | | State |
 |---|---|
 | **Push, server side** | **DONE.** All three founder behaviours compose and route: `dailyQuestion` at couple-local 08:00, `partnerAnswered` on the reveal trigger, the unanswered nudge at 16:00. `fcmTokens` has writers and a rules lock. |
-| **Push, device side** | **Nothing has ever arrived.** #188, blocked on the App ID tick. |
+| **Push, device side** | **Nothing has ever arrived** — but as of #191 the plugin, the FCM adapter and the app-root activation are ON `main` and **compile on macOS**. What is missing is literally `aps-environment` in `Runner.entitlements`, which cannot land until the tick. |
 | **App ID capabilities** | Measured 2026-08-06 (run `31054773143`): `APPLE_ID_AUTH` + `IN_APP_PURCHASE` ticked; **`PUSH_NOTIFICATIONS`, `ASSOCIATED_DOMAINS`, `APP_ATTEST` ABSENT.** Re-dispatch `appid-capabilities.yml` — it is one command and it decides whether #188 is live. |
 | **Build 113** | Apple-approved, `IN_BETA_TESTING`, 8 in `Friends` (2 anonymous public-link installs). |
 | **Build 114** | Uploaded 2026-08-02, **`READY_FOR_BETA_SUBMISSION` — never submitted.** Everyone is still on 113. |
@@ -92,9 +92,26 @@ first: read with `tool/ci/testflight_testers.py --store-status`; if `tr` exists,
 dispatch `appstore-screenshots.yml -f upload=true -f locales=en-US,tr`. If not, it
 is a founder action already on the operator page.
 
-**2 — #188, the device half — ONLY if the capability probe returns exit 0.** Run it
-first; it is one command. If it still returns 1, say so and move on rather than
-building around it. Everything above the device is done and waiting.
+**2 — #188's last line — ONLY if the capability probe returns exit 0.** Run it
+first; it is one command. If it still returns **1**, say so and move on rather than
+building around it.
+
+If it returns **0**, the remaining work is genuinely one commit:
+```
+app/ios/Runner/Runner.entitlements   + aps-environment  (development / production)
+```
+…then a release. **Do not add `UIBackgroundModes: remote-notification` in the same
+breath** — that is the event SEC-3 is waiting for
+(`secure_storage_pin_lock_store.dart:25-28`: a locked-device background read of an
+`unlocked_this_device` Keychain item fails and hits the fail-open path). Decide
+SEC-3 first, separately. Token capture does not need background modes; only
+background *delivery* does.
+
+⚠️ **Runtime is still unobserved.** #191 proved the plugin BUILDS against this
+project's pure-Dart `FirebaseOptions` (there is no `GoogleService-Info.plist`) and
+coexists with the scene-based AppDelegate. It could not prove the swizzling behaves
+on a live device. `PushTokenSync` fails open around it, but **watch the first build
+that reaches a tester** rather than assuming.
 
 **3 — The rest.** Re-derive from `gh issue list`. **#176** (Rubik Light declared,
 not bundled — the cheapest real bug here) · **#175** (10 of 14 raised cards render

--- a/docs/session-lessons.md
+++ b/docs/session-lessons.md
@@ -38,6 +38,30 @@ something, ask which of these you are standing in:
 
 ### Recent, in full
 
+**84 — A dev-only dependency pin constrains the WHOLE resolution, and a package can declare a constraint its own code violates.** *(2026-08-06)*
+Adding `firebase_messaging` resolved cleanly, analyzed clean, and passed all 1653
+tests. The iOS build then failed with `Type 'FirebasePlugin' not found`. Two
+compounding causes, and neither is a mistake anyone made locally:
+
+* **16.4.2 is a broken release.** It declares
+  `firebase_core_platform_interface: ^7.1.0` and uses `FirebasePlugin`, which
+  exists only in **8.x**. Upstream corrected the *declaration* in 16.4.3. A
+  resolver cannot catch this: the metadata is self-consistent and wrong.
+* **A `dev_dependencies` pin is not test-only.** This repo pinned
+  `firebase_core_platform_interface: ^7.1.0` so one test could import that
+  package's `test.dart`. 7.1.0 was the newest 7.x, so the pin looked current —
+  but it constrained the entire Firebase set, made 16.4.3+ unsatisfiable, and
+  silently selected the one broken version. **A pin in `dev_dependencies`
+  restricts production resolution exactly as hard as one in `dependencies`.**
+
+**The general lesson is about which check can see what.** `flutter analyze` never
+type-checks a plugin against the platform it will compile for; only the kernel
+snapshot for that platform does. So a class of defect exists that is invisible to
+every fast, cheap, Linux-side gate and visible only to the slow platform build.
+When adding or upgrading a **plugin** (as opposed to a pure-Dart package), local
+green means nothing until the platform build has run — and if the only such check
+is `--no-codesign`, remember it still cannot see anything about *signing*.
+
 **83 — Changing an eligibility rule changes WHO reads the message, so the message has to change with it.** *(2026-08-06)*
 ADR-042 D4 dropped the `streak.count > 0` gate so the afternoon nudge would reach
 couples with no streak — that population *was the reason for the change*. The ADR


### PR DESCRIPTION
Folds #191's result back into the documents that get read next.

## ADR-042's two UNVERIFIED items are answered — at build level

| | |
|---|---|
| **PROVEN** | `firebase_messaging` compiles and links against this project's **pure-Dart `FirebaseOptions`** with **no `GoogleService-Info.plist`**, and coexists with the scene-based `FlutterImplicitEngineDelegate` AppDelegate. |
| **STILL OPEN** | **Runtime.** A build cannot prove method swizzling behaves on a live device. Bounded by ADR-039's fail-open posture (`PushTokenSync` treats a throw or null as a logged no-op) — but *bounded is not observed*, and the first build reaching a tester should be watched. |

The residue is **renamed to what it actually is** rather than closed.

## Lesson 84 — the finding no reasoning would have produced

**A dev-only dependency pin constrains the whole resolution, and a package can declare a constraint its own code violates.**

`firebase_messaging` **16.4.2** declares `firebase_core_platform_interface: ^7.1.0` and uses `FirebasePlugin` — which exists only in **8.x**. Upstream corrected the *declaration* in 16.4.3. A resolver cannot catch this: the metadata is self-consistent and wrong.

Compounding it, this repo pinned `firebase_core_platform_interface: ^7.1.0` in **`dev_dependencies`**, solely so one test could import that package's `test.dart`. 7.1.0 was the newest 7.x, so the pin looked current — while it constrained the entire Firebase set, made 16.4.3+ unsatisfiable, and steered pub onto the one broken release.

**The transferable part is about which check can see what.** `flutter analyze` never type-checks a plugin against the platform it will compile for; only that platform's kernel snapshot does. `pub get`, `analyze`, all **1653** tests and `format` were green. Only `ios-build-smoke` failed — and if that build runs `--no-codesign`, it still cannot see anything about *signing*.

## Handoff changes

**`resume-prompt.md`** — the device half is no longer "a session's work". It is **one entitlement line** behind a founder checkbox, with an explicit warning **not** to add `UIBackgroundModes: remote-notification` in the same breath: that is the event SEC-3 is waiting for (`secure_storage_pin_lock_store.dart:25-28` — a locked-device background read of an `unlocked_this_device` Keychain item fails and hits the fail-open path). Token capture does not need background modes; only background *delivery* does.

**`operator-expected.md`** — restated for the founder: the plugin is installed and building, so what remains is two things from them plus one line from us. The reason we cannot add that line early is that it fails at the **release** step rather than in the checks — said as history, not caution, because it already happened once on a different capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)