### PR TITLE
fix(#188): a push arriving while the app is OPEN displayed nothing

### DIFF
--- a/app/lib/core/firebase/messaging_bootstrap.dart
+++ b/app/lib/core/firebase/messaging_bootstrap.dart
@@ -1,0 +1,55 @@
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/foundation.dart';
+
+/// Tell iOS to DISPLAY a push that arrives while the app is in the FOREGROUND
+/// (ADR-044 addendum, issue #188).
+///
+/// **Without this, a delivered notification shows nothing when the app is
+/// open.** iOS's default foreground behaviour is to hand the payload to the app
+/// and present no banner, no sound and no badge; `firebase_messaging` only
+/// overrides that when this option is set. The message is not lost — it is
+/// simply invisible, which is indistinguishable from "notifications are still
+/// broken" to the person testing them.
+///
+/// That matters unevenly across the three pushes, which is why it is worth
+/// fixing rather than filing:
+///
+/// * the **08:00 daily question** lands when the app is almost certainly
+///   backgrounded, so it was never affected;
+/// * **"your partner answered"** fires the instant the other member submits —
+///   precisely when the recipient is most likely to have the app open. The
+///   founder's own words for this feature were *"or your partner is answered"*,
+///   and it is the one most likely to be tested by two people using the app at
+///   the same time.
+///
+/// **Called ONLY by the flavor entrypoints**, never from `initializeFirebase` —
+/// the same rule `activateAppCheck` and `initializeCrashlytics` follow, and for
+/// the same reason: this drives a platform channel and throws in the plain test
+/// VM, while `initializeFirebase` is unit-tested there (`architecture.md` §2).
+///
+/// **Fail-open and never awaited (ADR-039 D1/D2, ADR-022).** A foreground
+/// presentation preference is a display nicety; blocking the first frame on a
+/// channel round-trip to set it would trade a real cost (launch latency) for a
+/// cosmetic one. A throw is a logged no-op, exactly as App Check and Crashlytics
+/// fail open where they stand.
+///
+/// **Deliberately thin and deliberately untested**, on the same trade as
+/// `FcmPushTokenSource` (ADR-042 D2): one plugin call with no branches of its
+/// own, where a fake would satisfy any assertion the real thing would.
+///
+/// Harmless on Android, where the OS decides foreground presentation itself.
+Future<void> configureForegroundNotifications() async {
+  try {
+    await FirebaseMessaging.instance
+        .setForegroundNotificationPresentationOptions(
+          alert: true,
+          badge: true,
+          sound: true,
+        );
+  } catch (failure) {
+    // A device or a test VM without the plugin channel is not an error worth
+    // surfacing: every push still arrives, and still displays whenever the app
+    // is backgrounded, which is the common case.
+    debugPrint('configureForegroundNotifications failed: $failure');
+  }
+}

--- a/app/lib/main_dev.dart
+++ b/app/lib/main_dev.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:cloud_firestore/cloud_firestore.dart' show FirebaseFirestore;
 import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
 import 'package:flutter/widgets.dart'
@@ -11,6 +13,7 @@ import 'core/config/app_config.dart';
 import 'core/firebase/app_check_bootstrap.dart';
 import 'core/firebase/firebase_bootstrap.dart';
 import 'core/firebase/google_sign_in_config.dart';
+import 'core/firebase/messaging_bootstrap.dart';
 import 'core/observability/boot_trace.dart';
 import 'core/observability/crashlytics_bootstrap.dart';
 import 'core/storage/local_flag_store.dart';
@@ -125,6 +128,10 @@ Future<void> main() async {
     ).wait;
     BootTrace.mark(BootTrace.stageLocalStateReady);
     final googleConfig = googleSignInConfigFor(config.flavor);
+    // ADR-044 addendum (#188): ask iOS to SHOW a push that arrives while the
+    // app is open. Unawaited on purpose — a display preference must not cost
+    // launch latency (ADR-022), and it fails open (ADR-039 D1).
+    unawaited(configureForegroundNotifications());
     BootTrace.mark(BootTrace.stageRunApp);
     runHayati(
       config,

--- a/app/lib/main_prod.dart
+++ b/app/lib/main_prod.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:cloud_firestore/cloud_firestore.dart' show FirebaseFirestore;
 import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
 import 'package:flutter/widgets.dart'
@@ -11,6 +13,7 @@ import 'core/config/app_config.dart';
 import 'core/firebase/app_check_bootstrap.dart';
 import 'core/firebase/firebase_bootstrap.dart';
 import 'core/firebase/google_sign_in_config.dart';
+import 'core/firebase/messaging_bootstrap.dart';
 import 'core/observability/boot_trace.dart';
 import 'core/observability/crashlytics_bootstrap.dart';
 import 'core/storage/local_flag_store.dart';
@@ -125,6 +128,10 @@ Future<void> main() async {
     ).wait;
     BootTrace.mark(BootTrace.stageLocalStateReady);
     final googleConfig = googleSignInConfigFor(config.flavor);
+    // ADR-044 addendum (#188): ask iOS to SHOW a push that arrives while the
+    // app is open. Unawaited on purpose — a display preference must not cost
+    // launch latency (ADR-022), and it fails open (ADR-039 D1).
+    unawaited(configureForegroundNotifications());
     BootTrace.mark(BootTrace.stageRunApp);
     runHayati(
       config,

--- a/docs/adr/044-apns-readiness-and-the-one-shot-token-capture.md
+++ b/docs/adr/044-apns-readiness-and-the-one-shot-token-capture.md
@@ -138,6 +138,60 @@ throw is *retried* and that a token appearing on a later attempt **is
 registered**. A test that blesses the defect is worse than no test, because it
 converts a bug into a specification.
 
+## Addendum (same day) — a SECOND defect, found by hunting rather than by waiting
+
+With the fix merged and build 118 shipped, the remaining step was the founder's
+tap. Rather than wait, the whole delivery path was hunted adversarially for a
+second defect that would still stop a notification *after* a valid token landed.
+Five lenses; four found nothing; one found this, and it survived refutation.
+
+**There is no foreground presentation handler anywhere in the app.** No
+`setForegroundNotificationPresentationOptions`, no `onMessage`, no
+`UNUserNotificationCenter` delegate. iOS's default is to hand a foreground push
+to the app and display **nothing** — no banner, no sound, no badge. The message
+is not lost; it is invisible, which to the person testing is indistinguishable
+from *"notifications are still broken."*
+
+It matters unevenly, and that asymmetry is why it was worth fixing now rather
+than filing:
+
+* the **08:00 daily question** arrives when the app is almost certainly
+  backgrounded — never affected;
+* **"your partner answered"** fires the instant the other member submits,
+  precisely when the recipient is most likely to be *in* the app. It is also
+  the push the founder named in their own words, and the one two people testing
+  together would hit first.
+
+`configureForegroundNotifications()` is called fire-and-forget from the flavor
+entrypoints — the rule `activateAppCheck` and `initializeCrashlytics` already
+follow, because it drives a platform channel and `initializeFirebase` is
+unit-tested on a plain VM. Unawaited and fail-open: a display preference must
+not cost launch latency (ADR-022) and must not be able to fail a boot
+(ADR-039 D1).
+
+**Why the entrypoints and not `ensurePermission()`.** The tempting placement is
+beside the permission grant. It is wrong: on a warm start where permission was
+granted in an earlier session, `promptForPermissionAndRegister` returns early on
+an already-registered token and `ensurePermission` is never reached — so the
+option would be set on the first launch after granting and never again.
+
+### What the hunt confirmed, which is worth as much as what it found
+
+Both paths the founder named are **verified working in production**, and they
+are independent of each other:
+
+```
+daily question   05:00Z sweep     checked:1  sent:0  skippedNoToken:2
+partner answered answerReveal     kind=partnerAnswered  "push skipped, no fcm tokens"
+                 (fired 2026-08-06 12:33, 21:26; 2026-08-07 01:14)
+```
+
+Two unrelated triggers, both composing a correct push, both stopping at the same
+missing input. The FCM message shape was checked too — `notification: {title,
+body}`, which is what produces a real alert rather than a silent data message —
+and FCM v1 was probed live and accepts sends for both projects. **No blocker
+remains on the path between an FCM token and a lock screen.**
+
 ## Consequences
 
 * The founder's remaining action is unchanged in words — install a build, tap


### PR DESCRIPTION
Found by **hunting** the delivery path rather than waiting for the founder's tap. Five adversarial lenses over the whole chain; four found nothing; this one survived refutation.

## The defect

iOS's default foreground behaviour is to hand the payload to the app and present **no banner, no sound, no badge**. `firebase_messaging` only overrides that when `setForegroundNotificationPresentationOptions` is set — and nothing in this app set it. No `onMessage` handler and no `UNUserNotificationCenter` delegate either.

The message is not lost. It is **invisible**, which to the person testing is indistinguishable from *"notifications are still broken."*

It matters unevenly, and that asymmetry is why it was worth fixing now rather than filing:

* the **08:00 daily question** arrives when the app is almost certainly backgrounded — never affected;
* **"your partner answered"** fires the instant the other member submits, precisely when the recipient is most likely to be *in* the app. It is the push the founder named in their own words, and the one two people testing together hit first.

## Placement

Fire-and-forget from the flavor entrypoints — the rule `activateAppCheck` and `initializeCrashlytics` already follow, because it drives a platform channel while `initializeFirebase` is unit-tested on a plain VM. Unawaited and fail-open: a display preference must not cost launch latency (ADR-022) nor be able to fail a boot (ADR-039 D1).

**Not** beside the permission grant, which is the tempting placement and is wrong: on a warm start where permission was granted in an earlier session, `promptForPermissionAndRegister` returns early on an already-registered token and `ensurePermission` is never reached — the option would be set once and never again.

## What the hunt confirmed is worth as much as what it found

Both paths the founder named are **verified working in production**, and they are independent of each other:

```
daily question    05:00Z sweep    checked:1  sent:0  skippedNoToken:2
partner answered  answerReveal    kind=partnerAnswered, "push skipped, no fcm tokens"
                                  (fired 2026-08-06 12:33, 21:26; 2026-08-07 01:14)
```

Two unrelated triggers, both composing a correct push, both stopping at the same missing input. The FCM message shape was checked too — `notification: {title, body}`, a real alert rather than a silent data message — and FCM v1 was probed live and accepts sends for both projects.

**No blocker remains between an FCM token and a lock screen.**

## Proven

`1669 tests pass` · `flutter analyze` clean · `dart format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)