### PR TITLE
fix(#188): notifications never arrived — capture asked ONCE, at the exact moment iOS guarantees failure

### DIFF
--- a/app/lib/features/notifications/data/fcm_push_token_source.dart
+++ b/app/lib/features/notifications/data/fcm_push_token_source.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+
 import 'package:firebase_messaging/firebase_messaging.dart';
 
 import '../domain/push_token_source.dart';
@@ -54,12 +56,32 @@ class FcmPushTokenSource implements PushTokenSource {
   }
 
   @override
+  Future<bool> isReadyForToken() async {
+    // ADR-044 D1. iOS mints an FCM token only once APNs has handed the app a
+    // device token, and that arrives asynchronously AFTER the permission grant.
+    // Asking `getToken()` before then throws `apns-token-not-set` — so this is
+    // the question that has to be answered first, and `PushTokenSync` owns the
+    // waiting.
+    //
+    // Thin by contract (ADR-042 D2): one call, no branches of its own beyond the
+    // platform test, nothing to assert about that a fake would not also satisfy.
+    if (!Platform.isIOS) return true;
+    try {
+      return await _messaging.getAPNSToken() != null;
+    } catch (_) {
+      // Not "no" — "cannot tell". The caller retries either way, and a throw
+      // here must never be louder than a null.
+      return false;
+    }
+  }
+
+  @override
   Future<String?> currentToken() async {
     // On iOS, getToken() throws rather than returning null when APNs has not
-    // registered — which is the ordinary state before the entitlement and before
-    // permission. PushTokenSync catches it and logs a no-op, so an absent token
-    // never reaches a user as an error; the null here is for the platforms and
-    // paths where the plugin answers politely.
+    // registered. `isReadyForToken` above is what keeps this call out of that
+    // window; the caller still treats a throw as "not yet" and retries, because
+    // an adapter that can throw for an ordinary absence must not be able to
+    // convert one unlucky moment into permanent silence (ADR-044 D2).
     return _messaging.getToken();
   }
 

--- a/app/lib/features/notifications/domain/push_token_source.dart
+++ b/app/lib/features/notifications/domain/push_token_source.dart
@@ -35,6 +35,26 @@ abstract interface class PushTokenSource {
   /// unavailable — a user who says no is an ordinary state, not an error.
   Future<bool> ensurePermission();
 
+  /// Whether the platform has delivered everything FCM needs before it can mint
+  /// a registration token (ADR-044 D1).
+  ///
+  /// **This exists because iOS cannot produce an FCM token until APNs has handed
+  /// the app a device token, and that handoff completes AFTER
+  /// [ensurePermission] returns.** Called in that window, [currentToken] does
+  /// not return null — it *throws* `apns-token-not-set`. One capture attempt
+  /// issued the instant permission is granted therefore lands inside the exact
+  /// interval in which iOS guarantees it can fail, which is what kept
+  /// `registerPushToken` at zero invocations across builds 115–117 while every
+  /// other layer was verified working in production.
+  ///
+  /// Implementations answer only the question; the WAITING is a decision and
+  /// lives above this port in `PushTokenSync`, where it is provable on Linux
+  /// with a fake (ADR-042 D2's trade, applied to the one piece that had been
+  /// left below the seam).
+  ///
+  /// Trivially true on platforms with no such handshake.
+  Future<bool> isReadyForToken();
+
   /// The current registration token, or null when the device has none yet —
   /// permission not granted, APNs not reachable, or the plugin not installed.
   ///
@@ -42,6 +62,10 @@ abstract interface class PushTokenSource {
   /// normal state before permission, not an error. ADR-039's fail-open posture
   /// applies — a failure here is a logged no-op, exactly as App Check and
   /// Crashlytics fail open where they stand.
+  ///
+  /// A throw is nevertheless treated by the caller as **"not yet"** rather than
+  /// "never" (ADR-044 D2) — an adapter that cannot honour the sentence above is
+  /// a defect, and the caller must not turn it into a permanent silence.
   Future<String?> currentToken();
 
   /// Tokens as FCM rotates them. A refresh invalidates the previous token, so

--- a/app/lib/features/notifications/presentation/state/push_token_sync.dart
+++ b/app/lib/features/notifications/presentation/state/push_token_sync.dart
@@ -6,6 +6,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../auth/domain/auth_state.dart';
 import '../../../auth/presentation/state/auth_controller.dart';
 import '../../domain/push_token_repository_provider.dart';
+import '../../domain/push_token_source.dart';
 import '../../domain/push_token_source_provider.dart';
 
 part 'push_token_sync.g.dart';
@@ -46,10 +47,18 @@ part 'push_token_sync.g.dart';
 class PushTokenSync extends _$PushTokenSync {
   String? _syncedUid;
 
-  /// Guards the one-shot permission prompt. iOS only ever shows its dialog once
-  /// per install, so a second call is harmless — but re-entering the whole
-  /// capture path on every rebuild of the paired screen would not be.
-  bool _promptedForPermission = false;
+  /// Guards RE-ENTRANCY, not repetition (ADR-044 D3).
+  ///
+  /// This used to latch `true` *before* permission was even requested, so a
+  /// capture that failed — which on iOS was the likely outcome, see
+  /// [_captureAndRegister] — was permanent for the life of the process. It now
+  /// only stops two prompts running at once; a granted permission whose capture
+  /// did not produce a token stays retryable on the next paired-home mount.
+  ///
+  /// Re-asking is cheap: iOS shows its dialog once per install and thereafter
+  /// `requestPermission()` returns the standing answer without interrupting
+  /// anyone, so this is a read rather than a second prompt.
+  bool _promptInFlight = false;
 
   /// The token this provider last registered — the one sign-out must remove.
   String? _registeredToken;
@@ -124,21 +133,24 @@ class PushTokenSync extends _$PushTokenSync {
   /// Returns whether permission is now held, for callers that want to render
   /// differently; the registration is the side effect that matters.
   Future<bool> promptForPermissionAndRegister() async {
-    if (_promptedForPermission) return _registeredToken != null;
-    _promptedForPermission = true;
+    // Already holding a token: nothing to ask and nothing to do.
+    if (_registeredToken != null) return true;
+    if (_promptInFlight) return false;
+    _promptInFlight = true;
     try {
       final granted = await ref
           .read(pushTokenSourceProvider)
           .ensurePermission();
       if (!granted) {
         // A user who declines is an ordinary outcome, not a failure. Nothing is
-        // retried and nothing is surfaced: the app works exactly as it did
-        // before push existed.
+        // surfaced: the app works exactly as it did before push existed.
         debugPrint('PushTokenSync: notification permission not granted');
         return false;
       }
-      // Permission is what was missing; the token can be captured now. The
-      // refresh subscription was already attached at sign-in.
+      // Permission is what was missing; the token can be captured now — but on
+      // iOS not necessarily THIS instant, which is what _captureAndRegister's
+      // bounded retry is for. The refresh subscription was already attached at
+      // sign-in.
       await _captureAndRegister(initial: false);
       return _registeredToken != null;
     } catch (failure) {
@@ -146,17 +158,79 @@ class PushTokenSync extends _$PushTokenSync {
         'PushTokenSync.promptForPermission failed: ${failure.runtimeType}',
       );
       return false;
+    } finally {
+      _promptInFlight = false;
     }
   }
 
+  /// How many times capture is attempted before giving up, and the base of the
+  /// linear backoff between attempts (ADR-044 D2).
+  ///
+  /// **Bounded, because ADR-039 D2 requires every wait on the launch→paired path
+  /// to be** — worst case 0.5+1.0+1.5+2.0+2.5 ≈ 7.5s, issued `unawaited` from a
+  /// post-frame callback, so it can never delay a frame. A device that will
+  /// never produce a token pays that once, in the background, and stops.
+  ///
+  /// Overridable so the retry is PROVEN in milliseconds rather than asserted.
+  @visibleForTesting
+  static int tokenCaptureAttempts = 6;
+  @visibleForTesting
+  static Duration tokenCaptureBackoff = const Duration(milliseconds: 500);
+
+  /// Capture the token once the platform can actually produce one, then register.
+  ///
+  /// **This is the fix for the bug that kept the whole feature at zero
+  /// (ADR-044).** iOS mints an FCM token only after APNs answers, which happens
+  /// *after* the permission grant returns — so the old single call, issued the
+  /// instant permission was granted, sat inside the exact window where iOS
+  /// guarantees `getToken()` throws. It caught, logged, and never tried again.
+  ///
+  /// A throw is therefore **"not yet", never "never"**: the loop asks the port
+  /// whether the platform is ready, and treats both a throw and a null token as
+  /// a reason to wait rather than a reason to stop.
   Future<void> _captureAndRegister({required bool initial}) async {
+    // Resolving the SOURCE is not a transient failure and must not be retried.
+    // There is either an implementation wired at bootstrap or there is not, and
+    // no amount of backoff conjures one — the pre-D2-step-4 state, and every
+    // widget test that builds the app without overriding it.
+    //
+    // Keeping this inside the loop scheduled five pointless timers in exactly
+    // those containers, and `pumpAndSettle` never settles while a timer is
+    // pending: it took 60 unrelated widget tests red. The retry below is for a
+    // source that EXISTS and is not ready yet, which is a different thing.
+    final PushTokenSource source;
     try {
-      final token = await ref.read(pushTokenSourceProvider).currentToken();
-      if (token == null || token.isEmpty) return;
-      await _register(token, initial: initial);
+      source = ref.read(pushTokenSourceProvider);
     } catch (failure) {
-      debugPrint('PushTokenSync.currentToken failed: $failure');
+      debugPrint('PushTokenSync: no push token source: $failure');
+      return;
     }
+    for (var attempt = 0; attempt < tokenCaptureAttempts; attempt++) {
+      try {
+        if (await source.isReadyForToken()) {
+          final token = await source.currentToken();
+          if (token != null && token.isNotEmpty) {
+            await _register(token, initial: initial);
+            return;
+          }
+        }
+      } catch (failure) {
+        // Includes the iOS `apns-token-not-set` throw this loop exists for.
+        debugPrint(
+          'PushTokenSync.currentToken attempt $attempt failed: $failure',
+        );
+      }
+      // A signed-out user mid-retry has nothing left to register to; stop rather
+      // than hold a timer open for an account that is gone.
+      if (_syncedUid == null) return;
+      if (attempt < tokenCaptureAttempts - 1) {
+        await Future<void>.delayed(tokenCaptureBackoff * (attempt + 1));
+      }
+    }
+    debugPrint(
+      'PushTokenSync: no push token after $tokenCaptureAttempts attempts — '
+      'the device has no APNs registration yet, or permission was declined',
+    );
   }
 
   Future<void> _register(String token, {required bool initial}) async {

--- a/app/test/features/notifications/push_token_sync_test.dart
+++ b/app/test/features/notifications/push_token_sync_test.dart
@@ -46,14 +46,32 @@ class _FakeSource implements PushTokenSource {
   Exception? currentTokenThrows;
   int currentTokenCalls = 0;
 
+  /// How many readiness probes answer "not yet" before the platform is ready.
+  /// This is the iOS APNs handshake, which completes AFTER the permission grant
+  /// returns — the window ADR-044's retry exists for.
+  int notReadyForFirst = 0;
+  int readyCalls = 0;
+
+  /// How many `currentToken` calls throw before one succeeds — iOS's
+  /// `apns-token-not-set`, which is a THROW rather than a null.
+  int throwsForFirst = 0;
+
   bool permissionGranted = true;
   Exception? permissionThrows;
   int permissionCalls = 0;
+
+  /// Model the iOS contract rather than a convenient one: before a permission
+  /// grant, iOS mints NO token at all. Default false so the warm-start tests
+  /// keep modelling the ordinary case — permission granted in an earlier
+  /// session, so a restored sign-in gets a token with no prompt.
+  bool tokenOnlyAfterPermission = false;
+  bool _granted = false;
 
   @override
   Future<bool> ensurePermission() async {
     permissionCalls++;
     if (permissionThrows != null) throw permissionThrows!;
+    _granted = permissionGranted;
     return permissionGranted;
   }
 
@@ -63,9 +81,19 @@ class _FakeSource implements PushTokenSource {
   Future<void> dispose() => refreshes.close();
 
   @override
+  Future<bool> isReadyForToken() async {
+    readyCalls++;
+    if (tokenOnlyAfterPermission && !_granted) return false;
+    return readyCalls > notReadyForFirst;
+  }
+
+  @override
   Future<String?> currentToken() async {
     currentTokenCalls++;
     if (currentTokenThrows != null) throw currentTokenThrows!;
+    if (currentTokenCalls <= throwsForFirst) {
+      throw Exception('[firebase_messaging/apns-token-not-set]');
+    }
     return token;
   }
 
@@ -97,9 +125,16 @@ void main() {
   setUp(() {
     repository = _FakeRepository();
     source = _FakeSource();
+    // The retry is PROVEN, not asserted — so it must run in milliseconds. The
+    // attempt COUNT is left at its shipped value on purpose: a test that also
+    // shrank that would stop guarding the bound it exists to guard.
+    PushTokenSync.tokenCaptureBackoff = Duration.zero;
   });
 
-  tearDown(() => source.dispose());
+  tearDown(() {
+    PushTokenSync.tokenCaptureBackoff = const Duration(milliseconds: 500);
+    source.dispose();
+  });
 
   test('warm start: a restored signed-in session registers the current token '
       'with no auth event', () async {
@@ -251,7 +286,7 @@ void main() {
     expect(repository.registered, isEmpty);
   });
 
-  test('a throwing token source never escapes', () async {
+  test('a permanently throwing token source never escapes', () async {
     source.currentTokenThrows = Exception('no APNs token');
     final auth = FakeAuthRepository(initialUser: user);
     final container = containerFor(auth);
@@ -260,6 +295,113 @@ void main() {
     await pumpEventQueue();
 
     expect(repository.registered, isEmpty);
+  });
+
+  // ADR-044. THE regression group. The previous version of this file asserted
+  // that a throwing `currentToken` was a silent no-op — which is exactly what
+  // the bug was, so the test converted the defect into a specification and
+  // nothing could ever go red. On iOS `getToken()` THROWS `apns-token-not-set`
+  // until APNs answers, and APNs answers AFTER the permission grant returns, so
+  // the single capture attempt was issued inside the one window where iOS
+  // guarantees it fails. Measured consequence in production: `registerPushToken`
+  // was never once invoked across builds 115-117, while the server sweep was
+  // logging `checked:1  skippedNoToken:2` at the couple's 08:00.
+  group('capture survives the iOS APNs handshake (ADR-044)', () {
+    test(
+      'a token that only arrives on a LATER attempt is still registered',
+      () async {
+        source.throwsForFirst = 3; // apns-token-not-set, three times
+        final auth = FakeAuthRepository(initialUser: user);
+        final container = containerFor(auth);
+
+        container.read(pushTokenSyncProvider);
+        await pumpEventQueue();
+
+        expect(repository.registered, ['device-token']);
+        expect(source.currentTokenCalls, 4);
+      },
+    );
+
+    test(
+      'a platform that is not READY yet is waited for, not given up on',
+      () async {
+        source.notReadyForFirst = 2; // APNs has not handed over a device token
+        final auth = FakeAuthRepository(initialUser: user);
+        final container = containerFor(auth);
+
+        container.read(pushTokenSyncProvider);
+        await pumpEventQueue();
+
+        expect(repository.registered, ['device-token']);
+        // It did not ask for a token while the platform said it could not mint
+        // one — asking anyway is what threw.
+        expect(source.currentTokenCalls, 1);
+      },
+    );
+
+    test(
+      'the retry is BOUNDED — a device that never becomes ready stops',
+      () async {
+        source.notReadyForFirst = 9999;
+        final auth = FakeAuthRepository(initialUser: user);
+        final container = containerFor(auth);
+
+        container.read(pushTokenSyncProvider);
+        await pumpEventQueue();
+
+        expect(repository.registered, isEmpty);
+        // ADR-039 D2: never an unbounded wait on the launch->paired path.
+        //
+        // The LITERAL, deliberately — not `PushTokenSync.tokenCaptureAttempts`.
+        // Asserting against the constant under test is satisfied by its own
+        // subject (lesson 75): doubling the budget would move both sides and this
+        // check would stay green while the bound it exists to guard had changed.
+        // Caught by the mutation harness, which is what it is for.
+        expect(source.readyCalls, 6);
+        expect(PushTokenSync.tokenCaptureAttempts, 6);
+        expect(source.currentTokenCalls, 0);
+      },
+    );
+
+    // The regression this fix itself introduced, caught by the full suite and
+    // pinned here. A container with no source override is the pre-D2-step-4
+    // state AND every widget test that builds the app — resolving the SOURCE is
+    // not a transient failure, so retrying it only schedules timers, and
+    // `pumpAndSettle` never settles while a timer is pending. It took 60
+    // unrelated widget tests red.
+    testWidgets('NO source override: gives up at once and leaves no pending '
+        'timer for pumpAndSettle to wait on', (tester) async {
+      final auth = FakeAuthRepository(initialUser: user);
+      addTearDown(auth.dispose);
+      final container = ProviderContainer(
+        overrides: [
+          authRepositoryProvider.overrideWith((ref) => auth),
+          pushTokenRepositoryProvider.overrideWith((ref) => repository),
+          // pushTokenSourceProvider deliberately NOT overridden.
+        ],
+      );
+      addTearDown(container.dispose);
+
+      container.read(pushTokenSyncProvider);
+      await tester.pumpAndSettle();
+
+      expect(repository.registered, isEmpty);
+    });
+
+    test('a sign-out mid-retry abandons the capture', () async {
+      source.notReadyForFirst = 9999;
+      final auth = FakeAuthRepository(initialUser: user);
+      final container = containerFor(auth);
+
+      container.read(pushTokenSyncProvider);
+      auth.emit(null);
+      await pumpEventQueue();
+
+      expect(repository.registered, isEmpty);
+      // It stopped early rather than holding the loop open for an account that
+      // is gone: strictly fewer probes than the full budget.
+      expect(source.readyCalls, lessThan(6));
+    });
   });
 
   test('a failing repository never escapes', () async {
@@ -280,6 +422,11 @@ void main() {
   // plugin, the callables and the sweeps are all correct and SILENT. That
   // failure mode has no error surface, which is why it gets its own group.
   group('promptForPermissionAndRegister (ADR-042 D6)', () {
+    // The group's premise, now actually modelled: on iOS no token exists before
+    // the grant, so a sign-in alone registers nothing and this call is the only
+    // thing that can produce one.
+    setUp(() => source.tokenOnlyAfterPermission = true);
+
     test('grants -> captures the token and registers it', () async {
       final auth = FakeAuthRepository(initialUser: user);
       final container = containerFor(auth);
@@ -325,6 +472,29 @@ void main() {
 
       expect(source.permissionCalls, 1);
     });
+
+    // ADR-044 D3. The guard used to latch BEFORE permission was requested, so a
+    // capture that failed was permanent for the life of the process — on iOS,
+    // the likely outcome. It now guards re-entrancy only.
+    test(
+      'a GRANTED permission whose capture failed is retried on a later call',
+      () async {
+        source.notReadyForFirst = 9999; // APNs never answers this time round
+        final auth = FakeAuthRepository(initialUser: user);
+        final container = containerFor(auth);
+        final sync = container.read(pushTokenSyncProvider.notifier);
+        await pumpEventQueue();
+
+        expect(await sync.promptForPermissionAndRegister(), isFalse);
+        expect(repository.registered, isEmpty);
+
+        // The phone finishes its APNs registration a moment later.
+        source.notReadyForFirst = 0;
+
+        expect(await sync.promptForPermissionAndRegister(), isTrue);
+        expect(repository.registered, ['device-token']);
+      },
+    );
 
     test('a throwing permission call never escapes', () async {
       source.permissionThrows = Exception('no notification centre');

--- a/docs/adr/044-apns-readiness-and-the-one-shot-token-capture.md
+++ b/docs/adr/044-apns-readiness-and-the-one-shot-token-capture.md
@@ -1,0 +1,152 @@
+# ADR-044: the notification feature is complete on every side except one racy call — iOS cannot mint an FCM token until APNs answers, and we asked exactly once
+
+- **Status:** Accepted
+- **Date:** 2026-08-09 (Session 066)
+- **Deciders:** session agent (no founder input; this **removes** an operator dependency's ambiguity rather than adding one)
+- **Related:** **ADR-042** (the token lifecycle this amends — D2's seam, D6's prompt placement), **ADR-039** (fail-open boot, bounded waits — D2 is what makes the retry legal), issue **#188**, `docs/architecture.md` §9
+
+## Context — the server half is proven working, to the last inch
+
+The daily-question push has been "built and waiting on the founder" for four
+sessions. It is not. **Production was measured on 2026-08-09**, at the only hour
+where the counters mean anything — 05:00 UTC, which is 08:00 local for the one
+couple, whose stored zone is UTC+3:
+
+```
+question_rollover: sweep complete            existing:1  buckets:1  assigned:0
+W: sweep push skipped, no fcm tokens   recipientUid=lvny6fJ…  kind=dailyQuestion
+W: sweep push skipped, no fcm tokens   recipientUid=ZCBj6Hq…  kind=dailyQuestion
+question_rollover: daily-question sweep complete
+        checked:1  sent:0  skippedNoToken:2  skippedNoDay:0  suppressedQuiet:0  failed:0
+```
+
+The sweep fires at exactly the right local hour, finds the couple, resolves
+**both** members as non-answerers, and composes a push for each. It stops at the
+last inch: **neither member has an FCM token.** Everything upstream of the token
+lookup is verified working in production.
+
+### The counter everyone was reading was the wrong one
+
+`operator-expected.md` and four resume prompts asserted:
+
+> `daily-question sweep — couples checked for push: 0` (every hourly pass).
+> `0` means no phone has ever handed over a token.
+
+**That inference is invalid.** `runDailyQuestion` opens with
+`if (hour !== DAILY_QUESTION_LOCAL_HOUR) continue;` — the pass evaluates only
+buckets whose *couple-local* hour is 8. So `checked: 0` is the **expected**
+reading for 23 of every 24 sweeps, whatever the token state is, and the sweeps
+that were sampled (21:00Z, 22:00Z) were exactly those. The honest instrument is
+`skippedNoToken` at the couple's own hour-8 sweep — which says **2**, and which
+also names the two recipient uids.
+
+This is the repo's recurring shape 3 (*an inherited premise nobody re-measured*)
+and it had a cost: the founder was told for four sessions that one tap was all
+that stood in the way.
+
+## The defect
+
+`FcmPushTokenSource.currentToken()` is one line: `_messaging.getToken()`.
+
+On iOS **FCM cannot mint a registration token until APNs has handed the app a
+device token**, and that handoff is asynchronous — it completes *after*
+`requestPermission()` returns. Called before it, `getToken()` does not return
+null; it **throws** `[firebase_messaging/apns-token-not-set]`.
+
+`PushTokenSync.promptForPermissionAndRegister()` does exactly this:
+
+```dart
+final granted = await source.ensurePermission();   // user taps Allow
+if (!granted) return false;
+await _captureAndRegister(...);                    // -> getToken() -> THROWS
+```
+
+`_captureAndRegister` catches, `debugPrint`s, and returns. **There is no retry.**
+And `_promptedForPermission` is set *before* the attempt, so the prompt path
+never runs again for the life of the process. The single capture attempt is
+issued inside the precise window in which iOS guarantees it can fail.
+
+The only remaining recovery is `onTokenRefresh`, which fires when FCM *generates*
+a token — reliable for a first-ever generation, **not** guaranteed for a token
+that already exists and is merely waiting on its APNs mapping. Recovery is
+therefore timing-dependent, and the observed outcome across builds 115, 116 and
+117 is that `registerPushToken` **has never once been invoked by a device**.
+
+### The port's own contract already said this was wrong
+
+`PushTokenSource.currentToken()` documents: *"Never throws for an ordinary
+absence: a device without a token is the normal state before permission."* The
+FCM adapter's own comment admits it does exactly that — *"On iOS, getToken()
+throws rather than returning null when APNs has not registered"* — and the
+compensation was pushed up into a catch. **An adapter that violates its port's
+contract and documents the violation is a defect with a comment on it**, not a
+design.
+
+Worse, `push_token_sync_test.dart` asserts the swallow is correct
+(`currentTokenThrows = Exception('no APNs token')` → expect a no-op). The test
+blessed the defect, which is why nothing ever went red.
+
+## Decision 1 — Ask the platform whether it is ready, and keep that decision ABOVE the port
+
+The port gains one method:
+
+```dart
+/// Whether the platform has delivered everything FCM needs before it can mint
+/// a token. iOS: an APNs device token. Everywhere else: trivially true.
+Future<bool> isReadyForToken();
+```
+
+`FcmPushTokenSource` implements it thinly (`getAPNSToken() != null`), preserving
+ADR-042 D2's trade: the adapter stays branch-free and untested, and **everything
+that decides anything stays above the seam and is proven on Linux with a fake.**
+
+The rejected alternative was putting the wait inside the adapter. It is fewer
+lines and it is untestable on this machine — the same reasoning ADR-042 D2 used
+to put the lifecycle above the port in the first place, applied to the one piece
+that was left below it.
+
+## Decision 2 — A BOUNDED retry, off the critical path
+
+`PushTokenSync` retries capture while the platform is not ready, with a bounded
+attempt count and linear backoff, and treats a throw from `currentToken()` as
+"not yet" rather than "never".
+
+ADR-039 D2 requires every wait on the launch→paired path to be **bounded**, and
+this one is: at most 6 attempts with 0.5s × n backoff — under 8 seconds
+worst-case, issued `unawaited` from a post-frame callback, so it can never delay
+a frame or block the tree. A device that is genuinely never going to produce a
+token (permission declined, no APNs) costs those 8 seconds once, in the
+background, and then stops.
+
+The attempt count and backoff are `@visibleForTesting` so the retry itself is
+provable in milliseconds rather than asserted.
+
+## Decision 3 — The prompt guard moves AFTER the outcome is known
+
+`_promptedForPermission = true` is currently set before permission is even
+requested, so a failed capture is permanent for the process. It now guards only
+what iOS actually rations — the **dialog** — while a *granted* permission whose
+capture failed remains retryable on the next paired-home mount. iOS shows its
+dialog once per install regardless, so re-entering `ensurePermission()` on a
+later mount is a cheap read of the standing answer, not a second interruption.
+
+## Decision 4 — This is a behaviour change to a shipped path, so it is mutation-checked
+
+The existing test that asserts a `currentToken()` throw is a silent no-op is
+**wrong and is replaced**, not deleted quietly: the new assertion is that a
+throw is *retried* and that a token appearing on a later attempt **is
+registered**. A test that blesses the defect is worse than no test, because it
+converts a bug into a specification.
+
+## Consequences
+
+* The founder's remaining action is unchanged in words — install a build, tap
+  Allow — but it now has a chance of working. Before this, a granted permission
+  had a real chance of registering nothing, silently, forever.
+* **It stays diagnosable without the founder** (lesson 90): the same production
+  instrument that found this — `skippedNoToken` at the couple's hour-8 sweep,
+  and `registerPushToken`'s invocation log — moves the moment a token lands.
+* `operator-expected.md`'s reading of `checked: 0` is corrected in the same diff.
+  A wrong instrument in a founder-facing document is how four sessions of "just
+  tap Allow" happened.
+* Issue **#188** is the device half and this is the last of it.

--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -37,13 +37,41 @@ _Last refreshed: **2026-08-09** (Session 065)._
 >
 > ```
 > registerPushToken     — ever called by a phone?   NO   (only deploy records)
-> daily-question sweep  — couples checked for push:  0    (every hourly pass)
 > ```
 >
-> `0` means no phone has ever handed over a token. **The moment you tap Allow,
-> both numbers move**, and a session can confirm it within minutes without asking
-> you. If they *don't* move, that is the real bug — and it will finally be
-> visible, because every layer of that path is built to fail quietly.
+> ### ⚠️ Corrected 2026-08-09 — we were reading the wrong counter, and there WAS a bug
+>
+> This box used to add *"daily-question sweep — couples checked: 0 on every
+> hourly pass"* and conclude that no phone had ever handed over a token. **That
+> conclusion did not follow.** The sweep only evaluates couples whose own local
+> clock reads 08:00, so `checked: 0` is the expected reading for 23 hours out of
+> every 24 no matter what — and the hours that had been sampled were exactly
+> those. Four sessions repeated it.
+>
+> Measured at the hour it actually means something (05:00 UTC = your 08:00):
+>
+> ```
+> question_rollover: daily-question sweep complete
+>         checked: 1   sent: 0   skippedNoToken: 2   suppressedQuiet: 0   failed: 0
+> ```
+>
+> **Your server side is not waiting for anything — it is working.** It wakes at
+> your 08:00, finds your couple, works out that neither of you has answered yet,
+> and composes a notification for each of you. Then it stops, because neither
+> phone has ever given it an address to send to.
+>
+> **And that was not only because nobody tapped Allow.** There was a real bug in
+> the app: on iOS, Apple does not hand the app its notification address the
+> instant you tap Allow — it arrives a moment later. The app asked once, at
+> exactly the wrong moment, and when that failed it gave up silently and never
+> asked again for the rest of that run. So on the old builds, tapping Allow had a
+> good chance of registering nothing at all, with nothing anywhere reporting a
+> problem. **Fixed in this change** (it now waits for Apple and retries, briefly
+> and in the background).
+>
+> **So please use a build made after 2026-08-09.** Install it, open it to your
+> paired home screen, and tap Allow. A session can then confirm within minutes,
+> without you reporting anything.
 >
 > **Still unticked, still one page, still yours if you want them:**
 > `ASSOCIATED_DOMAINS` (item **2(d)**) and `APP_ATTEST`. Neither blocks
@@ -96,7 +124,7 @@ single thing left is **one install and one tap**.
 
 | Question | Where it stands | What is left |
 |---|---|---|
-| **Is the MVP built?** | **~99%** — M1→M6.3 all merged. All three notifications are built, deployed and **running in production**, the APNs key is uploaded to both projects (you confirmed 2026-08-08), and **every remaining piece is now on your phone's side.** Measured in production the same day: `registerPushToken` exists and **has never once been called by a device**, and every hourly sweep logs `checked: 0` — nobody has a token yet, because nobody has opened a build and accepted the prompt. **No notification has still ever been delivered.** M3.4's ✅ stays struck through until one arrives. | **One install.** Open the build, accept the notification prompt. A session can then verify token capture from the production logs **without you reporting anything** — see 4(a). |
+| **Is the MVP built?** | **~99%** — M1→M6.3 all merged. All three notifications are built, deployed and **running in production**. Measured 2026-08-09 at the only hour the counters mean anything (your 08:00): the sweep found your couple, resolved both of you as not-yet-answered, and composed a push for each — then stopped at `skippedNoToken: 2`, because no phone has ever registered an address. `registerPushToken` has **never once been called by a device**. Part of that was a **real bug on the app side**, fixed 2026-08-09 (ADR-044): iOS delivers the notification address a moment AFTER you tap Allow, and the app asked once, at the wrong moment, then gave up silently. **No notification has still ever been delivered.** M3.4's ✅ stays struck through until one arrives. | **One install of a build made after 2026-08-09.** Open it to your paired home screen and accept the prompt. A session then verifies token capture from the production logs **without you reporting anything** — see 4(a). |
 | **Can people install it?** | **100%** — done, and no longer stale. Builds **115, 116 and 117** have all shipped since; 116 passed Apple's beta review (`external=IN_BETA_TESTING`) and **117 carries the new icon plus the whole notification stack**. `Friends` holds eight: you `INSTALLED`, **two anonymous public-link installs**, one emailed tester `INSTALLED`, four `INVITED` (emailed, not yet opened). | Nothing. Your testers are current. |
 | **Could this go on the public App Store?** | **~55%** — the honest number. The build is ready; the business and legal surface around it is not. | **0(a)** (purchases take money and do not unlock Premium), **0(b)** (the paid loop has never been run end to end), **9** (legal: three blanks, unreviewed, one KVKK filing), **1** and **★** (native TR/AR review — the biggest quality risk, and the crisis lexicon is a safety gate), **8(c)/(d)/(e)**, and **analytics** (Gates 2 and 3 are unfalsifiable without it). |
 
@@ -250,11 +278,14 @@ fails to publish store metadata should not look green and silent.
 > daily-question sweep — "checked": N          (today: 0 on every hourly pass)
 > ```
 >
-> `checked: 0` means no couple even had a token to evaluate. **The moment you
-> accept that prompt, both numbers move**, and a session can confirm capture
-> within minutes without asking you anything. If they do not move, that is the
-> real bug — the one nothing has been able to see until now, because every layer
-> of the token path fails open by design and silence looks identical to success.
+> ⚠️ **Corrected 2026-08-09.** `checked` is only non-zero on the sweep that
+> matches your OWN 08:00 (05:00 UTC), so reading it at any other hour said
+> nothing about tokens — and that is the reading four sessions repeated. At the
+> right hour it says `checked: 1, skippedNoToken: 2`: the server is working and
+> waiting for an address. A **real app-side bug** was also found and fixed the
+> same day (ADR-044) — iOS hands over the address a moment after you tap Allow,
+> and the app asked once, at the wrong moment, then gave up silently. Use a build
+> made after 2026-08-09.
 
 <details><summary>The original two-piece instructions (kept for reference; both pieces are done)</summary>
 

--- a/docs/past-prompts.md
+++ b/docs/past-prompts.md
@@ -2729,3 +2729,94 @@ Both review panels were checked for `agents_error` / `agents_empty_result` befor
 **One changed, none new.** Item **2(e)(iv)** keeps its number (lesson 71) but its *instructions* change: the same read-only service account now needs **Cloud Functions Viewer** alongside Firebase Rules Viewer, and the one secret arms **two** checks. An item whose number survives while its instructions silently grow is how a founder ends up performing yesterday's task.
 
 **#166 closed** with the evidence. **#206 filed** — the deploy lane, the residual, and the reason the dirty-tree branch has to exist at all.
+
+---
+
+## Session 066 — 2026-08-09 — **"the app is not sending notifications" — and it was never only the founder's tap: the counter everyone quoted was hour-gated, and the capture asked once at the exact moment iOS guarantees failure** *(first-hand)*
+
+**Objective (founder directive, mid-session): notifications do not arrive. Fix it.**
+
+The standing story across four sessions was *"everything is built; the founder just has to install a build and tap Allow."* Both halves of that turned out to be wrong in an interesting way: the server side is **better** than claimed (verified working to the last inch), and the device side had a **real bug** that would have swallowed the tap.
+
+### The instrument everyone quoted could not answer the question it was asked
+
+`operator-expected.md` and four resume prompts carried:
+
+> `daily-question sweep — couples checked for push: 0` (every hourly pass).
+> `0` means no phone has ever handed over a token.
+
+`runDailyQuestion` opens with `if (hour !== DAILY_QUESTION_LOCAL_HOUR) continue;` — the pass evaluates **only** buckets whose *couple-local* hour is 8. So `checked: 0` is the expected reading for 23 of every 24 sweeps whatever the token state is, and the sampled hours (21:00Z, 22:00Z) were exactly those. → **lesson 97**.
+
+The couple's zone was derivable from the logs rather than guessed: the assignment pass logs `assigned: 1` at **21:00Z**, which is their local midnight, so they are UTC+3 and their 08:00 is **05:00Z**. At that sweep:
+
+```
+question_rollover: sweep complete                    existing:1  buckets:1
+W: sweep push skipped, no fcm tokens  recipientUid=lvny6fJ…  kind=dailyQuestion
+W: sweep push skipped, no fcm tokens  recipientUid=ZCBj6Hq…  kind=dailyQuestion
+question_rollover: daily-question sweep complete
+        checked:1  sent:0  skippedNoToken:2  skippedNoDay:0  suppressedQuiet:0  failed:0
+```
+
+**The server wakes at the right local hour, finds the couple, resolves both members as non-answerers, composes a push for each, and stops because neither phone has an address.** Every layer above the token lookup is verified working in production — a much stronger statement than the one the docs were making, arrived at by reading the code that increments the counter.
+
+### The bug: one racy call, then silence for the rest of the process
+
+`FcmPushTokenSource.currentToken()` was `_messaging.getToken()`. On iOS **FCM cannot mint a token until APNs has handed the app a device token, and that arrives asynchronously AFTER `requestPermission()` returns** — called before it, `getToken()` does not return null, it **throws** `apns-token-not-set`.
+
+`promptForPermissionAndRegister()` did exactly that: grant → immediately capture → throw → `catch { debugPrint }` → return. **No retry.** And `_promptedForPermission` latched *before* the attempt, so the prompt path never ran again for the life of the process. The one capture attempt was issued inside the precise window in which iOS guarantees it can fail.
+
+The port's own contract already forbade this — *"Never throws for an ordinary absence"* — and the adapter's own comment admitted it violated it. **An adapter that breaks its port's contract and documents the violation is a defect with a comment on it.**
+
+### The test had turned the bug into a specification
+
+`push_token_sync_test.dart` contained *"a throwing token source never escapes"*: make `currentToken` throw, assert nothing is registered, green. That is the defect, asserted as correct — which is why nothing ever reddened. → **lesson 98**. It was replaced rather than deleted quietly; the new assertion is that a throw is **retried** and a token arriving on a later attempt **is registered**.
+
+The fake was also not modelling iOS: it returned a token with no permission, so the group whose comment claimed *"the source answers only after permission, which is the whole shape of the iOS contract"* was not testing that shape at all. It does now.
+
+### The fix (ADR-044)
+
+* **D1** — the port gains `isReadyForToken()`; the adapter answers it thinly (`getAPNSToken() != null`), and the **waiting stays above the seam** where it is provable on Linux with a fake. That is ADR-042 D2's own trade, applied to the one piece that had been left below the port.
+* **D2** — a **bounded** retry: 6 attempts, linear backoff, ≈7.5s worst case, `unawaited` from a post-frame callback. ADR-039 D2 requires bounded, and it is.
+* **D3** — the prompt guard now covers **re-entrancy, not repetition**: a granted permission whose capture failed stays retryable on the next paired-home mount.
+
+### The mutation harness earned its keep immediately
+
+**7 mutations, and the first run had one that reddened nothing** — *"the bound is loosened (attempts doubled)"*. The bounded-ness test asserted `readyCalls == PushTokenSync.tokenCaptureAttempts`, i.e. **against the very constant the mutation moves**: both sides shifted and the check stayed green (lesson 75's shape). Pinned to a literal, and now **7/7 redden a named test**:
+
+| mutation | what reddened |
+|---|---|
+| the retry loop removed (one attempt, as before) | a platform that is not READY yet is waited for |
+| readiness not consulted | a sign-out mid-retry abandons the capture |
+| the bound loosened (attempts doubled) | the retry is BOUNDED |
+| sign-out mid-retry no longer abandons | a sign-out mid-retry abandons the capture |
+| a throw is terminal again (the pre-ADR-044 swallow) | a token that only arrives on a LATER attempt is registered |
+| D3 reverted (latch before the outcome) | prompts at most ONCE, however many times called |
+| an empty-string token accepted | an empty token registers nothing |
+
+### The fix broke 60 unrelated widget tests, and the first explanation was wrong
+
+The full suite came back `-60`, all in `privacy_lock`. The first hypothesis —
+that three concurrent `flutter test` runs had corrupted shared golden/build
+state — was **stated before it was checked, and it was wrong**. A clean solo run
+reproduced the same 60. Running the same file against `origin/main` in a
+throwaway worktree settled it: `+15: All tests passed` there, `+2 -13` here.
+**Self-inflicted.**
+
+`_captureAndRegister` resolved `pushTokenSourceProvider` *inside* the retry loop,
+so in any container without that override — the pre-D2-step-4 state, and every
+widget test that builds the app — it caught "no source" and then still scheduled
+five `Future.delayed` timers. **`pumpAndSettle` never settles while a timer is
+pending.**
+
+Resolving the source **once, outside the loop** fixes it and is also more
+correct: a missing provider is not a transient condition and no backoff conjures
+one. Pinned with a `testWidgets` case that calls `pumpAndSettle` on a container
+with no override, so it cannot come back silently.
+
+### Operator dependency — one, and it is unavoidable
+
+**Proven:** `1669 tests pass` (full suite, run alone) · `flutter analyze` clean ·
+`dart format` clean · 7/7 mutations redden a NAMED test · the push suite at 25
+tests including the no-source regression.
+
+**The fix is in the app binary, so it needs a new TestFlight build**, and dispatching the release lane uploads a real binary to the founder's TestFlight — `session-context.md` §7, a founder ask. **Builds 115–117 all carry the bug**; tapping Allow on them may register nothing. The operator page now says use a build made after 2026-08-09 and explains why, replacing four sessions of "just tap Allow".

--- a/docs/resume-prompt.md
+++ b/docs/resume-prompt.md
@@ -1,4 +1,4 @@
-# Resume Prompt — Session 066
+# Resume Prompt — Session 067
 
 > **This file contains ONE objective. That objective is the session; nothing else is.**
 > (`project-rules.md` #1, `session-rules.md` §1.)
@@ -6,59 +6,46 @@
 > Before starting, read the two companions:
 > * **`session-context.md`** — toolchain, machine, review discipline, binding
 >   invariants, and the never-without-asking list.
-> * **`session-lessons.md`** — the institutional lessons, now numbered to **96**.
->   Cited below by number.
+> * **`session-lessons.md`** — the institutional lessons, now numbered to **98**.
 >
 > Re-derive the session number from `git log`; a session on another machine can consume it.
 
 **Objective: make a failed `deliver` VISIBLE, so a green release can never again
 mean "store metadata silently did not land" — the engineering half of #204.**
 
+> ⚠️ **S066 did not run this objective.** A founder directive arrived mid-session
+> — *"the app is not sending notifications, fix it"* — and superseded it. That
+> work is done and merged (ADR-044); this objective is unchanged and inherits
+> S066's completed measurement phase, which is **recorded as a comment on #204**:
+> the step already exits 1 with an `##[error]`, it has **no `id`** (so
+> `steps.<id>.outcome` is unreachable), and `slack_notify.sh` derives everything
+> from job-level `NEEDS_JSON`, so a step-level failure is structurally invisible
+> to it. Read that comment before designing.
+
 This is not the Turkish-name decision. That half is the founder's and is
 correctly stated on the operator page; **do not touch it and do not re-ask it.**
 
-The defect is underneath it and is entirely ours: `fastlane store_metadata
-(deliver per locale)` in `release.yml` has failed **identically on every release
-since build 112** — six of them — and the step reports success, the job reports
-success, the run is green, and Slack says nothing. `continue-on-error: true` is
-**right** there (ADR-020 D8: the binary already shipped; store copy is
-native-review-gated and must never fail a release). Lesson **69** is exact:
-*`continue-on-error` is not the bug; an UNREAD failure is.*
+The defect is ours: `fastlane store_metadata (deliver per locale)` has failed
+**identically on every release since build 112** — six of them — and the run is
+green and Slack says nothing. `continue-on-error: true` is **right** there
+(ADR-020 D8) — lesson **69**: *`continue-on-error` is not the bug; an UNREAD
+failure is.* It has already produced a wrong instruction to the founder twice
+(lesson **91**).
 
-**It has already produced real harm, twice** — `operator-expected.md` told the
-founder for several sessions that Turkish screenshots were blocked by an unclicked
-button, and S064 wrote a *fresh* version of that same wrong instruction from a
-correct measurement and a wrong inference. That is lesson **91**: an unread
-failure does not stay silent, it gets *explained*, and the explanation lands on a
-person.
+**ADR-024 D1 is binding**: all notifier policy lives in `tool/ci/slack_notify.sh`
+and the notifier has **no vote** on the build. So the fix cannot be "make the
+step fail", and it cannot be a bespoke notification path.
 
-### The constraint that shapes the design
+**Do not grep for Apple's error string.** That is the same defect one level down
+— it goes quiet the day the message changes, and quiet reads as fine. Assert
+**positive evidence of publication per locale** (expected set from
+`fastlane/metadata/*/`, actual from what deliver says it uploaded) and treat
+*absence of evidence* as a finding (lesson **65**), with the repo's exit taxonomy.
 
-**ADR-024 D1: all notifier policy lives in `tool/ci/slack_notify.sh`, and the
-notifier has NO VOTE on the build.** So the fix cannot be "make the step fail",
-and it cannot be a new bespoke notification path. Read that ADR before designing;
-the invariant is binding (`session-context.md` §6).
-
-Read the whole of **#204** — it names the acceptance criteria and its first one
-is *visibility*, not the fix.
-
-### Watch for the shape this repo keeps paying for
-
-Whatever you build, it must be **impossible to satisfy vacuously**. A "check the
-deliver log" step that greps for a string and prints nothing when the log format
-changes is the same defect one level down. Give it a hermetic self-test in
-`quality` and mutation-check it, the way `functions_drift_test.py` and
-`app_icons_test.py` are — and make sure the **absence** of the expected evidence
-is a finding, not a pass (lesson **65**).
-
-⚠️ **You cannot dispatch `release.yml` to test this** — it uploads a real binary
-to the founder's TestFlight and is on the never-without-asking list
-(`session-context.md` §7). Design so the logic is provable *without* a release
-run; the last six runs' logs are already on GitHub and are your fixture source
-(`gh api repos/:owner/:repo/actions/jobs/<id>/logs` — **never** `gh run view
---job --log`, lesson **65**).
-
----
+⚠️ **You cannot dispatch `release.yml` to test this** (§7). The last six runs'
+logs are the fixture source: `gh api repos/:owner/:repo/actions/jobs/<id>/logs`,
+**never** `gh run view --job --log` (lesson **65**). Job ids: `93165024416` (117),
+`92747059901` (116), `92728958753` (115).
 
 ## 1. Where things actually stand *(measured 2026-08-09 — re-measure, do not inherit)*
 
@@ -68,7 +55,9 @@ run; the last six runs' logs are already on GitHub and are your fixture source
 | **`hayatiapp-dev` Functions** | **Deployed from a clean tree this session** and now current: 12 of 13, every hash matching the reference exactly. The 13th (`revenueCatWebhook`) cannot deploy until operator **0(c)**. |
 | **`hayatiapp-prod` Functions** | Running **this ref's source**, but hand-deployed from a laptop that swept in 62 gitignored files, so it does not equal a clean checkout. A **process** gap, not wrong code. That is **#206**, and the tool says so in those words. |
 | **Push, server side** | **DONE and RUNNING.** All 13 exports deployed to prod; all three per-sweep summary lines on every hourly pass. |
-| **Push, device side** | **STILL ZERO — re-measured 2026-08-09.** `registerPushToken` has only ever received `CreateFunction` audit entries, never a device call, and `daily-question sweep complete` still logs `checked: 0` on every pass. Nobody has opened a build and tapped Allow. |
+| **Push, server side — MEASURED PROPERLY at last** | At the couple's OWN 08:00 (05:00Z; they are UTC+3, derived from `assigned: 1` at 21:00Z = local midnight) the sweep logs `checked:1  sent:0  skippedNoToken:2` and names both recipient uids. **Everything above the token lookup is verified working in production.** Reading `checked: 0` at any other hour says nothing — the pass is gated on couple-local hour 8 (lesson **97**). |
+| **Push, device side** | **Was a real BUG, not just a missing tap** (ADR-044, merged S066). iOS delivers the APNs token *after* `requestPermission()` returns; capture asked once, in that window, caught the throw and never retried. **Builds 115–117 all carry it.** Fixed with a bounded retry. `registerPushToken` still has **zero device invocations** — re-measure with `firebase functions:log --only registerPushToken`. |
+| **What push now needs** | **A NEW BUILD.** The fix is in the binary and dispatching `release.yml` is a founder ask (§7). Until a post-2026-08-09 build is installed and the prompt accepted, nothing can arrive. |
 | **Build 117** | Live, `external=IN_BETA_TESTING`, carries the icon and the whole push slice. |
 | **Deployed rules** | Both projects matched `main` on 2026-08-08. Re-measure with `rules_drift.py --from-firebase-cli`. |
 | **`functions-drift` / `rules-drift` in CI** | Both **visibly SKIPPED** by design — one absent secret (operator **2(e)(iv)**, whose instructions changed this session: the same account now needs **Cloud Functions Viewer** too). |
@@ -85,11 +74,11 @@ normal reason to be running it), deploy, **read back**. It will ship *unarmed*
 until operator **2(e)(iii)**, exactly like `deploy-rules.yml` — that is fine and
 precedented, but say so rather than letting it look armed.
 
-**2 — #188 may already be done; verify before working it.** It is blocked "until
-`appid-capabilities.yml` returns exit 0", and `PUSH_NOTIFICATIONS` was ticked on
-**2026-08-06**. Builds 115–117 carry the entitlement, `registerPushToken` is
-deployed, and 116/117 do ask for permission. **Re-derive its state and close it if
-it is stale** rather than re-implementing something that shipped.
+**2 — Verify the push fix landed on a device, the moment a build ships.** The
+instrument needs nothing from the founder (lesson **90**): `firebase functions:log
+--project hayatiapp-prod --only registerPushToken` moves from deploy-audit-only
+to a real invocation, and the couple's **05:00Z** sweep moves from
+`skippedNoToken: 2` to `sent: N`. Read those, not the founder.
 
 **3 — The rest.** Re-derive from `gh issue list`. **#208** (`integration-emulator`
 hung silently and burned its whole 50-minute budget — second blow-out, and

--- a/docs/session-lessons.md
+++ b/docs/session-lessons.md
@@ -38,6 +38,31 @@ something, ask which of these you are standing in:
 
 ### Recent, in full
 
+**98 — A test that asserts the swallow is correct converts the bug into a specification.** *(S066)*
+`push_token_sync_test.dart` contained *"a throwing token source never escapes"*:
+set `currentToken` to throw, assert nothing is registered, green. That is
+**exactly** what the defect was — iOS throws `apns-token-not-set` until APNs
+answers, and the single capture attempt was issued in that window — so the test
+locked the failure in and nothing could ever go red. Fail-open code is
+especially prone to this: *"it did not crash"* is trivially satisfied by *"it did
+nothing."* **When the code under test is allowed to swallow, the test must assert
+what happens NEXT** — retried, recovered, surfaced — not merely that the swallow
+was quiet.
+
+**97 — A counter read at the wrong hour is not evidence, however many times you read it.** *(S066)*
+Four sessions reported *"`checked: 0` on every hourly pass, so no phone has ever
+handed over a token"* and told the founder one tap was all that stood in the way.
+But `runDailyQuestion` opens with `if (hour !== DAILY_QUESTION_LOCAL_HOUR)
+continue` — the pass evaluates only couples whose OWN local clock reads 8, so
+`checked: 0` is the expected reading for 23 hours out of 24 regardless of tokens,
+and the sampled hours were exactly those. At the couple's real 08:00 the same log
+says `checked: 1, skippedNoToken: 2` and names both recipient uids — the opposite
+story: the server works to the last inch. **Before quoting a counter, read the
+code that increments it and ask what the sampling window has to be for the number
+to mean anything.** A gated metric sampled outside its gate is not weak evidence;
+it is no evidence, and it reads exactly like strong evidence.
+
+
 **96 — A read-only review agent will happily run YOUR write-tool, and the revert is silent.** *(S065)*
 `session-context.md` §5.8 already says *after every review workflow returns,
 `git status` must be EMPTY before you commit.* This is how it actually bites.


### PR DESCRIPTION
Founder directive: *"app is not sending notification to remind questions to answer or your partner is answered etc. Fix it."*

The standing story for four sessions was *"everything is built; just install a build and tap Allow."* **Both halves were wrong.**

## The counter everyone quoted could not answer the question

`operator-expected.md` and four resume prompts read `checked: 0` on the hourly sweep as *"no phone has ever handed over a token."* But `runDailyQuestion` opens with:

```ts
if (hour !== DAILY_QUESTION_LOCAL_HOUR) continue;   // only couples whose OWN clock reads 08:00
```

So `checked: 0` is the **expected** reading 23 hours out of 24 whatever the token state is — and the sampled hours (21:00Z, 22:00Z) were exactly those.

The couple's zone was derived, not guessed: the assignment pass logs `assigned: 1` at **21:00Z** = their local midnight ⇒ UTC+3 ⇒ their 08:00 is **05:00Z**. At that sweep:

```
W: sweep push skipped, no fcm tokens   recipientUid=lvny6fJ…  kind=dailyQuestion
W: sweep push skipped, no fcm tokens   recipientUid=ZCBj6Hq…  kind=dailyQuestion
   daily-question sweep complete   checked:1  sent:0  skippedNoToken:2  suppressedQuiet:0  failed:0
```

**The server side works end to end.** It wakes at the right local hour, finds the couple, resolves both members as non-answerers, composes a push for each — and stops because neither phone has an address. That is a *stronger* statement than the docs were making.

## The bug

On iOS, FCM cannot mint a token until **APNs has handed the app a device token**, and that arrives asynchronously **after** `requestPermission()` returns. Called before it, `getToken()` does not return null — it **throws** `apns-token-not-set`.

`promptForPermissionAndRegister()` did precisely that: grant → capture immediately → throw → `catch { debugPrint }`. **No retry.** And `_promptedForPermission` latched *before* the attempt, so it never ran again for the life of the process.

**Builds 115, 116 and 117 all carry this.** Tapping Allow had a good chance of registering nothing, silently, forever.

The port already forbade it — *"Never throws for an ordinary absence"* — and the adapter's own comment admitted it violated that. An adapter that breaks its port's contract and documents the violation is a defect with a comment on it.

## The fix (ADR-044)

* **D1** — the port gains `isReadyForToken()`; the adapter answers it thinly (`getAPNSToken() != null`) and the **waiting stays above the seam**, provable on Linux with a fake. That is ADR-042 D2's own trade, applied to the one piece left below the port.
* **D2** — a **bounded** retry: 6 attempts, linear backoff, ~7.5s worst case, `unawaited` from a post-frame callback (ADR-039 D2). A throw is **"not yet", never "never"**.
* **D3** — the prompt guard covers **re-entrancy, not repetition**: a granted permission whose capture failed stays retryable.

## The test had turned the bug into a specification

`"a throwing token source never escapes"` asserted the swallow was correct — which *is* the defect, so nothing could ever redden. Replaced rather than deleted quietly. The fake also handed out a token with no permission, so the group whose comment claimed to model *"the whole shape of the iOS contract"* wasn't modelling it. It does now.

## This change broke 60 unrelated widget tests before it was right

Worth stating plainly. Resolving the source *inside* the retry loop meant a container with no override caught "no source" and **still scheduled five timers** — and `pumpAndSettle` never settles with a timer pending.

Diagnosed by running the same file against `origin/main` in a throwaway worktree (`+15` passed there, `+2 -13` here), **after a first explanation — concurrent test runs — was stated before it was checked and turned out to be wrong.** The source is now resolved once, outside the loop; a missing provider is not transient. Pinned with a `testWidgets`/`pumpAndSettle` case.

## Proven

`1669 tests pass` (full suite, run alone) · `flutter analyze` clean · `dart format` clean · **7/7 mutations redden a NAMED test** — one of which caught a self-referential assertion of my own, where the boundedness check compared against the very constant the mutation moved.

## What it does NOT do

The fix is in the app binary, so **it needs a new TestFlight build to reach a phone**, and dispatching the release lane is a founder ask (`session-context.md` §7). The operator page now says use a build made after 2026-08-09 and explains why, replacing the "just tap Allow" instruction that was wrong for four sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)