### PR TITLE
docs(s066): build 119 carries BOTH fixes — and lesson 99, hunt while blocked

### DIFF
--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -69,20 +69,35 @@ _Last refreshed: **2026-08-09** (Session 065)._
 > problem. **Fixed in this change** (it now waits for Apple and retries, briefly
 > and in the background).
 >
-> ### ✅ BUILD 118 IS UPLOADED AND ON YOUR TESTFLIGHT — it carries the fix
+> ### ✅ BUILD 119 IS ON YOUR TESTFLIGHT — install THIS one, it carries BOTH fixes
 >
 > You authorised the release on 2026-08-09 and it is done. Verified by reading
 > App Store Connect, not by trusting a green build:
 >
 > ```
-> build 118   processing=VALID   uploaded 2026-08-09
+> build 119   processing=VALID   uploaded 2026-08-09
 >     internal = IN_BETA_TESTING             <-- YOU can install it right now
 >     external = READY_FOR_BETA_SUBMISSION   <-- your friends cannot yet, see below
 > ```
 >
-> **Install build 118, open it to your paired home screen, and tap Allow.**
-> That is the whole remaining action, and it is the first build in this app's
-> history that can actually keep the answer.
+> **Install build 119, open it to your paired home screen, and tap Allow.**
+> That is the whole remaining action.
+>
+> **Two separate bugs were found and fixed today, not one.** 118 fixed the first;
+> **119 fixes both** and is the one to install.
+>
+> 1. **The app threw away your notification address.** Apple hands it over a
+>    moment *after* you tap Allow. The app asked once, a moment too early, and
+>    when that failed it gave up silently and never asked again. Builds 115, 116
+>    and 117 all had this — **tapping Allow on any of them could register nothing
+>    at all**, with nothing anywhere reporting a problem.
+> 2. **A notification arriving while the app was OPEN showed nothing.** iOS does
+>    not display a banner over a foregrounded app unless the app asks it to, and
+>    ours never did. Your 08:00 question was unaffected (you would be out of the
+>    app), but **"your partner answered" was hit hardest** — that one fires the
+>    second the other person submits, exactly when you are most likely to be
+>    looking at the app. You would have seen silence and reasonably concluded it
+>    was still broken.
 >
 > *(The earlier "delete and reinstall 117" trick is now unnecessary — 118 has the
 > real fix, so an ordinary update is fine.)*
@@ -102,7 +117,7 @@ _Last refreshed: **2026-08-09** (Session 065)._
 > Google to Apple — and that needs the address your phone produces when you tap
 > Allow.
 >
-> **Your seven friends are still on 117 and still have the bug.** 118 was
+> **Your seven friends are still on 117 and still have BOTH bugs.** 119 was
 > assigned to the `Friends` group but **not submitted for Apple's beta review**,
 > which external testers need. One dispatch fixes that whenever you want it —
 > just say so:

--- a/docs/past-prompts.md
+++ b/docs/past-prompts.md
@@ -2813,6 +2813,44 @@ correct: a missing provider is not a transient condition and no backoff conjures
 one. Pinned with a `testWidgets` case that calls `pumpAndSettle` on a container
 with no override, so it cannot come back silently.
 
