### PR TITLE
feat(push): ask for notification permission — without it the whole feature is silent

### DIFF
--- a/app/lib/features/daily_question/presentation/paired_home_screen.dart
+++ b/app/lib/features/daily_question/presentation/paired_home_screen.dart
@@ -17,6 +17,7 @@ import '../../coach/presentation/coach_screen.dart';
 import '../../entitlements/presentation/pack_selection_screen.dart';
 import '../../entitlements/presentation/premium_gate.dart';
 import '../../entitlements/presentation/state/entitlement_providers.dart';
+import '../../notifications/presentation/state/push_token_sync.dart';
 import '../../settings/presentation/widgets/settings_gear_overlay.dart';
 import '../domain/couple.dart';
 import '../domain/couple_answer.dart';
@@ -75,6 +76,25 @@ class _PairedHomeScreenState extends ConsumerState<PairedHomeScreen>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    // ADR-042 D6: ask for notification permission HERE — after pairing, on the
+    // first screen that has actually shown the user what the app is for — and
+    // never during boot. ADR-039 D1/D2 make that binding: the boot is fail-open
+    // and every wait on the launch->paired path is bounded, while a permission
+    // prompt is an indefinite wait on a human. iOS also gives exactly one dialog
+    // per install, so the moment is a product decision and this is it.
+    //
+    // Post-frame and unawaited: this must never delay the first paint, and the
+    // provider swallows every failure (a declined prompt is an ordinary answer,
+    // not an error). PushTokenSync guards itself against repeat calls, so a
+    // rebuild costs nothing.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(
+        ref
+            .read(pushTokenSyncProvider.notifier)
+            .promptForPermissionAndRegister(),
+      );
+    });
   }
 
   @override

