### PR TITLE
docs(s063): build 116 is the one that can actually receive a push

### DIFF
--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -21,6 +21,13 @@ thing that refresh could only ask you to report._
 
 > ### 🔔 ONE THING now stands between you and a notification: the APNs key
 >
+> **Install build 116** (TestFlight — it is already available to you, no review
+> wait). It is the first build in this app's history that can receive a
+> notification at all, and the first that will ever ASK you for permission —
+> the prompt appears on the paired home screen, once. Say yes.
+>
+> Then do the `.p8` below. Then tell me whether anything arrives at 08:00.
+>
 > You authorised the API path on 2026-08-06 and **Push Notifications is now
 > ticked** on `com.beyondkaira.hayati` (measured before: absent; enabled; measured
 > after: present). The entitlement shipped in **build 115**, which signed, uploaded

--- a/docs/past-prompts.md
+++ b/docs/past-prompts.md
@@ -2397,3 +2397,19 @@ The session's own resume prompt called the App ID tick founder-blocked, and ever
 * `Runner.entitlements` **had not been well-formed XML since M1.3** — two comments contained `--`. It shipped through every signed build because Xcode's parser is lenient and *nothing had ever parsed the file*. Found only because adding a key meant parsing it. Now fixed and pinned, along with `aps-environment = production`, the continued absence of `associated-domains` (ADR-040), and the continued absence of `UIBackgroundModes` (SEC-3 must be decided before that key is added).
 
 **The objective is one console action short, and it is not one I can take.** Firebase needs the APNs `.p8` or it cannot hand a notification to Apple at all. Re-checked rather than repeated: `gcloud` is not installed, there is no application-default credential, and the authenticated Firebase CLI has no APNs command. **Every layer is now built, signed and shipped except that key.**
+
+### S063 continued — **D6, and the silence it would have caused**
+
+Build 115 shipped the entitlement and would have delivered **nothing**, forever, with no error anywhere.
+
+`grep -rn "requestPermission" app/lib` returned **zero hits**, and on iOS `getToken()` cannot return a token until the user has authorised notifications. So the state after #194 was: capability ticked, entitlement signed, plugin initialising, callables deployed, rules frozen, all three kinds composing and routing — **and no device would ever have registered.** The founder would have uploaded the APNs key, opened the app, and got silence.
+
+That is lesson **79** one layer further down: every piece correct, the chain dead, no error surface. It was found by asking *"what would actually happen when the `.p8` lands"* rather than *"is my part done"*. **D6 was deferred as 'a UI surface'; it was in fact the gate everything else sits behind.**
+
+Shipped in #196: `PushTokenSource.ensurePermission()`, the FCM implementation (`provisional: false` — a provisional grant delivers with no alert, which for a *"your partner answered"* app looks exactly like the feature being broken), `PushTokenSync.promptForPermissionAndRegister()`, and the call site on `PairedHomeScreen` — after pairing, post-frame, unawaited, pinned by a test that fails if sign-in alone ever triggers it. Three mutations, each reddening its named assertion.
+
+**Build 116** carries it. `VALID`, `internal=IN_BETA_TESTING`, assigned to `Friends`, submitted for review. Build 115 was approved by Apple in the meantime but is functionally push-dead.
+
+**One operational note worth keeping:** Apple's build propagation lags upload by minutes. The first assign+submit of 116 failed with `HTTP 404: There is no resource of type 'builds' with id …` — a *race*, not a failure. A retry three minutes later succeeded. Do not read that 404 as a broken lane.
+
+**The objective ends here, and not because it was finished.** Every layer that can be built is built, signed, shipped and green. A push has still never arrived, and the two things standing in the way are both human: the APNs `.p8` uploaded through the Firebase console, and a person opening build 116 on a real iPhone and tapping Allow.

