### PR TITLE
feat(ci): tick a capability from CI — the write half, behind two locks

### DIFF
--- a/.github/workflows/appid-capabilities.yml
+++ b/.github/workflows/appid-capabilities.yml
@@ -18,11 +18,26 @@
 # ENVIRONMENT secrets while ASC_API_KEY_P8_BASE64 is a REPOSITORY secret, so
 # only a job declaring the environment sees both (the REL-2 lesson).
 #
-# READ-ONLY BY CONSTRUCTION. The tool has no code path that can tick a
-# capability. Enabling one changes how a real binary signs; that is a founder
-# decision, and a lane that could do it would also be a lane that could do it by
-# accident. Manual dispatch only — nothing here should run as a merge side
-# effect.
+# READ BY DEFAULT; WRITE ONLY WHEN ASKED, TWICE. This lane was read-only by
+# construction until 2026-08-06, on the reasoning that enabling a capability
+# changes how a real binary signs — a founder decision, and a lane that could do
+# it would also be a lane that could do it by accident.
+#
+# The founder authorised the write on 2026-08-06 (they were shown the trade-off:
+# tick it in the portal by hand, or let the API do it and accept that the
+# provisioning profile is invalidated while `match` runs readonly). The accident
+# half of that reasoning is unchanged and is now ENFORCED rather than avoided:
+# the `enable` input does nothing unless `confirm` is the literal `ENABLE`, the
+# capability must be in a closed vocabulary, and the write tool is a separate
+# file with its own self-tests (tool/ci/appid_capability_enable.py).
+#
+# AFTER A SUCCESSFUL ENABLE THE RELEASE LANE IS BROKEN UNTIL THE PROFILE IS
+# REGENERATED. That is not a risk, it is the mechanism: a capability change
+# invalidates the App ID's profiles and CI fetches them readonly. The job prints
+# the documented recovery (MATCH_BOOTSTRAP=true for one release run) so the
+# person who runs this reads it at the moment it becomes their problem.
+#
+# Manual dispatch only — nothing here should run as a merge side effect.
 #
 # THE JOB REDDENS ON BOTH FINDINGS, AND THEY ARE DIFFERENT FINDINGS:
 #   exit 1  measured, a required capability is NOT ticked  -> the founder must act
@@ -43,6 +58,18 @@ on:
         description: 'Comma-separated capabilities that must be ticked (blank = plain read-out)'
         required: false
         default: 'PUSH_NOTIFICATIONS,ASSOCIATED_DOMAINS,APP_ATTEST'
+      enable:
+        description: 'WRITES TO APPLE. One capability to tick. Needs confirm=ENABLE. Invalidates provisioning profiles.'
+        required: false
+        default: ''
+      disable_id:
+        description: 'WRITES TO APPLE. Undo: the bundleIdCapability resource id to remove. Needs confirm=ENABLE.'
+        required: false
+        default: ''
+      confirm:
+        description: 'Must be exactly ENABLE for enable/disable to do anything at all'
+        required: false
+        default: ''
 
 concurrency:
   group: appid-capabilities
@@ -66,6 +93,37 @@ jobs:
       # lesson recorded in ci.yml's rules-drift job.
       - name: install deps
         run: python3 -m pip install --quiet 'pyjwt[crypto]==2.10.1'
