### PR TITLE
docs(s063): the handoff was pointing at the build that CANNOT work

### DIFF
--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -40,7 +40,7 @@ thing that refresh could only ask you to report._
 >
 > You authorised the API path on 2026-08-06 and **Push Notifications is now
 > ticked** on `com.beyondkaira.hayati` (measured before: absent; enabled; measured
-> after: present). The entitlement shipped in **build 115**, which signed, uploaded
+> after: present). The entitlement shipped in **build 115** (and 116), which signed, uploaded
 > and is **installable by you right now** — you are an internal tester, so it needs
 > no review.
 >
@@ -67,14 +67,13 @@ thing that refresh could only ask you to report._
 
 > **What changed since the last refresh (2026-08-01):**
 >
-> * ✅ **Apple approved build 113.** It is `IN_BETA_TESTING`, the invitations went
->   out, and **the `Friends` group holds eight — four have installed it.** Item 2(c) is closed
->   and gone from this page.
-> * 🔴 **Two new things need you**, both small, both blocking real work: **4(a)**
->   (an APNs key and one portal tick — without them the app can never send a
->   notification) and **an icon decision** (the box below).
-> * ⚠️ **Build 114 has been sitting unsubmitted since 2026-08-02.** Your testers
->   are on 113, which does not have the "Something went wrong" fix you reported.
+> * ✅ **Apple approved build 113**, and **builds 115 and 116 have since shipped** —
+>   116 on 2026-08-07, carrying the whole notification stack. Your testers are no
+>   longer three weeks behind. Item 2(c) is closed and gone from this page.
+> * ✅ **The portal tick is done** (2026-08-06, with your authorisation, over the
+>   API rather than by hand). Only the APNs **key** is left — the box at the top.
+> * 🔴 **The icon decision is still open** — the box below. It has now waited three
+>   sessions behind the notification work.
 
 **Where things stand in one line:** the MVP is code-complete, both backends run
 current code and current rules, the invite site is live, **build 113 is approved
@@ -86,7 +85,7 @@ decision from you before a session can finish them.
 
 | Question | Where it stands | What is left |
 |---|---|---|
-| **Is the MVP built?** | **~98%** — M1→M6.3 all merged. All three notifications you asked for are built, and **build 115 is the first ever signed to receive them**. The phone can now register itself and the server can address it. **No notification has still ever been delivered**, because Firebase has no APNs key to hand it to Apple with. The plan's ✅ on M3.4 stays struck through until one actually arrives. | **4(a) piece 1** — the `.p8`. Nothing else. |
+| **Is the MVP built?** | **~98%** — M1→M6.3 all merged. All three notifications you asked for are built, deployed and **running in production**, and **build 116 is the first that can actually receive one** — it is the first that asks you for permission, without which iOS never issues a token. (115 has the entitlement but not the prompt, so it cannot work; install 116.) **No notification has still ever been delivered**, because Firebase has no APNs key to hand it to Apple with. The plan's ✅ on M3.4 stays struck through until one actually arrives. | **4(a) piece 1** — the `.p8`. Nothing else. |
 | **Can people install it?** | **100%** — done. Build 113 is approved and live. `Friends` holds eight: you `INSTALLED`, **two anonymous public-link installs**, one emailed tester `INSTALLED`, four `INVITED` (emailed, not yet opened). | Nothing. Ship **114+** so they stop testing three-week-old code. |
 | **Could this go on the public App Store?** | **~55%** — the honest number. The build is ready; the business and legal surface around it is not. | **0(a)** (purchases take money and do not unlock Premium), **0(b)** (the paid loop has never been run end to end), **9** (legal: three blanks, unreviewed, one KVKK filing), **1** and **★** (native TR/AR review — the biggest quality risk, and the crisis lexicon is a safety gate), **8(c)/(d)/(e)**, and **analytics** (Gates 2 and 3 are unfalsifiable without it). |
 
@@ -614,10 +613,11 @@ Build numbers are automatic (`100 + the CI run number`); the *version* (`0.1.0`)
 comes from `app/pubspec.yaml` and must match the tag, and CI stops you loudly if
 they disagree.
 
