### PR TITLE
docs(s065): the post-merge run needed a second attempt — say so, and file #208

### DIFF
--- a/docs/past-prompts.md
+++ b/docs/past-prompts.md
@@ -2707,6 +2707,21 @@ after one. Everything below was re-run after the workflow actually finished.
 
 `functions_drift: 159 checks, 0 failed` **read back out of the runner's own job log** · 22/22 mutations redden a named assertion · the tool run live against **both** projects · `ci.yml` parses and the new jobs are wired into `slack-notify`'s fan-in · dev deploy exit 0 and independently re-read.
 
+**The post-merge `main` run needed a second attempt, and that is recorded rather
+than tidied away.** `integration-emulator` was killed at exactly its 50-minute
+budget — reported by GitHub as **`cancelled`**, which reads like someone pressed
+a button — after emitting **nothing for 38 minutes** while parked at `00:00 +0`,
+immediately following a clean 49-second Xcode build. It was not this diff: the
+merge touches nothing under `app/` or `functions/`, and a re-run of the same job
+on the same commit passed with every suite genuinely executing
+(`auth +2`, `daily_question +1`, `pairing +2`, `profile`). `main` is green.
+
+It is instance **two** of this job blowing its budget — the job's own comment
+records S024's, which was answered by raising 40 → 50 — and this one has a
+different shape: S024's was uniform slowness, this was silence. Raising 50 → 60
+would convert a 50-minute hang into a 60-minute one. Filed as **#208** with the
+log excerpt.
+
 Both review panels were checked for `agents_error` / `agents_empty_result` before their distributions were believed (§5.5). The diff panel reported three "empty results" — inspected rather than assumed, and they were three lenses returning an empty *findings array*, not three dead agents. All five findings it did raise were refuted against primary sources; none survived.
 
 ### Operator dependencies

--- a/docs/resume-prompt.md
+++ b/docs/resume-prompt.md
@@ -91,9 +91,11 @@ precedented, but say so rather than letting it look armed.
 deployed, and 116/117 do ask for permission. **Re-derive its state and close it if
 it is stale** rather than re-implementing something that shipped.
 
-**3 — The rest.** Re-derive from `gh issue list`. **#175** (10 of 14 raised cards
-render flat) · **#174** (no `liveRegion` — the reveal is never announced) ·
-**#137** · **#136** · **#129/#121** · **#115** · **#41**.
+**3 — The rest.** Re-derive from `gh issue list`. **#208** (`integration-emulator`
+hung silently and burned its whole 50-minute budget — second blow-out, and
+raising the ceiling again is not a fix) · **#175** (10 of 14 raised cards render
+flat) · **#174** (no `liveRegion` — the reveal is never announced) · **#137** ·
+**#136** · **#129/#121** · **#115** · **#41**.
 
 ⚠️ **Do not add `UIBackgroundModes: remote-notification`** without deciding SEC-3
 first. Token capture needs none of it; only background *delivery* does.


### PR DESCRIPTION
Docs-only. Keeps the S065 record honest and points at **#208**.

The `Proven` line claimed *"post-merge main CI green"*. That is true — but only after a re-run, and the entry did not say so. `integration-emulator` was killed at exactly its 50-minute budget (reported as `cancelled`, which reads like a human pressed a button) after **38 minutes of complete silence** at `00:00 +0`, immediately following a clean 49-second Xcode build.

Checked rather than assumed that it was not the diff: the merge touches nothing under `app/` or `functions/`, and re-running the same job on the same commit passed with every suite genuinely executing.

It is the **second** budget blow-out for this job — the job's own comment records S024's, answered by raising 40 → 50 — and this one has a different shape (silence, not slowness), so raising the ceiling again would convert a 50-minute hang into a 60-minute one. Hence #208 rather than a bump.

`integration-emulator` will skip on this PR's post-merge run: it is gated on `quality.outputs.code_changed`, and this is docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)