+      # The WRITE step runs FIRST and only when asked, so the read below is a
+      # verification of the new state rather than a stale snapshot of the old one.
+      # A no-op (no `enable`/`disable_id`) skips entirely — the default dispatch
+      # is exactly the read-only lane it always was.
+      - name: enable / disable a capability (writes to Apple)
+        if: inputs.enable != '' || inputs.disable_id != ''
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_API_KEY_P8_BASE64: ${{ secrets.ASC_API_KEY_P8_BASE64 }}
+          BUNDLE_ID: ${{ inputs.bundle_id }}
+          ENABLE: ${{ inputs.enable }}
+          DISABLE_ID: ${{ inputs.disable_id }}
+          CONFIRM: ${{ inputs.confirm }}
+        run: |
+          if [ -n "$DISABLE_ID" ]; then
+            args=(--disable-id "$DISABLE_ID" --confirm "$CONFIRM")
+          else
+            args=(--bundle-id "$BUNDLE_ID" --enable "$ENABLE" --confirm "$CONFIRM")
+          fi
+          set +e
+          python3 tool/ci/appid_capability_enable.py "${args[@]}"
+          status=$?
+          set -e
+          case "$status" in
+            0) echo "::warning::App ID capabilities CHANGED. The provisioning profile is now invalid — regenerate it with MATCH_BOOTSTRAP=true on the next release run, or the sign step will fail." ;;
+            1) echo "::error::REFUSED — a guard said no and NOTHING was sent (missing/wrong confirm literal, or an unknown capability)" ;;
+            2) echo "::error::the write FAILED — a request was sent and did not succeed. 'I would not' and 'I could not' are different facts; this is the second one." ;;
+            *) echo "::error::appid_capability_enable.py exited $status, outside its documented taxonomy" ;;
+          esac
+          exit "$status"
       - name: read capabilities
         # Inputs reach the shell as ENV, never interpolated into the script body:
         # `${{ }}` expands before bash sees the line, so an input containing shell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,16 @@ jobs:
       # EXIT_ABSENT reddens ten named assertions.
       - name: app id capability probe self-tests
         run: python3 tool/ci/appid_capabilities_test.py
+      # The WRITE half (S063). Registered here the moment it existed, because an
+      # unregistered test is a green run that proves nothing — this repo's own
+      # recorded lesson, and it would bite hardest on exactly this file: the
+      # assertions below are the locks that stand between a flag typo and a
+      # capability change on a live App ID. Hermetic (a fake transport records
+      # every request), and mutation-checked: removing the confirm literal, the
+      # closed vocabulary, the idempotence guard, the undo gate, or the failure
+      # mapping each reddens the assertion that names it.
+      - name: app id capability WRITE self-tests
+        run: python3 tool/ci/appid_capability_enable_test.py
       # ADR-034: the behavioural half of the advisory-delta gate. The gate itself
       # runs in functions-rules (it needs npm); these tests are hermetic — no npm,
       # no network, no emulator — so they belong here with the other pre-`pub get`