-⚠️ **Build 114 is uploaded and has never been submitted.** Your eight testers are
-on **113**, which predates the post-sign-in dead-end fix (the "Something went
-wrong" you reported), the real support page, the UI polish pass and the
-iPhone-only change. Submitting it is one dispatch and a session will offer:
+✅ **Resolved 2026-08-06/07.** Build 114 was never submitted, and rather than
+submit a stale binary, **115 and then 116 were built and submitted** — 116 carries
+the post-sign-in dead-end fix (the "Something went wrong" you reported), the real
+support page, the UI polish pass, the iPhone-only change AND the entire
+notification stack. **Install 116.** The dispatch below is kept for the next time:
 
 ```sh
 gh workflow run testflight-testers.yml \

--- a/docs/resume-prompt.md
+++ b/docs/resume-prompt.md
@@ -24,7 +24,7 @@ left.
 > not running; lesson **86**). **One console action remains** — the APNs `.p8` into both Firebase projects — and it is
 > founder-only and unmeasurable (`gcloud` absent, no ADC, no Firebase CLI APNs
 > command; re-checked 2026-08-06, do not re-derive by guessing). When the founder
-> says it is done, the very next thing to do is **ask them to open build 115,
+> says it is done, the very next thing to do is **ask them to open build 116,
 > grant the notification permission, and report whether a push arrives** — that
 > observation is the only thing that can close M3.4, and no session can make it.
 
@@ -35,7 +35,7 @@ left.
 | | State |
 |---|---|
 | **Push, server side** | **DONE.** All three founder behaviours compose and route: `dailyQuestion` at couple-local 08:00, `partnerAnswered` on the reveal trigger, the unanswered nudge at 16:00. `fcmTokens` has writers and a rules lock. |
-| **Push, device side** | **Nothing has ever arrived** — but the plugin, the adapter, the app-root activation AND `aps-environment` are all on `main` and **shipped in build 115**. Missing: the APNs `.p8` in Firebase (founder-only). |
+| **Push, device side** | **Nothing has ever arrived** — but the plugin, the adapter, the app-root activation, `aps-environment` AND the permission prompt are all on `main` and **shipped in build 116**. The server half is deployed and proven running. Missing: the APNs `.p8` in Firebase (founder-only). |
 | **App ID capabilities** | `PUSH_NOTIFICATIONS` **ticked 2026-08-06** (API, founder-authorised; undo id `Q344R7M7MY_PUSH_NOTIFICATIONS`). `ASSOCIATED_DOMAINS` and `APP_ATTEST` still absent — neither blocks anything today. |
 | **Build 116** | Uploaded 2026-08-07, `VALID`, `internal=IN_BETA_TESTING`, assigned to `Friends`, submitted for review. **THE build to talk to the founder about** — 115 has the entitlement but NOT the permission prompt, so 115 can never capture a token. 116 can. |
 | **Build 115** | Superseded. Apple approved its beta review (`external=IN_BETA_TESTING`), but it is functionally push-dead — no permission request. |
@@ -72,7 +72,7 @@ it is load-bearing for the on-device check at operator 4(3).
 
 ### Part 2 — ship the icon in a build
 
-Build 115 went out on 2026-08-06 with the push slice. The icon needs one more.
+Builds 115 and 116 went out on 2026-08-06/07 with the push slice. The icon needs one more.
 
 ```sh
 gh workflow run release.yml --ref main
@@ -119,7 +119,8 @@ pure-Dart `FirebaseOptions` (there is no `GoogleService-Info.plist`) and coexist
 with the scene-based AppDelegate — both proven by a real macOS compile. Nothing has
 proven the swizzling behaves on a live device, or that a token is ever actually
 captured. `PushTokenSync` fails open around all of it, so the honest failure mode
-is silence. **Build 115 is the first build that could show this. Ask.**
+is silence. **Build 116 is the first build that could show this — NOT 115, which has
+the entitlement but no permission prompt and therefore can never capture a token. Ask.**
 
 ⚠️ **Do not add `UIBackgroundModes: remote-notification`** without deciding SEC-3
 first (`secure_storage_pin_lock_store.dart`: a locked-device background read of an


### PR DESCRIPTION
A consistency check over the handoff caught this — which is the only reason it was caught. **Four places in `resume-prompt.md` and three in `operator-expected.md` still named build 115.**

Build 115 has the entitlement and **not** the permission prompt, so it can never capture a token. It is the build that *provably cannot deliver a push*.

The resume prompt was telling the next session to *"ask them to open build 115"* and calling it *"the first build that could show this"*. Following that handoff would have sent the founder to test a dead build, watched nothing happen, and **produced a false negative on the whole feature.**

## `resume-prompt.md`

Every reference now points at 116, and the two load-bearing ones say **why** 115 is not it — so a future reader cannot quietly substitute the number back.

## `operator-expected.md` — worse, because the founder reads it

- The readiness snapshot credited 115 with being *"the first ever signed to receive them"*. True and useless: **signed to receive is not able to ask**, and without the prompt iOS never issues a token. Now says 116, and says why.
- A ⚠️ block still warned that **build 114 was uploaded and never submitted** and that testers were on 113 — three builds stale. 115 and 116 have both shipped and been submitted since. Marked resolved, with the dispatch kept for next time rather than deleted.
- The "what changed" summary still listed **the portal tick as an open ask**. It was done on 2026-08-06 with their authorisation.

The founder-facing page now asks for exactly **one** thing (the APNs `.p8`) and names exactly **one** build (116).

🤖 Generated with [Claude Code](https://claude.com/claude-code)