### PR TITLE
docs(s063): correct the record — it was merged and green and NOT RUNNING

### DIFF
--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -21,12 +21,22 @@ thing that refresh could only ask you to report._
 
 > ### 🔔 ONE THING now stands between you and a notification: the APNs key
 >
-> **Install build 116** (TestFlight — it is already available to you, no review
-> wait). It is the first build in this app's history that can receive a
-> notification at all, and the first that will ever ASK you for permission —
-> the prompt appears on the paired home screen, once. Say yes.
+> **Install build 116** (TestFlight — already available to you, no review wait).
+> It is the first build in this app's history that can receive a notification at
+> all, and the first that will ever ASK you for permission — the prompt appears
+> on the paired home screen, once. Say yes.
 >
 > Then do the `.p8` below. Then tell me whether anything arrives at 08:00.
+>
+> **Correction, recorded because you were told otherwise.** On 2026-08-06 you were
+> told everything was built and shipped bar the `.p8`. That was wrong: the server
+> code had been merged but **never deployed**, so the two functions the app calls
+> to register your phone did not exist in production at all. Your phone would have
+> asked for permission, got a token, tried to hand it over, and been told there is
+> no such function — silently, because every layer is built to fail quietly rather
+> than alarm you. Deployed on 2026-08-07 with your authorisation, and verified by
+> reading production back rather than trusting the deploy. The security rules that
+> lock that field went out at the same time.
 >
 > You authorised the API path on 2026-08-06 and **Push Notifications is now
 > ticked** on `com.beyondkaira.hayati` (measured before: absent; enabled; measured

--- a/docs/past-prompts.md
+++ b/docs/past-prompts.md
@@ -2413,3 +2413,20 @@ Shipped in #196: `PushTokenSource.ensurePermission()`, the FCM implementation (`
 **One operational note worth keeping:** Apple's build propagation lags upload by minutes. The first assign+submit of 116 failed with `HTTP 404: There is no resource of type 'builds' with id …` — a *race*, not a failure. A retry three minutes later succeeded. Do not read that 404 as a broken lane.
 
 **The objective ends here, and not because it was finished.** Every layer that can be built is built, signed, shipped and green. A push has still never arrived, and the two things standing in the way are both human: the APNs `.p8` uploaded through the Firebase console, and a person opening build 116 on a real iPhone and tapping Allow.
+
+### S063 continued — **"merged and green" was not "running", and nothing here could have said so**
+
+Everything above was merged, green, and **not deployed**. Production was running Functions from before #190: `registerPushToken` and `unregisterPushToken` **did not exist there at all**, and `questionRollover` had no daily-question pass.
+
+Build 116 would have prompted for permission, captured a token, called the callable, and received **NOT_FOUND** — no token, no push, ever, with no error surface, because every layer is fail-open by design. **The founder had been told twice that everything was shipped bar the `.p8`.** That was false.
+
+**Caught by reading production, not by a check.** `firebase functions:log --project hayatiapp-prod` over four consecutive hourly sweeps showed `sweep complete` and `at-risk sweep complete` and **no `daily-question sweep complete`** — a line the new code emits unconditionally. Its absence was the entire diagnosis. → **lesson 86.**
+
+**Deployed 2026-08-07 with founder authorisation**, both halves, and verified by reading back rather than trusting the deploy output:
+
+* `firebase deploy --only functions` — 13 functions, `registerPushToken` and `unregisterPushToken` **created**; confirmed by `functions:list`.
+* `firebase deploy --only firestore:rules` — confirmed by the repo's own instrument, `rules_drift.py --from-firebase-cli` → **exit 0, "MATCHES the ruleset on this ref"**. The `fcmTokens` freeze is live in production for the first time.
+
+**#166 gets its concrete recurrence.** It has been open since 2026-08-01 saying nothing compares deployed Functions to `main`; the comment records that this instance cost the whole feature, and that two *cheap partial* checks would each have caught it — a deployed-function-list set comparison, or an assertion over the sweep's own structured log. Neither answers the exhaustive "is the deployed code identical to main" that the issue was filed against. **Both would have worked, which is the argument for building one.**
+
+**Also true and worth stating: there is no Functions deploy workflow in this repo.** `deploy-rules.yml` and `deploy-site.yml` exist; functions have none. Every deploy is manual, and nothing tracks whether it happened.

--- a/docs/resume-prompt.md
+++ b/docs/resume-prompt.md
@@ -19,8 +19,9 @@ left.
 
 > **Push is no longer this file's objective.** S063 took it as far as engineering
 > reaches: the capability is ticked, `aps-environment` is signed into **build
-> 115**, and all three behaviours compose and route. **One console action
-> remains** — the APNs `.p8` into both Firebase projects — and it is
+> 116**, all three behaviours compose and route, and — this was nearly missed —
+> **the server half is now actually DEPLOYED** (it had been merged and green and
+> not running; lesson **86**). **One console action remains** — the APNs `.p8` into both Firebase projects — and it is
 > founder-only and unmeasurable (`gcloud` absent, no ADC, no Firebase CLI APNs
 > command; re-checked 2026-08-06, do not re-derive by guessing). When the founder
 > says it is done, the very next thing to do is **ask them to open build 115,
@@ -39,6 +40,8 @@ left.
 | **Build 116** | Uploaded 2026-08-07, `VALID`, `internal=IN_BETA_TESTING`, assigned to `Friends`, submitted for review. **THE build to talk to the founder about** — 115 has the entitlement but NOT the permission prompt, so 115 can never capture a token. 116 can. |
 | **Build 115** | Superseded. Apple approved its beta review (`external=IN_BETA_TESTING`), but it is functionally push-dead — no permission request. |
 | **`MATCH_BOOTSTRAP`** | Set for exactly one release run to regenerate the profile, then **deleted**. Verify it is still gone (`gh variable list`) — if it is set, CI can mint credentials, which ADR-032's readonly exists to prevent. |
+| **Deployed Functions** | Brought up to `main` on 2026-08-07 by hand (there is **no deploy workflow** — see #166). **Re-measure, do not inherit:** `firebase functions:list --project hayatiapp-prod` against the exports in `functions/src/index.ts`, and `firebase functions:log --only questionRollover` for the three per-sweep summary lines. A missing `daily-question sweep complete` means prod is behind again. |
+| **Deployed rules** | Match `main` as of 2026-08-07 (`rules_drift.py --project hayatiapp-prod --from-firebase-cli` → exit 0). The `fcmTokens` freeze is live. |
 | **Build 113/114** | Superseded by 115. |
 | **`firestore.rules`** | **Changed in S062 and NOT deployed** — prod/dev differ from `main` until `deploy-rules.yml` runs, which needs `FIREBASE_SERVICE_ACCOUNT` (operator 2(e)(iii)). **The `fcmTokens` freeze is not live yet.** |
 | **Screenshots** | en-US: 6 live since 2026-08-03. `tr` never uploaded. |

--- a/docs/session-lessons.md
+++ b/docs/session-lessons.md
@@ -38,6 +38,35 @@ something, ask which of these you are standing in:
 
 ### Recent, in full
 
+**86 — "Merged and green" is not "running". This repo has no instrument that can tell you the difference for Functions, and it cost the whole push feature.** *(2026-08-07)*
+S062/S063 merged the entire push stack across #187-#196. Every PR green, every
+post-merge `main` run green including `integration-emulator`, the capability
+ticked, the entitlement signed, two builds shipped. I told the founder more than
+once that *"everything is built and shipped except the APNs `.p8`."*
+
+**Production was running Functions code from before #190.** `registerPushToken`
+and `unregisterPushToken` did not exist there at all. Build 116 would have
+prompted for permission, captured a token, called the callable, and received
+NOT_FOUND — no token, no push, ever, with no error surface, because every layer
+is fail-open by design.
+
+**Nothing in the repository could have told me.** There is no Functions deploy
+workflow (`deploy-rules.yml` and `deploy-site.yml` exist; functions have none),
+so deployment is a manual step nothing tracks, and #166 has been open since
+2026-08-01 saying exactly this.
+
+**How it was actually caught, and the transferable part:** by reading production
+logs — `firebase functions:log --project hayatiapp-prod`. Four consecutive hourly
+sweeps logged the two passes the old code has and **not** the one my new code
+emits unconditionally. The absence of an expected log line was the whole
+diagnosis.
+
+So: **when a feature spans a deploy boundary, "did my code merge" and "is my code
+running" are different questions, and only the second one matters to a user.**
+Ask the second one directly, against the live system, before reporting a feature
+as shipped. The tooling to do it already existed here — an authenticated CLI —
+and no session had thought to point it at production.
+
 **85 — A boundary a past session drew on SAFETY grounds is not the same as one drawn on CAPABILITY grounds, and the two need opposite treatment.** *(2026-08-06)*
 `appid_capabilities.py` was built read-only with an explicit reason in its header:
 enabling a capability "is a founder decision, and a tool that could do it would


### PR DESCRIPTION
I told the founder **twice** that everything was built and shipped bar the APNs `.p8`. **That was false**, and this PR says so on the page they read.

## What was actually true

Production was running Functions from before #190:

```
registerPushToken    ABSENT
unregisterPushToken  ABSENT
questionRollover     pre-#190 (no daily-question pass)
```

Build 116 would have prompted for permission, captured an FCM token, called `registerPushToken` — and got **NOT_FOUND**. No token, no push, ever, **with no error surface**, because every layer is fail-open by design.

## Nothing in this repository could have told me

There is **no Functions deploy workflow** — `deploy-rules.yml` and `deploy-site.yml` exist; functions have none. Deployment is a manual step nothing tracks. That is **#166**, open since 2026-08-01, which now carries its concrete recurrence.

## How it was caught — by reading production, not by a check

```
firebase functions:log --project hayatiapp-prod --only questionRollover
```

Four consecutive hourly sweeps logged `sweep complete` and `at-risk sweep complete` and **no `daily-question sweep complete`** — a line the new code emits unconditionally. **The absence of an expected log line was the entire diagnosis.**

## Deployed 2026-08-07, and verified by reading back

| | |
|---|---|
| functions | 13 deployed; `registerPushToken` + `unregisterPushToken` **created**, confirmed by a fresh `functions:list` |
| rules | confirmed by this repo's own instrument — `rules_drift.py --from-firebase-cli` → **exit 0, "MATCHES the ruleset on this ref"**. The `fcmTokens` freeze is live in production for the first time. |

## Lesson 86

> **"Merged and green" is not "running", and only the second one matters to a user.**

When a feature spans a deploy boundary, *"did my code merge"* and *"is my code running"* are different questions. Ask the second one against the live system before reporting a feature as shipped. The tooling already existed here — an authenticated CLI — and no session had thought to point it at production.

## Handoff

`resume-prompt.md` gives S064 **both** deploy states as things to *re-measure, not inherit*, with the exact commands — and the tell: **a missing `daily-question sweep complete` line means prod is behind again.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)