--- a/tool/ci/appid_capability_enable.py
+++ b/tool/ci/appid_capability_enable.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Enable (or disable) ONE capability on an App ID, over the App Store Connect API.
+
+WHY THIS EXISTS, AND WHY ITS SIBLING SAYS IT SHOULDN'T.
+
+`appid_capabilities.py` — the read half — states in its own header:
+
+    WHAT IT IS NOT. It reads. It cannot tick a capability, and it deliberately
+    has no code path that could: enabling a capability changes how a real
+    binary signs, which is a founder decision, and a tool that could do it
+    would also be a tool that could do it by accident.
+
+Both halves of that sentence are still true, and this tool does not overturn
+either. The FIRST half — "a founder decision" — was settled on 2026-08-06: the
+founder was shown the trade-off (do it in the portal yourself vs. authorise the
+API path, which regenerates the provisioning profile while `match` runs
+readonly and may break the release lane) and chose the API path explicitly.
+This file exists because of that answer, not in spite of it.
+
+The SECOND half — "could do it by accident" — is the real engineering problem,
+and it is answered rather than waved at. Two locks, both from this repo's own
+prior art:
+
+  * a **wire-level confirm literal** (`--confirm ENABLE`), the ADR-019
+    `confirm: 'DELETE'` precedent: a literal the app sends and the server
+    checks verbatim, so no typo, no default and no truthy flag can invoke it;
+  * the **closed capability vocabulary** shared with the read half, checked
+    BEFORE any request — on the read side an unknown value could only produce
+    a false absence, but here it would POST an arbitrary string at a live App ID.
+
+WHAT ENABLING ACTUALLY COSTS, stated where the person running it will see it.
+A capability change INVALIDATES the App ID's existing provisioning profiles.
+`match` runs `readonly: true` in CI (fastlane/Fastfile) precisely so CI can
+never mint credentials, so the next release will fetch a stale profile and fail
+at codesign UNLESS the profile is regenerated — which the Fastfile's documented
+escape hatch does: set the repo variable `MATCH_BOOTSTRAP=true` for one run,
+then remove it. That sequence is the operator's job and this tool does not
+attempt it; what this tool guarantees is that its own change is UNDOABLE, from
+the same place, by someone who has just watched a build fail (`--disable`).
+
+EXIT CODES — a taxonomy, the ADR-041 discipline, and note that two of the three
+are failures for DIFFERENT reasons:
+
+    0   the capability is enabled (or was already, which is not an error)
+    1   REFUSED — a guard said no. Nothing was sent. Not Apple's opinion, ours.
+    2   FAILED  — a request was sent and did not succeed, or a credential was
+        missing. "I would not" and "I could not" are different facts.
+
+Run:
+    python3 tool/ci/appid_capability_enable.py --bundle-id com.beyondkaira.hayati \\
+        --enable PUSH_NOTIFICATIONS --confirm ENABLE
+
+    python3 tool/ci/appid_capability_enable.py --disable-id CAP123 --confirm ENABLE
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import importlib.util
+import pathlib
+import sys
+
+# The credential gate AND the read half are IMPORTED, never re-implemented.
+# Re-deriving the capability vocabulary or the redaction here would be a second
+# thing that can drift, and drift in either fails in the reassuring direction.
+_HERE = pathlib.Path(__file__).parent
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, _HERE / f"{name}.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault(name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+_probe = _load("appid_capabilities")
+_tft = _probe._tft
+
+AscError = _probe.AscError
+KNOWN_CAPABILITIES = _probe.KNOWN_CAPABILITIES
+PUSH_NOTIFICATIONS = _probe.PUSH_NOTIFICATIONS
+ASSOCIATED_DOMAINS = _probe.ASSOCIATED_DOMAINS
+APP_ATTEST = _probe.APP_ATTEST
+APPLE_ID_AUTH = _probe.APPLE_ID_AUTH
+_redact = _probe._redact
+
+EXIT_OK = 0
+EXIT_REFUSED = 1
+EXIT_FAILED = 2
+
+#: The literal a caller must send verbatim. Never typed by a human in normal
+#: use — CI and the operator runbook pass it — so it costs nothing and turns an
+#: accidental invocation from unlikely into impossible (ADR-019 D2 precedent).
+CONFIRM_LITERAL = "ENABLE"
+
+
+@dataclasses.dataclass(frozen=True)
+class Result:
+    exit_code: int
+    capability: str = ""
+    #: Apple's id for the created capability resource — the handle `--disable-id`
+    #: needs. Recorded because the undo path matters most to someone who is
+    #: already having a bad afternoon.
+    capability_id: str = ""
+    #: True when the capability was ALREADY ticked and nothing was sent.
+    already_enabled: bool = False
+    reason: str = ""
+
+
+def enable_capability(
+    call,
+    bundle_key: str,
+    capability: str,
+    *,
+    confirm: str,
+    already_enabled: list[str],
+) -> Result:
+    """POST one bundleIdCapability. Guards first, request second, never both.
+
+    `already_enabled` is passed IN rather than read here so the caller's read
+    and this write see the same snapshot — and so the no-op case can be proven
+    without a network fake that has to model Apple's duplicate-create error.
+    """
+    # Guard order is deliberate: the vocabulary check runs before the confirm
+    # check so a typo'd capability is reported as a typo even when the operator
+    # got the literal right.
+    if capability not in KNOWN_CAPABILITIES:
+        return Result(
+            exit_code=EXIT_REFUSED,
+            capability=capability,
+            reason=(
+                f"{capability!r} is not in this tool's closed vocabulary "
+                f"({', '.join(sorted(KNOWN_CAPABILITIES))}). Refusing rather than "
+                f"POSTing an unrecognised string at a live App ID."
+            ),
+        )
+    if confirm != CONFIRM_LITERAL:
+        return Result(
+            exit_code=EXIT_REFUSED,
+            capability=capability,
+            reason=(
+                f"--confirm must be exactly {CONFIRM_LITERAL!r}. Enabling a "
+                f"capability invalidates this App ID's provisioning profiles, so "
+                f"it is not something to do by flag alone."
+            ),
+        )
+
+    if capability in already_enabled:
+        return Result(
+            exit_code=EXIT_OK,
+            capability=capability,
+            already_enabled=True,
+            reason=f"{capability} is already ticked; nothing sent.",
+        )
+
+    body = {
+        "data": {
+            "type": "bundleIdCapabilities",
+            "attributes": {"capabilityType": capability},
+            "relationships": {"bundleId": {"data": {"type": "bundleIds", "id": bundle_key}}},
+        }
+    }
+    try:
+        payload = call("POST", "/v1/bundleIdCapabilities", body)
+    except AscError as failure:
+        return Result(
+            exit_code=EXIT_FAILED, capability=capability, reason=_redact(str(failure))
+        )
+
+    data = payload.get("data") if isinstance(payload, dict) else None
+    capability_id = data.get("id") if isinstance(data, dict) else None
+    return Result(
+        exit_code=EXIT_OK,
+        capability=capability,
+        capability_id=capability_id if isinstance(capability_id, str) else "",
+        reason=f"{capability} enabled.",
+    )
+
+
+def disable_capability(call, capability_id: str, *, confirm: str) -> Result:
+    """DELETE one bundleIdCapability by Apple's resource id — the undo path.
+
+    Also gated on the literal: undoing is as much a live-signing-config change
+    as doing, and an accidental untick during a release would be worse than the
+    accidental tick it was reverting.
+    """
+    if confirm != CONFIRM_LITERAL:
+        return Result(
+            exit_code=EXIT_REFUSED,
+            reason=f"--confirm must be exactly {CONFIRM_LITERAL!r} to disable a capability.",
+        )
+    try:
+        call("DELETE", f"/v1/bundleIdCapabilities/{capability_id}")
+    except AscError as failure:
+        return Result(exit_code=EXIT_FAILED, reason=_redact(str(failure)))
+    return Result(exit_code=EXIT_OK, capability_id=capability_id, reason="capability disabled.")
+
+
+def render(result: Result) -> None:
+    if result.exit_code == EXIT_OK and result.already_enabled:
+        print(f"no change: {result.reason}")
+    elif result.exit_code == EXIT_OK:
+        print(f"OK: {result.reason}")
+        if result.capability_id:
+            print(f"  capability id (for --disable-id): {result.capability_id}")
+            print()
+            print("  NEXT, and it is not optional: this App ID's provisioning")
+            print("  profiles are now INVALID. `match` runs readonly in CI, so the")
+            print("  next release will fetch a stale profile and fail at codesign.")
+            print("  Regenerate once via the Fastfile's documented escape hatch:")
+            print("      gh variable set MATCH_BOOTSTRAP --body true")
+            print("      gh workflow run release.yml --ref main")
+            print("      gh variable delete MATCH_BOOTSTRAP     # after it lands")
+    elif result.exit_code == EXIT_REFUSED:
+        print(f"REFUSED (nothing was sent): {result.reason}")
+    else:
+        print(f"FAILED: {result.reason}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Enable or disable ONE capability on an App ID (WRITES to Apple).",
+    )
+    parser.add_argument("--bundle-id", help="e.g. com.beyondkaira.hayati (with --enable)")
+    parser.add_argument("--enable", metavar="CAPABILITY", help=", ".join(sorted(KNOWN_CAPABILITIES)))
+    parser.add_argument("--disable-id", metavar="ID", help="Apple's bundleIdCapability resource id")
+    parser.add_argument(
+        "--confirm",
+        default="",
+        help=f"must be exactly {CONFIRM_LITERAL!r}; nothing is sent without it",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.enable and not args.disable_id:
+        print("REFUSED (nothing was sent): pass --enable CAPABILITY or --disable-id ID.")
+        return EXIT_REFUSED
+
+    try:
+        token = _tft._token()
+
+        def call(method: str, path: str, body: dict | None = None) -> dict:
+            return _tft._call(token, method, path, body)
+
+    except AscError as failure:
+        print(f"FAILED: {_redact(str(failure))}")
+        return EXIT_FAILED
+
+    if args.disable_id:
+        result = disable_capability(call, args.disable_id, confirm=args.confirm)
+        render(result)
+        return result.exit_code
+
+    if not args.bundle_id:
+        print("REFUSED (nothing was sent): --enable needs --bundle-id.")
+        return EXIT_REFUSED
+
+    # Read first, from the SAME credential and the same snapshot the write will
+    # use, so "already enabled" is a fact rather than an assumption.
+    try:
+        bundle_key = _probe.find_bundle_id(lambda m, p: call(m, p), args.bundle_id)
+        enabled = _probe.list_capabilities(lambda m, p: call(m, p), bundle_key)
+    except AscError as failure:
+        print(f"FAILED: {_redact(str(failure))}")
+        return EXIT_FAILED
+
+    print(f"App ID: {args.bundle_id}")
+    print(f"  currently ticked: {', '.join(enabled) if enabled else '(none)'}")
+    result = enable_capability(
+        call, bundle_key, args.enable, confirm=args.confirm, already_enabled=enabled
+    )
+    render(result)
+    return result.exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tool/ci/appid_capability_enable_test.py
+++ b/tool/ci/appid_capability_enable_test.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Self-tests for appid_capability_enable.py — the WRITE half.
+
+The read half (appid_capabilities.py) says in its own header that it
+deliberately has no code path that could tick a capability, "because a tool
+that could do it would also be a tool that could do it by accident."
+
+That reasoning is still correct and this tool does not contradict it — it
+answers it. The founder authorised the write on 2026-08-06; the accident
+concern is handled the way this repo already handles an irreversible callable,
+with a wire-level confirm literal (the ADR-019 `confirm: 'DELETE'` precedent):
+nothing here mutates without BOTH an explicit --enable and the literal.
+
+Run: python3 tool/ci/appid_capability_enable_test.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+_HERE = pathlib.Path(__file__).parent
+_spec = importlib.util.spec_from_file_location(
+    "appid_capability_enable", _HERE / "appid_capability_enable.py"
+)
+assert _spec is not None and _spec.loader is not None
+mod = importlib.util.module_from_spec(_spec)
+# Register BEFORE exec: @dataclasses.dataclass resolves the defining module out
+# of sys.modules, so a module executed without being registered blows up on its
+# first frozen dataclass with a bare AttributeError.
+sys.modules.setdefault("appid_capability_enable", mod)
+_spec.loader.exec_module(mod)
+
+FAILURES: list[str] = []
+BUNDLE_KEY = "ABCDE12345"
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name}{(': ' + detail) if detail else ''}")
+        FAILURES.append(name)
+
+
+class FakeCall:
+    """Records every (method, path, body) and replays canned responses."""
+
+    def __init__(self, responses: dict | None = None, raises: dict | None = None):
+        self.calls: list[tuple[str, str, dict | None]] = []
+        self.responses = responses or {}
+        self.raises = raises or {}
+
+    def __call__(self, method: str, path: str, body: dict | None = None) -> dict:
+        self.calls.append((method, path, body))
+        for prefix, error in self.raises.items():
+            if path.startswith(prefix) and method == "POST":
+                raise error
+        for prefix, payload in self.responses.items():
+            if path.startswith(prefix):
+                return payload
+        return {}
+
+    @property
+    def writes(self) -> list[tuple[str, str, dict | None]]:
+        return [c for c in self.calls if c[0] in {"POST", "DELETE", "PATCH"}]
+
+
+# --------------------------------------------------------------------------
+# the confirm literal
+
+
+def test_the_confirm_literal_is_required_and_exact() -> None:
+    """Nothing mutates without the wire-level literal (ADR-019 precedent).
+
+    A --enable flag alone is one typo away from a capability change on a live
+    App ID. The literal is never typed by a human in normal use — CI passes it
+    — so it costs nothing and it makes an accidental invocation impossible
+    rather than unlikely.
+    """
+    check("the literal is the documented string", mod.CONFIRM_LITERAL == "ENABLE")
+
+    call = FakeCall()
+    result = mod.enable_capability(
+        call, BUNDLE_KEY, mod.PUSH_NOTIFICATIONS, confirm="", already_enabled=[]
+    )
+    check(
+        "an empty confirm refuses and writes NOTHING",
+        result.exit_code == mod.EXIT_REFUSED and not call.writes,
+        f"exit={result.exit_code} writes={call.writes}",
+    )
+
+    call = FakeCall()
+    result = mod.enable_capability(
+        call, BUNDLE_KEY, mod.PUSH_NOTIFICATIONS, confirm="enable", already_enabled=[]
+    )
+    check(
+        "a lowercased confirm refuses (exact match, like DELETE)",
+        result.exit_code == mod.EXIT_REFUSED and not call.writes,
+    )
+
+    call = FakeCall()
+    result = mod.enable_capability(
+        call, BUNDLE_KEY, mod.PUSH_NOTIFICATIONS, confirm="ENABLE ", already_enabled=[]
+    )
+    check(
+        "a whitespace-padded confirm refuses rather than being trimmed into a yes",
+        result.exit_code == mod.EXIT_REFUSED and not call.writes,
+    )
+
+
+# --------------------------------------------------------------------------
+# the vocabulary
+
+
+def test_an_unknown_capability_is_refused_before_any_request() -> None:
+    """The closed vocabulary is a WRITE guard here, not just a spelling check.
+
+    On the read side an unknown value could only produce a false absence. Here
+    it would POST an arbitrary string to a live App ID, and Apple would either
+    reject it or enable something nobody named.
+    """
+    call = FakeCall()
+    result = mod.enable_capability(
+        call, BUNDLE_KEY, "PUSH_NOTIFICATION", confirm=mod.CONFIRM_LITERAL, already_enabled=[]
+    )
+    check(
+        "a near-miss capability name is refused and issues no request at all",
+        result.exit_code == mod.EXIT_REFUSED and not call.calls,
+        f"calls={call.calls}",
+    )
+
+
+# --------------------------------------------------------------------------
+# idempotence
+
+
+def test_an_already_enabled_capability_is_a_no_op() -> None:
+    """Re-running must never issue a second POST.
+
+    Apple returns an error for a duplicate capability, and a tool whose second
+    run fails is a tool nobody dares re-run — which matters most in exactly the
+    situation where someone is unsure whether the first run landed.
+    """
+    call = FakeCall()
+    result = mod.enable_capability(
+        call,
+        BUNDLE_KEY,
+        mod.PUSH_NOTIFICATIONS,
+        confirm=mod.CONFIRM_LITERAL,
+        already_enabled=[mod.PUSH_NOTIFICATIONS, mod.APPLE_ID_AUTH],
+    )
+    check(
+        "already ticked -> exit 0 and NO write",
+        result.exit_code == mod.EXIT_OK and not call.writes,
+        f"exit={result.exit_code} writes={call.writes}",
+    )
+    check("it says so rather than claiming to have acted", result.already_enabled is True)
+
+
+# --------------------------------------------------------------------------
+# the request Apple actually accepts
+
+
+def test_the_enable_request_shape() -> None:
+    call = FakeCall(responses={"/v1/bundleIdCapabilities": {"data": {"id": "CAP1"}}})
+    result = mod.enable_capability(
+        call,
+        BUNDLE_KEY,
+        mod.PUSH_NOTIFICATIONS,
+        confirm=mod.CONFIRM_LITERAL,
+        already_enabled=[mod.APPLE_ID_AUTH],
+    )
+    check("a fresh enable succeeds", result.exit_code == mod.EXIT_OK, str(result))
+    check("exactly ONE write is issued", len(call.writes) == 1, str(call.writes))
+
+    method, path, body = call.writes[0]
+    check("it POSTs", method == "POST")
+    check("to the collection, not the relationship", path == "/v1/bundleIdCapabilities", path)
+    check(
+        "the body is Apple's bundleIdCapabilities create shape",
+        body
+        == {
+            "data": {
+                "type": "bundleIdCapabilities",
+                "attributes": {"capabilityType": mod.PUSH_NOTIFICATIONS},
+                "relationships": {
+                    "bundleId": {"data": {"type": "bundleIds", "id": BUNDLE_KEY}}
+                },
+            }
+        },
+        str(body),
+    )
+    check("it records the created id so the change can be UNDONE", result.capability_id == "CAP1")
+
+
+def test_the_disable_request_shape() -> None:
+    """Reversibility is a property of this tool, not a promise about Apple.
+
+    Enabling a capability invalidates provisioning profiles. If the release
+    lane cannot regenerate them, the change must be undoable from the same
+    place it was made, by someone who has just watched a build fail.
+    """
+    call = FakeCall()
+    result = mod.disable_capability(call, "CAP1", confirm=mod.CONFIRM_LITERAL)
+    check("a disable succeeds", result.exit_code == mod.EXIT_OK)
+    check("exactly one write", len(call.writes) == 1, str(call.writes))
+    method, path, body = call.writes[0]
+    check("it DELETEs the capability resource by id", (method, path) == ("DELETE", "/v1/bundleIdCapabilities/CAP1"), f"{method} {path}")
+    check("with no body", body is None)
+
+    call = FakeCall()
+    result = mod.disable_capability(call, "CAP1", confirm="")
+    check(
+        "a disable ALSO requires the literal — undo is still a live-config change",
+        result.exit_code == mod.EXIT_REFUSED and not call.writes,
+    )
+
+
+# --------------------------------------------------------------------------
+# failure is never reported as success
+
+
+def test_an_apple_rejection_is_a_failure_not_a_shrug() -> None:
+    call = FakeCall(
+        raises={"/v1/bundleIdCapabilities": mod.AscError("POST /v1/bundleIdCapabilities -> HTTP 403: FORBIDDEN")}
+    )
+    result = mod.enable_capability(
+        call, BUNDLE_KEY, mod.PUSH_NOTIFICATIONS, confirm=mod.CONFIRM_LITERAL, already_enabled=[]
+    )
+    check("a 403 is exit 2, never 0", result.exit_code == mod.EXIT_FAILED, str(result))
+    check("the reason names the HTTP status", "403" in result.reason, result.reason)
+
+
+def test_a_credential_shaped_string_never_reaches_stdout() -> None:
+    """Same anti-leak sentinel as the read half: this tool prints Apple's own
+    error bodies, and a failing request carried an Authorization header."""
+    leaked = "POST /v1/x -> HTTP 401: Bearer eyJhbGciOiJFUzI1NiJ9.fake.sig rejected"
+    call = FakeCall(raises={"/v1/bundleIdCapabilities": mod.AscError(leaked)})
+    result = mod.enable_capability(
+        call, BUNDLE_KEY, mod.PUSH_NOTIFICATIONS, confirm=mod.CONFIRM_LITERAL, already_enabled=[]
+    )
+    check("the bearer token is redacted", "eyJhbGciOiJFUzI1NiJ9" not in result.reason, result.reason)
+    check("something is still said", "401" in result.reason, result.reason)
+
+
+# --------------------------------------------------------------------------
+# exit taxonomy
+
+
+def test_the_exit_codes_are_distinct_and_documented() -> None:
+    codes = {mod.EXIT_OK, mod.EXIT_REFUSED, mod.EXIT_FAILED}
+    check("three distinct codes", len(codes) == 3, str(codes))
+    check("0 is success", mod.EXIT_OK == 0)
+    check(
+        "REFUSED and FAILED are different: 'I would not' is not 'I could not'",
+        mod.EXIT_REFUSED != mod.EXIT_FAILED,
+    )
+
+
+def main() -> int:
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            print(f"{name}:")
+            fn()
+    print()
+    if FAILURES:
+        print(f"FAILED ({len(FAILURES)}): " + ", ".join(FAILURES))
+        return 1
+    print("all green")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The read half (`appid_capabilities.py`) says in its own header that it deliberately cannot do this:

