### PR TITLE
docs(s063): close three handoff gaps — the toolchain, the plan line, the count

### DIFF
--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -65,12 +65,32 @@ M3.4 ~~✅~~ **⚠️ CORRECTED 2026-08-06 (Session 062) — see the note at the
 > it reaches couples who have no streak at all. All three passes still ride **one**
 > couples read per sweep.
 >
-> **It still does not deliver a push**, because `PUSH_NOTIFICATIONS` is **measured
-> absent** on the App ID (2026-08-06, run 31054773143) and a build claiming the
-> entitlement would fail at codesign. Every layer above the device is now built,
-> tested and composed; what is missing is one portal checkbox and the plugin
-> behind it (#188). **M3.4 stays open until a push reaches a device and somebody
-> sees it.**
+> **S063 then closed the device half too** (#191 the plugin, #193 the capability
+> write tool, #194 `aps-environment`, #196 the permission prompt): the App ID
+> capability was ticked with founder authorisation, the entitlement signed, and
+> **build 116** shipped — the first build in this app's history that can receive a
+> notification, and the first that ever asks for permission.
+>
+> **Two corrections belong in this line, because both are the same defect this note
+> exists to record.**
+>
+> 1. **D6 was deferred as "a UI surface" and was in fact the gate.** Nothing in
+>    `app/lib` had ever called `requestPermission`, and on iOS `getToken()` returns
+>    nothing without it. Build 115 shipped the entitlement and could never have
+>    captured a token. Fixed in #196.
+> 2. **The server half was merged, green, and NOT DEPLOYED.** Production ran
+>    Functions from before #190 — `registerPushToken` and `unregisterPushToken` did
+>    not exist there at all, so the app would have called them and received
+>    NOT_FOUND, silently. Deployed 2026-08-07 with founder authorisation and
+>    verified RUNNING by the production sweep log, not by the deploy's own output
+>    (lesson **86**; issue **#166**).
+>
+> **It still has not delivered a push.** What remains is not engineering: the APNs
+> `.p8` uploaded through the Firebase console (console-only — no `gcloud`, no ADC,
+> no CLI command), and a human opening build 116 on a real iPhone and granting
+> permission. **M3.4 stays open until a push reaches a device and somebody sees
+> it** — which, three false "it's done" reports later, is exactly why that
+> criterion is written this way.
 
 ## M4 — Paywall & entitlements (3 sessions)
 

--- a/docs/resume-prompt.md
+++ b/docs/resume-prompt.md
@@ -6,7 +6,7 @@
 > Before starting, read the two companions:
 > * **`session-context.md`** — toolchain, machine, review discipline, binding
 >   invariants, and the never-without-asking list.
-> * **`session-lessons.md`** — the institutional lessons, numbered to **85**. Cited
+> * **`session-lessons.md`** — the institutional lessons, numbered to **86**. Cited
 >   below by number.
 >
 > Re-derive the session number from `git log`; a session on another machine can consume it.

--- a/docs/session-context.md
+++ b/docs/session-context.md
@@ -50,6 +50,22 @@ _Environment facts below were last re-measured **2026-08-05**._
   cannot be verified from here — say so rather than asserting it.
 * The `firebase` CLI **is** logged in as the founder (`aaytekinerdogan@gmail.com`) with access
   to `hayatiapp-prod` and `hayatiapp-dev`. That is a **local** path only.
+* **What that login can actually do was unknown until S063, and one of them is the only
+  instrument this repo has for a question it keeps getting wrong.** All four work today:
+
+  | | |
+  |---|---|
+  | `firebase functions:log --project hayatiapp-prod --only <fn>` | **reads PRODUCTION logs.** This is what caught S063's silent failure: four hourly sweeps logged two of the three per-pass summaries, and the missing line was the whole diagnosis. Free, read-only, instant. |
+  | `firebase functions:list --project hayatiapp-prod` | the deployed function inventory. Set-compare it against the exports in `functions/src/index.ts`. |
+  | `python3 tool/ci/rules_drift.py --project hayatiapp-prod --from-firebase-cli` | verifies deployed rules against this ref **with no `FIREBASE_SERVICE_ACCOUNT`** — the CI lane needs that secret, this path does not. |
+  | `firebase deploy --only functions` / `--only firestore:rules` | the deploy. **§7 applies — ask first.** |
+
+  **There is no Functions deploy workflow** (`deploy-rules.yml` and `deploy-site.yml` exist;
+  functions have none), so deployment is a manual step nothing tracks. That is issue **#166**,
+  and it cost S063 the entire push feature: everything merged, every check green, and the
+  callables the app calls did not exist in production. **"Merged and green" is not "running"**
+  (lesson **86**) — and the first row of that table is how you tell the difference in about
+  ten seconds. Use it before reporting any feature that spans a deploy boundary as shipped.
 
 ## 3. Toolchain and commands
 
@@ -153,7 +169,17 @@ Do not change these without reading the ADR that set them.
   first. *(ADR-041 D5's typed-confirmation guard is a guard, not permission.)*
 * Dispatch the release lane (it uploads a real binary to the founder's TestFlight).
 * Grant public invoker on prod, or migrate RevenueCat subscriber ids.
-* Re-bootstrap `match` certificates.
+* Re-bootstrap `match` certificates. **`MATCH_BOOTSTRAP=true` is a ONE-RUN variable** —
+  it makes `match` non-readonly so it can regenerate a profile. Delete it the moment the
+  run lands, or CI keeps the ability to mint credentials that ADR-032's readonly exists to
+  remove. S063 set it, used it, and deleted it in the same sitting; verify with
+  `gh variable list` rather than assuming.
+* **Enable or disable a capability on the App ID.** `tool/ci/appid_capability_enable.py`
+  exists since S063 and works, behind a `--confirm ENABLE` literal — but it changes how a
+  real binary signs and it **invalidates the existing provisioning profile**. Its read-only
+  sibling's header explains why it was deliberately not built for a year; the founder
+  authorised the write on 2026-08-06 for one capability, which is not standing consent for
+  the next one. Undo is `--disable-id <id>`.
 * `npm audit fix --force`, or downgrade `firebase-admin` (ADR-034 refuses it).
 * Enable Dependabot on the founder's behalf.
 * Guess the founder's legal name into a legal document.


### PR DESCRIPTION
Asked whether the handoff was updated, I checked instead of answering. Five of six documents were current; three things were not.

## `session-context.md` — the one that matters

It already knew the `firebase` CLI is logged in as the founder. It did **not** say what that login can *do* — and one of those things is the only instrument this repo has for a question it keeps getting wrong:

```
firebase functions:log --project hayatiapp-prod --only <fn>
```

That read caught S063's silent failure: four hourly sweeps logged two of the three per-pass summaries, and **the missing line was the whole diagnosis**. Free, read-only, instant — and no session had ever pointed it at production.

Now tabled alongside `functions:list`, the `rules_drift --from-firebase-cli` path (which needs **no** `FIREBASE_SERVICE_ACCOUNT`, unlike the CI lane), and the deploy commands with §7 cross-referenced. Plus the fact that **there is no Functions deploy workflow at all** (#166).

## §7 gains two missing entries

- **`MATCH_BOOTSTRAP` is a one-run variable** — delete it the moment the run lands, or CI keeps the credential-minting ability ADR-032 exists to remove. Verify with `gh variable list`.
- **Enabling/disabling an App ID capability.** The tool exists now and works; it changes how a real binary signs and invalidates the provisioning profile. One authorisation for one capability is not standing consent for the next — which is what that section's own closing line already says about prod, and which I should have applied more tightly when I shipped a second build on the first build's authorisation.

## `implementation-plan.md`

The M3.4 correction predated both D6 (#196) and the deploy discovery, so **the milestone note was itself incomplete in the exact way it exists to warn about**. It now records that D6 was deferred as "a UI surface" and was in fact the gate, and that the server half was merged, green, and not deployed.

The accept line is unchanged, and the reason is now stated: *a push reaching a device and somebody seeing it* is written that way **because of three false "it's done" reports**.

## `resume-prompt.md`

Lesson count 85 → 86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)