### PR TITLE
feat(push): aps-environment — the line the whole feature waited on

### DIFF
--- a/app/ios/Runner/Runner.entitlements
+++ b/app/ios/Runner/Runner.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<!-- Sign in with Apple (M1.3). Entitlements are consumed only at codesign
-	     time, so CI's `flutter build ios --no-codesign` is unaffected; the
+	     time, so CI's no-codesign iOS build is unaffected; the
 	     emulator integration tests never invoke native ASAuthorization either.
 	     App Attest (com.apple.developer.devicecheck.appattest-environment) is
 	     deliberately NOT declared yet - deferred to the on-device/Mac slice
@@ -12,6 +12,44 @@
 	<array>
 		<string>Default</string>
 	</array>
+	<!-- PUSH NOTIFICATIONS (ADR-042 D2 step 4, S063). This is the line the whole
+	     notification feature waited on, and it could not land before 2026-08-06.
+
+	     THE ORDER MATTERS AND IT IS NOT REORDERABLE. An entitlement must also
+	     exist in the PROVISIONING PROFILE, and `match` fetches profiles READONLY
+	     (ADR-032) so CI can never mint one. A build claiming this key before the
+	     App ID carried the capability would fail at CODESIGN — and NOT in
+	     ci.yml, whose `ios-build-smoke` builds without codesigning and cannot see it
+	     coming, but in release.yml's macOS sign-upload job, the most expensive
+	     place in the system to learn it. That is ADR-040's recorded history, one
+	     capability over.
+
+	     So the capability came first, measured rather than assumed:
+	       * 2026-08-06, run 31054773143 -> exit 1, PUSH_NOTIFICATIONS ABSENT;
+	       * 2026-08-06, run 31130371860 -> enabled via the App Store Connect API
+	         (founder-authorised), and the verification read in the SAME run
+	         returned exit 0.
+	     Re-measure rather than trusting this comment:
+	         gh workflow run appid-capabilities.yml -f require=PUSH_NOTIFICATIONS
+
+	     UNDO HANDLE, if a signed build ever needs the capability removed:
+	         gh workflow run appid-capabilities.yml \
+	           -f disable_id=Q344R7M7MY_PUSH_NOTIFICATIONS -f confirm=ENABLE
+
+	     `production` because every build that consumes this file is signed for
+	     App Store distribution (release.yml -> match `appstore` -> pilot). A
+	     `development` value would be correct only for a locally-Xcode-signed
+	     debug build, which this project never produces — the dev FLAVOUR is a
+	     Dart entrypoint, not a separate signing identity.
+
+	     STILL DELIBERATELY ABSENT: UIBackgroundModes/remote-notification in
+	     Info.plist. That key is what SEC-3 is waiting for
+	     (secure_storage_pin_lock_store.dart: a locked-device background read of
+	     an `unlocked_this_device` Keychain item fails and hits the fail-open
+	     path). Token CAPTURE needs none of it; only background DELIVERY does.
+	     Decide SEC-3 before adding it. -->
+	<key>aps-environment</key>
+	<string>production</string>
 	<!-- com.apple.developer.associated-domains IS DELIBERATELY ABSENT (ADR-040).
 	     It was here, claiming applinks:ikimiz.web.app and
 	     applinks:ikimiz.beyondkaira.com (ADR-036/039), and it was REMOVED so a