> **WHAT IT IS NOT.** It reads. It cannot tick a capability, and it deliberately has no code path that could: enabling a capability changes how a real binary signs, which is a **founder decision**, and a tool that could do it would also be a tool that could **do it by accident**.

Both halves of that were right. This PR answers them rather than overruling them.

**The founder decision** was settled 2026-08-06: the founder was shown the trade-off — tick it in the portal by hand, or authorise the API path and accept that it invalidates the provisioning profile while `match` runs readonly — and chose the API path explicitly.

**The accident** is the real engineering problem, and it is now *enforced* rather than avoided, using this repo's own prior art:

| Lock | Prior art |
|---|---|
| `--confirm ENABLE`, exact match — `enable` and `ENABLE ` are both refused | ADR-019's `confirm: 'DELETE'` wire literal |
| closed capability vocabulary, checked **before** any request | ADR-026's seasonalWindow discipline, shared with the read half |
| idempotent — already ticked is exit 0 with **no write** | safe to re-run, which matters most when you're unsure the first run landed |
| `--disable-id` undo, gated on the same literal | an accidental untick mid-release would be worse than the tick it reverted |

## Exit taxonomy — two of the three are failures, for different reasons

```
0  enabled (or already was, which is not an error)
1  REFUSED — a guard said no. Nothing was sent. Our opinion, not Apple's.
2  FAILED  — a request went out and did not succeed, or a credential was missing.
```

*"I would not"* and *"I could not"* are different facts, the same reason the read half separates exit 1 from exit 2.

## Verification

21 self-test assertions. **Five mutations, each reddening the assertion that names it:**

- confirm-as-truthy → the lowercase and trailing-space cases
- vocabulary guard removed → the near-miss test, and **the failure output prints the exact POST that would have gone out**
- idempotence removed → the no-op test
- disable ungated → the undo test
- an Apple 403 swallowed as success → the 403 test

## Workflow

`enable`, `disable_id` and `confirm` inputs. The write step runs **before** the existing read, so the read that follows verifies the *new* state rather than reporting a stale snapshot — and it is skipped entirely when neither input is set, so **the default dispatch is exactly the read-only lane it has always been**.

On success the job emits a `::warning::` with the recovery, because a capability change invalidates the profile and CI fetches profiles readonly:

```
gh variable set MATCH_BOOTSTRAP --body true
gh workflow run release.yml --ref main
gh variable delete MATCH_BOOTSTRAP
```

That is the mechanism, not a risk — whoever runs this reads the fix at the moment it becomes their problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)