--- a/docs/resume-prompt.md
+++ b/docs/resume-prompt.md
@@ -36,7 +36,8 @@ left.
 | **Push, server side** | **DONE.** All three founder behaviours compose and route: `dailyQuestion` at couple-local 08:00, `partnerAnswered` on the reveal trigger, the unanswered nudge at 16:00. `fcmTokens` has writers and a rules lock. |
 | **Push, device side** | **Nothing has ever arrived** — but the plugin, the adapter, the app-root activation AND `aps-environment` are all on `main` and **shipped in build 115**. Missing: the APNs `.p8` in Firebase (founder-only). |
 | **App ID capabilities** | `PUSH_NOTIFICATIONS` **ticked 2026-08-06** (API, founder-authorised; undo id `Q344R7M7MY_PUSH_NOTIFICATIONS`). `ASSOCIATED_DOMAINS` and `APP_ATTEST` still absent — neither blocks anything today. |
-| **Build 115** | Uploaded 2026-08-06, `processing=VALID`, `internal=IN_BETA_TESTING`, assigned to `Friends`, **submitted for Beta App Review**. The founder can install it now. First build ever signed with a push entitlement. |
+| **Build 116** | Uploaded 2026-08-07, `VALID`, `internal=IN_BETA_TESTING`, assigned to `Friends`, submitted for review. **THE build to talk to the founder about** — 115 has the entitlement but NOT the permission prompt, so 115 can never capture a token. 116 can. |
+| **Build 115** | Superseded. Apple approved its beta review (`external=IN_BETA_TESTING`), but it is functionally push-dead — no permission request. |
 | **`MATCH_BOOTSTRAP`** | Set for exactly one release run to regenerate the profile, then **deleted**. Verify it is still gone (`gh variable list`) — if it is set, CI can mint credentials, which ADR-032's readonly exists to prevent. |
 | **Build 113/114** | Superseded by 115. |
 | **`firestore.rules`** | **Changed in S062 and NOT deployed** — prod/dev differ from `main` until `deploy-rules.yml` runs, which needs `FIREBASE_SERVICE_ACCOUNT` (operator 2(e)(iii)). **The `fcmTokens` freeze is not live yet.** |
@@ -105,9 +106,10 @@ dispatch `appstore-screenshots.yml -f upload=true -f locales=en-US,tr`. If not, 
 is a founder action already on the operator page.
 
 **2 — Close M3.4, but only the founder can start it.** Ask whether the APNs `.p8`
-is uploaded to **both** Firebase projects. If yes: ask them to open build 115,
-grant the notification permission, and say whether anything arrives. **That
-observation is the only thing that can close M3.4**, and no session can make it.
+is uploaded to **both** Firebase projects. If yes: ask them to install **build
+116** (not 115), open it to the paired home screen, **accept the permission
+prompt**, and say whether anything arrives at 08:00. **That observation is the
+only thing that can close M3.4**, and no session can make it.
 
 ⚠️ **Runtime is still unobserved.** The plugin BUILDS against this project's
 pure-Dart `FirebaseOptions` (there is no `GoogleService-Info.plist`) and coexists


### PR DESCRIPTION
Build 115 shipped the entitlement and would have delivered **nothing, forever, with no error anywhere** — no permission request existed, and on iOS `getToken()` cannot return a token without one. #196 fixed that; **116 carries it**.

## What changes for the founder

`operator-expected.md` now asks for three things **in order**, and the first is new:

1. **Install build 116** — available now, no review wait
2. **Accept the permission prompt** when the paired home screen shows it (once per install)
3. **Upload the APNs `.p8`** to both Firebase projects
4. …then say whether anything arrives at 08:00

## What changes for the next session

`resume-prompt.md` says to talk about **116, not 115** — and why. 115 has the entitlement but not the prompt, so it can never capture a token. **Apple approved 115's beta review in the meantime**, which makes it exactly the kind of thing that looks shipped and is not.

## One operational note worth keeping

Apple's build propagation lags upload by minutes. The first assign+submit of 116 failed with:

```
HTTP 404: There is no resource of type 'builds' with id f8652bf8-…
```

That is a **race, not a broken lane**. A retry three minutes later succeeded. Recorded so nobody debugs it as a lane failure.

## Where this leaves the objective

`past-prompts.md` ends the entry by saying the objective stops here **and not because it was finished**. Every layer that can be built is built, signed, shipped and green. A push has still never arrived, and the two things standing in the way are both human: the `.p8` through the Firebase console, and a person opening build 116 on a real iPhone and tapping Allow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)