--- a/app/lib/features/notifications/data/fcm_push_token_source.dart
+++ b/app/lib/features/notifications/data/fcm_push_token_source.dart
@@ -39,6 +39,21 @@ class FcmPushTokenSource implements PushTokenSource {
   final FirebaseMessaging _messaging;
 
   @override
+  Future<bool> ensurePermission() async {
+    // requestPermission() is idempotent from the caller's side: iOS shows its
+    // dialog only on the first call per install and thereafter returns the
+    // standing answer, so a repeated call is a cheap read rather than a repeated
+    // interruption. `provisional: false` deliberately — a provisional grant
+    // delivers quietly to the notification centre with no alert, which for a
+    // couples app whose whole point is "your partner answered" would look
+    // exactly like the feature not working.
+    final settings = await _messaging.requestPermission();
+    final status = settings.authorizationStatus;
+    return status == AuthorizationStatus.authorized ||
+        status == AuthorizationStatus.provisional;
+  }
+
+  @override
   Future<String?> currentToken() async {
     // On iOS, getToken() throws rather than returning null when APNs has not
     // registered — which is the ordinary state before the entitlement and before

--- a/app/lib/features/notifications/domain/push_token_source.dart
+++ b/app/lib/features/notifications/domain/push_token_source.dart
@@ -15,6 +15,26 @@
 /// written when the plugin lands, and everything that decides anything is here
 /// and tested now.
 abstract interface class PushTokenSource {
+  /// Ask the OS for notification permission, and report whether we now have it.
+  ///
+  /// **This is not optional plumbing — it is the gate everything else is behind.**
+  /// On iOS `getToken()` cannot return a token until the user has authorised
+  /// notifications, so without this call the entire feature is silent: the
+  /// entitlement signs, the plugin initialises, the server composes and routes,
+  /// and no device ever registers. That failure mode has no error surface, which
+  /// is precisely why it is worth a sentence here.
+  ///
+  /// iOS shows its dialog **once per install** and never again, so WHEN this is
+  /// called is a product decision, not a technical one — ADR-042 D6 puts it after
+  /// pairing, on a screen that has already shown the user what the app is for,
+  /// and never during boot (ADR-039 D1/D2: the boot is fail-open and every wait
+  /// on the launch->paired path is bounded; a permission prompt is an indefinite
+  /// wait on a human).
+  ///
+  /// Returns false rather than throwing when permission is denied or
+  /// unavailable — a user who says no is an ordinary state, not an error.
+  Future<bool> ensurePermission();
+
   /// The current registration token, or null when the device has none yet —
   /// permission not granted, APNs not reachable, or the plugin not installed.
   ///

--- a/app/lib/features/notifications/presentation/state/push_token_sync.dart
+++ b/app/lib/features/notifications/presentation/state/push_token_sync.dart
@@ -46,6 +46,11 @@ part 'push_token_sync.g.dart';
 class PushTokenSync extends _$PushTokenSync {
   String? _syncedUid;
 
+  /// Guards the one-shot permission prompt. iOS only ever shows its dialog once
+  /// per install, so a second call is harmless — but re-entering the whole
+  /// capture path on every rebuild of the paired screen would not be.
+  bool _promptedForPermission = false;
+
   /// The token this provider last registered — the one sign-out must remove.
   String? _registeredToken;
 
@@ -102,6 +107,45 @@ class PushTokenSync extends _$PushTokenSync {
       // No source overridden yet (the expected state until D2 step 4), or the
       // plugin failed to initialize. Either way: no pushes, no crash.
       debugPrint('PushTokenSync.tokenRefreshes unavailable: $failure');
+    }
+  }
+
+  /// Ask for notification permission, and register the token if it is granted.
+  ///
+  /// **The call that makes the rest of this file do anything on iOS.** Without a
+  /// permission grant `getToken()` returns nothing, so every other piece —
+  /// entitlement, plugin, callables, sweeps — is correct and silent.
+  ///
+  /// Called from the paired home screen, per ADR-042 D6: after pairing, on a
+  /// screen that has shown the user what the app is for, and never during boot.
+  /// Fire-and-forget by contract — it must never block a frame (ADR-039 D2) and
+  /// it never throws.
+  ///
+  /// Returns whether permission is now held, for callers that want to render
+  /// differently; the registration is the side effect that matters.
+  Future<bool> promptForPermissionAndRegister() async {
+    if (_promptedForPermission) return _registeredToken != null;
+    _promptedForPermission = true;
+    try {
+      final granted = await ref
+          .read(pushTokenSourceProvider)
+          .ensurePermission();
+      if (!granted) {
+        // A user who declines is an ordinary outcome, not a failure. Nothing is
+        // retried and nothing is surfaced: the app works exactly as it did
+        // before push existed.
+        debugPrint('PushTokenSync: notification permission not granted');
+        return false;
+      }
+      // Permission is what was missing; the token can be captured now. The
+      // refresh subscription was already attached at sign-in.
+      await _captureAndRegister(initial: false);
+      return _registeredToken != null;
+    } catch (failure) {
+      debugPrint(
+        'PushTokenSync.promptForPermission failed: ${failure.runtimeType}',
+      );
+      return false;
     }
   }
 

--- a/app/test/features/notifications/push_token_sync_test.dart
+++ b/app/test/features/notifications/push_token_sync_test.dart
@@ -46,6 +46,17 @@ class _FakeSource implements PushTokenSource {
   Exception? currentTokenThrows;
   int currentTokenCalls = 0;
 
+  bool permissionGranted = true;
+  Exception? permissionThrows;
+  int permissionCalls = 0;
+
+  @override
+  Future<bool> ensurePermission() async {
+    permissionCalls++;
+    if (permissionThrows != null) throw permissionThrows!;
+    return permissionGranted;
+  }
+
   final StreamController<String> refreshes =
       StreamController<String>.broadcast();
 
@@ -262,6 +273,86 @@ void main() {
     // The assertion is that pumping the queue completed with no unhandled
     // error: a background sync must never take down the tree.
     expect(repository.registered, isEmpty);
+  });
+
+  // ADR-042 D6. THE call that makes everything else do anything on iOS: without
+  // a permission grant `getToken()` returns nothing, so the entitlement, the
+  // plugin, the callables and the sweeps are all correct and SILENT. That
+  // failure mode has no error surface, which is why it gets its own group.
+  group('promptForPermissionAndRegister (ADR-042 D6)', () {
+    test('grants -> captures the token and registers it', () async {
+      final auth = FakeAuthRepository(initialUser: user);
+      final container = containerFor(auth);
+      final sync = container.read(pushTokenSyncProvider.notifier);
+      await pumpEventQueue();
+      // Nothing registered yet: the source answers only after permission, which
+      // is the whole shape of the iOS contract.
+      repository.registered.clear();
+
+      final granted = await sync.promptForPermissionAndRegister();
+
+      expect(granted, isTrue);
+      expect(source.permissionCalls, 1);
+      expect(repository.registered, ['device-token']);
+    });
+
+    test('declines -> registers NOTHING, and that is not an error', () async {
+      source.permissionGranted = false;
+      final auth = FakeAuthRepository(initialUser: user);
+      final container = containerFor(auth);
+      final sync = container.read(pushTokenSyncProvider.notifier);
+      await pumpEventQueue();
+      repository.registered.clear();
+
+      final granted = await sync.promptForPermissionAndRegister();
+
+      expect(granted, isFalse);
+      expect(repository.registered, isEmpty);
+    });
+
+    // iOS shows its dialog once per install and never again. The guard is not
+    // about the dialog — it is about not re-entering the capture path on every
+    // rebuild of the screen that calls this.
+    test('prompts at most ONCE, however many times it is called', () async {
+      final auth = FakeAuthRepository(initialUser: user);
+      final container = containerFor(auth);
+      final sync = container.read(pushTokenSyncProvider.notifier);
+      await pumpEventQueue();
+
+      await sync.promptForPermissionAndRegister();
+      await sync.promptForPermissionAndRegister();
+      await sync.promptForPermissionAndRegister();
+
+      expect(source.permissionCalls, 1);
+    });
+
+    test('a throwing permission call never escapes', () async {
+      source.permissionThrows = Exception('no notification centre');
+      final auth = FakeAuthRepository(initialUser: user);
+      final container = containerFor(auth);
+      final sync = container.read(pushTokenSyncProvider.notifier);
+      await pumpEventQueue();
+
+      expect(await sync.promptForPermissionAndRegister(), isFalse);
+    });
+
+    // The boot path must never touch this: ADR-039 D1 makes the boot fail-open
+    // and D2 bounds every wait on launch->paired. A permission prompt is an
+    // indefinite wait on a human, so nothing on that path may trigger it.
+    test(
+      'is NEVER triggered by sign-in alone — only by an explicit call',
+      () async {
+        final auth = FakeAuthRepository();
+        final container = containerFor(auth);
+        container.read(pushTokenSyncProvider);
+        await pumpEventQueue();
+
+        auth.emit(user);
+        await pumpEventQueue();
+
+        expect(source.permissionCalls, 0);
+      },
+    );
   });
 
   test('a second user signing in registers for that user', () async {


### PR DESCRIPTION
ADR-042 **D6**, which I had deferred as *"a UI surface"*. That was wrong, and **the way it was wrong is the point.**

## Measured

`grep -rn "requestPermission" app/lib` returns **zero hits** across the whole tree. And on iOS `getToken()` cannot return a token until the user has authorised notifications — the plugin's own `getNotificationSettings` doc-comment says *"To request permissions, call requestPermission."*

So the state before this PR was:

- ✅ capability ticked
- ✅ `aps-environment` signed into build 115
- ✅ plugin initialising
- ✅ callables deployed, rules frozen
- ✅ all three push kinds composing and routing
- ❌ **no device would ever have registered a token**

The founder would have uploaded the APNs key, opened the app, and got **silence** — with nothing anywhere reporting an error, because every layer is fail-open by design.

That is the same defect as M3.4's ✅ (lesson 79) one layer further down: **every piece correct, the chain dead, and no error surface to say so.** It was found by asking *"what would actually happen when the `.p8` lands"* rather than *"is my part done"*.

## What lands

| | |
|---|---|
| `PushTokenSource.ensurePermission()` | the port grows the gate, and its doc-comment says plainly that this is what everything else is behind |
| `FcmPushTokenSource` | implements it. **`provisional: false` deliberately** — a provisional grant delivers quietly to the notification centre with no alert, which for a couples app whose whole point is *"your partner answered"* would look exactly like the feature not working |
| `PushTokenSync.promptForPermissionAndRegister()` | prompt, and on a grant capture + register. Fires once; never throws; a declined prompt is an ordinary answer, not an error |
| `PairedHomeScreen` | calls it post-frame, unawaited |

## Where it is called is the product decision, and D6 already made it

**After pairing, on the first screen that has shown the user what the app is for — never during boot.** ADR-039 D1/D2 are binding: the boot is fail-open and every wait on the launch→paired path is bounded, while a permission prompt is an *indefinite* wait on a human.

iOS also gives exactly **one dialog per install**, so a badly-timed ask is not a bug you can fix in the next build. Pinned by a test that fails if sign-in alone ever triggers it.

## Verification

5 new tests (19 in the file). **Three mutations, each reddening the assertion that names it:**

- ignoring the permission result → *"declines → registers NOTHING"*
- dropping the once-guard → *"prompts at most ONCE"*
- not registering after a grant → *"grants → captures the token and registers it"*

app: **1663 tests** green, analyze clean, format clean.

## Still not delivered

Firebase has no APNs `.p8`, which is console-only — re-checked, not assumed: no `gcloud`, no application-default credential, and the authenticated Firebase CLI has no APNs command.

**This PR removes the last piece of engineering between the app and a notification.** What remains is that upload, and a human with a phone tapping Allow.

Closes ADR-042 D6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)