### PR TITLE
docs(s066): a FRESH install of 117 may already work — say so before asking for a build

### DIFF
--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -69,6 +69,26 @@ _Last refreshed: **2026-08-09** (Session 065)._
 > problem. **Fixed in this change** (it now waits for Apple and retries, briefly
 > and in the background).
 >
+> ### 🟢 Worth trying RIGHT NOW, before any of the below — it costs you two minutes
+>
+> **Delete İkimiz from your phone, reinstall build 117 from TestFlight, sign in,
+> and tap Allow.** A *fresh install* has a real chance of working even on the
+> buggy build, and here is the honest reason why.
+>
+> The app does two things: it asks Apple for your notification address once (that
+> is the broken part — it asks a moment too early and gives up), **and** it also
+> listens for Apple to announce a brand-new address. On a phone that has never
+> had one, that announcement fires the first time you grant permission — and the
+> listener is attached *before* the prompt, so it catches it. On an **upgrade**,
+> where an address already existed, nothing new is announced and there is nothing
+> to catch, which matches what we have seen for three builds.
+>
+> So: **delete first, then reinstall.** Not an update — a delete and a fresh
+> install. If notifications start arriving tomorrow at 08:00, that was it.
+>
+> Either way a session can tell within minutes whether your phone registered,
+> without you reporting anything.
+>
 > ### ⚠️ The fix is merged, but it is NOT in any build you can install yet
 >
 > Builds 115, 116 and 117 all carry the bug. **No build carrying the fix exists**


### PR DESCRIPTION
Docs-only, and possibly the shortest path to the founder's actual goal.

`_listenForRefreshes()` attaches the `onTokenRefresh` subscription **at sign-in, before the permission prompt**. On a phone that has never held an FCM token, the *first-ever* token generation fires that event and `_register()` runs — so the broken one-shot capture (ADR-044) gets rescued by the refresh path.

On an **upgrade**, where a token already existed, nothing new is announced and there is nothing to catch. That asymmetry matches the observed history exactly: three builds shipped, zero device registrations.

So there is a two-minute experiment worth offering **before** the thing that needs founder authorisation: **delete the app, reinstall 117 fresh, sign in, tap Allow.** If it works, notifications start at 08:00 tomorrow and no release dispatch is needed at all. If it does not, the merged fix and a new build are waiting.

Ordering the free experiment ahead of the authorisation request is the point of the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)