+### Then a SECOND defect, found by hunting rather than waiting
+
+With ADR-044 merged and build 118 shipped, the only remaining step was the
+founder's tap. Instead of waiting, the delivery path was hunted adversarially —
+five lenses, four of which found nothing. The fifth found this, and it survived
+refutation:
+
+**No foreground presentation option anywhere.** No
+`setForegroundNotificationPresentationOptions`, no `onMessage`, no
+`UNUserNotificationCenter` delegate. iOS presents nothing over a foregrounded
+app unless asked. The message is delivered and *invisible* — which to the person
+testing is indistinguishable from "still broken".
+
+Unevenly harmful, which is what made it worth fixing rather than filing: the
+08:00 daily question arrives when the app is backgrounded, but **"your partner
+answered" fires the instant the other member submits** — precisely when the
+recipient is in the app, and precisely the push the founder named. → **lesson 99**.
+
+Fixed in `messaging_bootstrap.dart`, fire-and-forget from the flavor entrypoints
+(the rule `activateAppCheck` already follows), unawaited and fail-open. **Not**
+beside the permission grant: on a warm start with permission already held,
+`promptForPermissionAndRegister` returns early and `ensurePermission` is never
+reached, so the option would be set once and never again.
+
+**What the hunt confirmed is worth as much as what it found.** Both paths the
+founder named are verified working in production, independently — the 05:00Z
+sweep (`checked:1 skippedNoToken:2`) and the real-time `answerReveal` trigger
+(`kind=partnerAnswered`, fired 2026-08-06 12:33 and 21:26, 2026-08-07 01:14).
+The FCM message shape is a real alert (`notification:{title,body}`), and FCM v1
+was probed live and accepts sends for both projects. No blocker remains between
+an FCM token and a lock screen.
+
+**Builds 118 and 119 both shipped**, on founder authorisation. 119 carries both
+fixes and is the one to install. The first release attempt produced NOTHING —
+`integration` hit its 40-minute budget after 27 minutes of silence and skipped
+signing while the run reported green (#208, second occurrence, first to cost a
+release).
+
 ### Operator dependency — one, and it is unavoidable
 
 **Proven:** `1669 tests pass` (full suite, run alone) · `flutter analyze` clean ·

--- a/docs/session-lessons.md
+++ b/docs/session-lessons.md
@@ -38,6 +38,22 @@ something, ask which of these you are standing in:
 
 ### Recent, in full
 
+**99 — When you are blocked on a human, hunt the REST of the path instead of waiting.** *(S066)*
+The push fix was merged and a build shipped; the only remaining step was the
+founder installing it and tapping Allow, which no session can do. Waiting was the
+obvious move. Instead the whole delivery chain was hunted adversarially for a
+*second* defect that would still bite after the token landed — and there was one:
+**no foreground presentation option, so a push arriving while the app was open
+displayed nothing.** Harmless for the 08:00 sweep, fatal for "your partner
+answered", which fires exactly when the recipient is in the app. Had it not been
+found, the founder would have installed, tapped, seen silence, and reported the
+feature still broken — costing another build and another day.
+**A blocked goal is not an idle one.** Ask what the human's action will *unblock*,
+then audit everything downstream of it while you wait. Four of the five lenses
+found nothing, and that was worth knowing too: it converted "we think it works"
+into "no blocker remains between a token and a lock screen."
+
+
 **98 — A test that asserts the swallow is correct converts the bug into a specification.** *(S066)*
 `push_token_sync_test.dart` contained *"a throwing token source never escapes"*:
 set `currentToken` to throw, assert nothing is registered, green. That is


### PR DESCRIPTION
Docs-only.

The operator page named build 118; **119** is the one to install, and it now explains — in the founder's terms — that there were **two** bugs, not one:

1. **The app threw away the notification address.** Apple hands it over a moment *after* the tap; the app asked once, too early, failed silently, and never retried. Builds 115/116/117 all have this, so tapping Allow on any of them could register nothing at all.
2. **A notification arriving while the app was OPEN displayed nothing.** iOS presents nothing over a foregrounded app unless asked, and ours never did. This spared the 08:00 question but hit **"your partner answered"** hardest — that fires the second the other person submits, exactly when the recipient is looking at the app.

**Lesson 99 — when blocked on a human, hunt the rest of the path instead of waiting.** The second defect was found only because the session did not sit idle on *"the founder needs to tap Allow."* Had it not been, the founder would have installed, tapped, seen silence, and reported the feature still broken — another build, another day.

Four of the five hunt lenses found nothing, and that was worth knowing too: it converted *"we think it works"* into *"no blocker remains between a token and a lock screen."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)