--- a/app/test/release/signing_sentinel_test.dart
+++ b/app/test/release/signing_sentinel_test.dart
@@ -36,6 +36,105 @@ import 'package:flutter_test/flutter_test.dart';
 /// BOUND, recorded: this proves the settings are present and correctly valued.
 /// It cannot prove Apple ACCEPTS them — only a real release-lane run does.
 void main() {
+  // ---------------------------------------------------------------------
+  // Runner.entitlements — the OTHER release-critical file no per-PR check reads.
+  //
+  // Same motivation as the pbxproj sentinel below and a sharper instance of it:
+  // entitlements are consumed only at CODESIGN time, and `ios-build-smoke` runs
+  // without codesigning, so this file is structurally invisible to every
+  // required check. A wrong value here fails in release.yml's macOS job.
+  //
+  // The XML-validity assertion is not pedantry. Until S063 this file was NOT
+  // well-formed XML — two comments contained `--`, which XML forbids inside a
+  // comment — and it had been shipping that way since M1.3 because Xcode's
+  // parser is lenient where a strict one is not. Nothing caught it, because
+  // nothing had ever parsed the file. Now something does.
+  group('Runner.entitlements', () {
+    const entitlementsPath = 'ios/Runner/Runner.entitlements';
+
+    late String source;
+
+    setUpAll(() {
+      final file = File(entitlementsPath);
+      expect(file.existsSync(), isTrue, reason: '$entitlementsPath is missing');
+      source = file.readAsStringSync();
+    });
+
+    test(
+      'is well-formed XML — no `--` inside a comment (it was not, until S063)',
+      () {
+        // Walk the comments only: `--` is legal in element text, illegal between
+        // `<!--` and `-->`. A hand check beats a full XML parser here because the
+        // failure we care about is exactly this one and the message can say so.
+        final comments = RegExp(
+          r'<!--(.*?)-->',
+          dotAll: true,
+        ).allMatches(source);
+        expect(
+          comments,
+          isNotEmpty,
+          reason:
+              'this file is heavily commented; zero matches means the regex broke',
+        );
+        for (final comment in comments) {
+          final body = comment.group(1)!;
+          expect(
+            body.contains('--'),
+            isFalse,
+            reason:
+                'XML forbids `--` inside a comment. Offending comment starts: '
+                '${body.trim().split('\n').first}',
+          );
+        }
+      },
+    );
+
+    test('declares aps-environment = production (ADR-042 D2 step 4)', () {
+      // production, not development: every build that consumes this file is
+      // signed for App Store distribution (release.yml -> match `appstore` ->
+      // pilot). The dev FLAVOUR is a Dart entrypoint, not a signing identity.
+      expect(source, contains('<key>aps-environment</key>'));
+      expect(
+        RegExp(
+          r'<key>aps-environment</key>\s*<string>production</string>',
+        ).hasMatch(source),
+        isTrue,
+        reason: 'aps-environment must be exactly `production`',
+      );
+    });
+
+    test(
+      'keeps Sign in with Apple — the entitlement that was already shipping',
+      () {
+        expect(source, contains('com.apple.developer.applesignin'));
+      },
+    );
+
+    // ADR-040. Re-adding this without first enabling the capability on the App ID
+    // is the exact failure that cost a release, and the file's own comment says
+    // so at length. This pins that the comment is still telling the truth.
+    test('still does NOT declare associated-domains (ADR-040)', () {
+      expect(
+        source.contains('<key>com.apple.developer.associated-domains</key>'),
+        isFalse,
+      );
+    });
+
+    // SEC-3. Background delivery is what the PIN-lock store's recorded finding is
+    // waiting for; token capture needs none of it. If this test goes red, SEC-3
+    // must be decided in the same change, not after it.
+    test('Info.plist declares NO UIBackgroundModes yet (SEC-3 is undecided)', () {
+      final plist = File('ios/Runner/Info.plist').readAsStringSync();
+      expect(
+        plist.contains('UIBackgroundModes'),
+        isFalse,
+        reason:
+            'Adding UIBackgroundModes/remote-notification is the event SEC-3 is '
+            'waiting for (secure_storage_pin_lock_store.dart). Decide it first.',
+      );
+    });
+  });
+
   const pbxprojPath = 'ios/Runner.xcodeproj/project.pbxproj';
 
   /// The founder's Apple Developer Team ID. An identifier, not a credential —


### PR DESCRIPTION
The App ID capability was enabled on 2026-08-06 ([run 31130371860](https://github.com/aytekXR/hayati-mobile-app/actions/runs/31130371860), founder-authorised), and the verification read **in that same run** returned exit 0. So this entitlement can finally land without breaking codesign.

## The order was not reorderable, and it was followed

| # | | |
|---|---|---|
| 1 | measured **ABSENT** | run 31054773143 → exit 1 |
| 2 | **enabled** via the ASC API | run 31130371860 → OK, id `Q344R7M7MY_PUSH_NOTIFICATIONS` |
| 3 | **verified ticked** | same run's read → exit 0 |
| 4 | this PR | |

A build claiming this key before step 2 would have failed at **codesign in `release.yml`'s macOS job** — not in `ci.yml`, which builds without codesigning and is structurally blind to it. ADR-040 is the record of that costing a release, one capability over.

`production`, not `development`: every build that consumes this file is signed for App Store distribution (`release.yml` → match `appstore` → `pilot`). The dev *flavour* is a Dart entrypoint, not a separate signing identity.

## The file was not valid XML, and had not been since M1.3

Adding the key meant parsing the file, and **it would not parse**: two comments contained `--`, which XML forbids inside a comment (`flutter build ios --no-codesign`, quoted in prose).

It has been shipping that way through every signed build, because Xcode's parser is lenient where a strict one is not — and nothing caught it because **nothing had ever parsed the file**. Reworded; it is now well-formed for the first time.

## Pinned, because this file is invisible to every required check

`signing_sentinel_test.dart` gains a `Runner.entitlements` group — same motivation as its pbxproj half and a sharper instance of it, since entitlements are consumed *only* at codesign time:

- **well-formed XML** (no `--` in a comment) — the defect above, now guarded
- `aps-environment` is exactly `production`
- Sign in with Apple is still declared
- `associated-domains` is still **absent** (ADR-040 — re-adding it without the capability is the exact failure that cost a release)
- `Info.plist` declares **no `UIBackgroundModes`** — SEC-3 is the reason, and if that test reddens, **SEC-3 must be decided in the same change**, not after it. Token *capture* needs no background modes; only background *delivery* does.

Three mutations, each reddening the assertion that names it: `development` instead of `production`, key removed entirely, and a `--` reintroduced into a comment.

## ⚠️ Merging this is not the last step

Enabling the capability **invalidated this App ID's provisioning profile.** `match` runs readonly in CI, so the next release fetches a stale profile and fails at codesign unless it is regenerated once via the Fastfile's documented escape hatch:

```
gh variable set MATCH_BOOTSTRAP --body true
gh workflow run release.yml --ref main
gh variable delete MATCH_BOOTSTRAP
```

app: **1658 tests** green.

Part of #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)