### PR TITLE
feat(adr-045): question at 09:00, nudge at 22:00 — and the quiet window that would have eaten the second one

### DIFF
--- a/docs/adr/045-notification-hours-and-the-quiet-window-that-would-have-eaten-them.md
+++ b/docs/adr/045-notification-hours-and-the-quiet-window-that-would-have-eaten-them.md
@@ -1,0 +1,129 @@
+# ADR-045: the founder's notification hours — 09:00 and 22:00 — and the quiet window that would have silently eaten the second one
+
+- **Status:** Accepted
+- **Date:** 2026-08-10 (Session 067)
+- **Deciders:** founder (the hours and the notification set), session agent (the quiet-window consequence, which is not a product choice)
+- **Related:** **ADR-042 D3/D4** (this re-points both of their hours; D4's *reason* is unchanged and reaffirmed), **ADR-012 D3** (one couples read per sweep; the quiet window this amends), `docs/architecture.md` §5
+
+## Context
+
+The founder set the notification policy directly:
+
+> 1. **Question delivery time:** Questions should be sent at **9:00 AM**, not at midnight.
+> 2. **Notifications:** Let's only send notifications in the following cases:
+>    * When a new question arrives
+>    * When the partner answers the question
+>    * At **10:00 PM**, if the question still hasn't been answered
+
+Two of the three cases already existed and needed only re-timing. The third —
+"when the partner answers" — already existed **twice**, and one ambiguity in the
+first line was material enough to ask about rather than guess.
+
+## Decision 1 — Only the ANNOUNCEMENT moves to 09:00. Rollover still assigns at local midnight
+
+*"Not at midnight"* has two readings, and they are not close in cost:
+
+* **(a)** the *notification* moves 08:00 → 09:00; the question is still assigned
+  at local midnight, so someone opening the app at 00:30 already sees it;
+* **(b)** the *assignment* moves to 09:00, so no question exists between midnight
+  and 09:00.
+
+**The founder chose (a)**, asked directly. (b) was not a smaller wording change:
+`dayKey`, the streak, the reveal decision and both push passes are all keyed on
+the local-midnight boundary, so moving assignment would have opened a nine-hour
+window per day with no question and no defined app state — a new screen state to
+design, not a constant to edit.
+
+So: `DAILY_QUESTION_LOCAL_HOUR` **8 → 9**, and `question-rollover` is untouched.
+
+## Decision 2 — The nudge moves 16:00 → 22:00, and its *meaning* was already right
+
+`AT_RISK_LOCAL_HOUR` **16 → 22**.
+
+Nothing else in that pass changed, because ADR-042 D4 had already made it exactly
+what the founder is now asking for: it fires for couples whose day doc exists and
+is **unrevealed**, with **no streak precondition**, and notifies the members who
+have not answered. The file name (`at-risk.ts`) lags that meaning and is left
+alone deliberately — renaming it would be a diff across the sweep, the tests and
+three ADRs to fix a noun, and ADR-042 D4's header already says so in place.
+
+## Decision 3 — The quiet window moves 22:00 → 23:00, and this is the decision that matters
+
+**This is not a preference. Shipping D2 without it would have delivered nothing.**
+
+`isQuietLocalHour` was `hour >= 22 || hour < 8`, and `deliverSweepPush` re-checks
+it per recipient as defense in depth (ADR-012 D3). **22 was the FIRST QUIET
+HOUR.** A nudge re-pointed to 22:00 would therefore have been composed, counted,
+and then dropped by our own guard into `suppressedQuiet` — on every couple, every
+night. The deploy would have been green, the sweep would have logged three
+healthy summary lines, and no phone would ever have buzzed at 10 PM.
+
+That is the exact failure shape this repo keeps paying for: a feature that fails
+by going **quiet**, where the absence of an effect is indistinguishable from
+absence of demand. It was caught by reading the guard before changing the
+constant, not by testing afterwards.
+
+So the window is now **23:00–08:00**, and **22:00 is the last legal hour** —
+precisely mirroring 08:00 as the first.
+
+### What this costs, stated rather than buried
+
+The founder asked for a 22:00 push and therefore, necessarily, for one fewer hour
+of protected quiet. A push may now arrive at 22:00–22:59 where previously nothing
+could. That is the direct consequence of the request and not a side effect worth
+hiding: **10 PM is inside anyone's evening, and the person receiving it may be
+with family.** The discreet-mode copy already governs *what* such a push says
+(ADR-018/payload-policy), so the exposure is a lock-screen line the user has
+already chosen the wording class of — but the hour itself is new, and if the
+founder wants it back, moving the nudge to 21:00 restores the old window with a
+one-constant change and no other consequence.
+
+## Decision 4 — The fragile boundary did not disappear; it MOVED, and it is asserted at its new end
+
+Under ADR-042 D3 the daily question sat exactly on the 08:00 edge, and that
+adjacency was documented and tested as the thing most likely to silently kill the
+feature. After this change:
+
+* **09:00 has an hour of slack** below it. The morning end is no longer fragile.
+* **22:00 is now flush against the 23:00 edge.** The fragility is entirely at the
+  evening end, and it is *coupled*: moving either `AT_RISK_LOCAL_HOUR` or
+  `isQuietLocalHour` by one, in either direction, kills the nudge with every
+  unrelated test still green.
+
+Both ends are asserted in three places rather than one — `local-hour.test.ts`
+(the window's full boundary table plus both scheduled hours), `at-risk.test.ts`
+(hour 22 open, hour 23 quiet, stated as the coupling), and
+`daily-question.test.ts` (hour 9 open, and that its OLD hour 08:00 is legal but
+no longer fires, so a half-applied re-point shows up somewhere).
+
+That last one is the assertion worth naming: **testing "not quiet" is not
+testing "the right hour."** 08:00 is still perfectly legal; only a test pinned to
+the pass's *own* hour catches a constant that moved in one file and not the other.
+
+## Decision 5 — No notification kind is removed. The founder's list already covers all four
+
+The founder wrote three cases; the system has four push kinds. Asked directly,
+they chose to keep both partner pushes, because both *are* "the partner
+answered", from opposite sides:
+
+| kind | fires | in the founder's list as |
+|---|---|---|
+| `dailyQuestion` | 09:00 local | "when a new question arrives" |
+| `partnerAnswered` | partner answers first, you have not | "when the partner answers" |
+| `reveal` | you answered first, partner completes the day | "when the partner answers" |
+| `streakAtRisk` | 22:00 local, day still unanswered | "at 10:00 PM, if still unanswered" |
+
+Dropping `reveal` would have meant the first answerer gets **no** notification
+when their partner finishes — they would have to open the app to discover the day
+had opened, which is the opposite of the ask.
+
+## Consequences
+
+* Two constants and one policy predicate changed; no logic, no schema, no copy.
+* `1071 functions tests` pass, coverage 97.45%.
+* **Prod runs the OLD hours until Functions are redeployed.** They are deployed by
+  hand (#206) and a prod deploy is a founder ask (`session-context.md` §7), so
+  until then production announces at 08:00 and nudges at 16:00 regardless of what
+  `main` says. `functions_drift.py` (ADR-043) is what makes that visible rather
+  than assumed — and this is exactly the merged-vs-running gap it was built for.
+* The 22:00 exposure of D3 is a founder-reversible one-constant change.

--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -15,235 +15,84 @@
 > when the list around it shrinks. Read top-to-bottom for priority. Numbers that
 > have closed but are still cited by code are listed at the very bottom.
 
-_Last refreshed: **2026-08-09** (Session 065)._
+_Last refreshed: **2026-08-10** (Session 067)._
 
-> ### 🔔 ONE THING now stands between you and a notification, and it takes ten seconds
->
-> **Install the newest build, open it, and tap Allow when iOS asks about
-> notifications.** That is the whole remaining action. Everything else — the
-> code, the deploy, the security rules, the entitlement, the portal tick, and
-> the APNs key you uploaded on 2026-08-08 — is done.
->
-> **Use build 117 or 116. Never 115** — it carries the entitlement but never asks
-> you for permission, and without permission iOS never issues a token, so 115
-> cannot work no matter how long you wait. **117 also carries your new icon.**
->
-> ### You do not have to report anything back, and that is new
->
-> This box used to end with *"then tell me whether anything arrives at 08:00"* —
-> which is why it sat here for three sessions: only you could see the answer. It
-> turns out production says it directly, and a session can read it. Measured on
-> 2026-08-08, before you install:
->
-> ```
-> registerPushToken     — ever called by a phone?   NO   (only deploy records)
-> ```
->
-> ### ⚠️ Corrected 2026-08-09 — we were reading the wrong counter, and there WAS a bug
->
-> This box used to add *"daily-question sweep — couples checked: 0 on every
-> hourly pass"* and conclude that no phone had ever handed over a token. **That
-> conclusion did not follow.** The sweep only evaluates couples whose own local
-> clock reads 08:00, so `checked: 0` is the expected reading for 23 hours out of
-> every 24 no matter what — and the hours that had been sampled were exactly
-> those. Four sessions repeated it.
->
-> Measured at the hour it actually means something (05:00 UTC = your 08:00):
->
-> ```
-> question_rollover: daily-question sweep complete
->         checked: 1   sent: 0   skippedNoToken: 2   suppressedQuiet: 0   failed: 0
-> ```
->
-> **Your server side is not waiting for anything — it is working.** It wakes at
-> your 08:00, finds your couple, works out that neither of you has answered yet,
-> and composes a notification for each of you. Then it stops, because neither
-> phone has ever given it an address to send to.
->
-> **And that was not only because nobody tapped Allow.** There was a real bug in
-> the app: on iOS, Apple does not hand the app its notification address the
-> instant you tap Allow — it arrives a moment later. The app asked once, at
-> exactly the wrong moment, and when that failed it gave up silently and never
-> asked again for the rest of that run. So on the old builds, tapping Allow had a
-> good chance of registering nothing at all, with nothing anywhere reporting a
-> problem. **Fixed in this change** (it now waits for Apple and retries, briefly
-> and in the background).
->
-> ### ✅ BUILD 119 IS ON YOUR TESTFLIGHT — install THIS one, it carries BOTH fixes
->
-> You authorised the release on 2026-08-09 and it is done. Verified by reading
-> App Store Connect, not by trusting a green build:
+> ### 🔔 ONE THING stands between you and a notification: install **build 119** and tap Allow
 >
 > ```
 > build 119   processing=VALID   uploaded 2026-08-09
->     internal = IN_BETA_TESTING             <-- YOU can install it right now
->     external = READY_FOR_BETA_SUBMISSION   <-- your friends cannot yet, see below
+>     internal = IN_BETA_TESTING             <-- you can install it right now
+>     external = READY_FOR_BETA_SUBMISSION   <-- your friends cannot yet
 > ```
 >
-> **Install build 119, open it to your paired home screen, and tap Allow.**
-> That is the whole remaining action.
+> Open it to your paired home screen and tap **Allow** when iOS asks about
+> notifications. That is the entire remaining action.
 >
-> **Two separate bugs were found and fixed today, not one.** 118 fixed the first;
-> **119 fixes both** and is the one to install.
+> ### Two real bugs were fixed to get here — it was never just the tap
+>
+> For four sessions this page told you the only thing missing was your tap. That
+> was wrong twice over, and both are now fixed and in build 119.
 >
 > 1. **The app threw away your notification address.** Apple hands it over a
->    moment *after* you tap Allow. The app asked once, a moment too early, and
->    when that failed it gave up silently and never asked again. Builds 115, 116
->    and 117 all had this — **tapping Allow on any of them could register nothing
->    at all**, with nothing anywhere reporting a problem.
+>    moment *after* you tap Allow; the app asked a moment too early, failed
+>    silently, and never asked again. **Builds 115, 116 and 117 all have this** —
+>    tapping Allow on any of them could register nothing at all, with nothing
+>    anywhere reporting a problem.
 > 2. **A notification arriving while the app was OPEN showed nothing.** iOS does
->    not display a banner over a foregrounded app unless the app asks it to, and
->    ours never did. Your 08:00 question was unaffected (you would be out of the
->    app), but **"your partner answered" was hit hardest** — that one fires the
->    second the other person submits, exactly when you are most likely to be
->    looking at the app. You would have seen silence and reasonably concluded it
->    was still broken.
+>    not display a banner over a foregrounded app unless asked, and ours never
+>    did. Your 09:00 question is unaffected (you would be out of the app), but
+>    **"your partner answered" was hit hardest** — that one fires the second the
+>    other person submits, exactly when you are most likely to be looking at the
+>    app.
 >
-> *(The earlier "delete and reinstall 117" trick is now unnecessary — 118 has the
-> real fix, so an ordinary update is fine.)*
+> ### Your server side is not waiting for anything — it is working
 >
-> **The sending side was probed on 2026-08-09 and is healthy.** A `validate_only`
-> send through Google's own FCM endpoint — which delivers nothing to anyone — was
-> accepted for both projects and rejected only the deliberately fake address it
-> was given:
+> Measured at the hour the counters actually mean something (your own morning
+> sweep), production finds your couple, works out that neither of you has
+> answered, and composes a notification for each of you:
 >
 > ```
-> hayatiapp-prod  ->  "The registration token is not a valid FCM registration token"
-> hayatiapp-dev   ->  same
+> daily-question sweep   checked: 1   sent: 0   skippedNoToken: 2
+> answer_reveal          kind=partnerAnswered  "push skipped, no fcm tokens"
 > ```
 >
-> No credential error, no project error. So the pipe from our server to Google is
-> open. The one link nobody can test without a real phone is the last hop —
-> Google to Apple — and that needs the address your phone produces when you tap
-> Allow.
+> It stops there because no phone has ever given it an address to send to. The
+> earlier reading of *"checked: 0, so nobody has a token"* was taken at the wrong
+> hours — that counter only moves at your own question hour — and it is corrected
+> now.
 >
-> **Your seven friends are still on 117 and still have BOTH bugs.** 119 was
-> assigned to the `Friends` group but **not submitted for Apple's beta review**,
-> which external testers need. One dispatch fixes that whenever you want it —
-> just say so:
+> ### You do not have to report anything back
+>
+> The moment you tap Allow, `registerPushToken` records its first real call and
+> the morning sweep flips from `skippedNoToken: 2` to `sent`. A session reads
+> both directly. If they do not move, that is a real bug and a findable one.
+>
+> ### Your seven friends are still on build 117, with both bugs
+>
+> 119 was assigned to the `Friends` group but **not submitted for Apple's beta
+> review**, which external testers need. One dispatch fixes that whenever you
+> want it — just say so:
 >
 > ```sh
 > gh workflow run testflight-testers.yml \
 >   -f dry_run=false -f assign_latest_build=true -f submit_for_review=true
 > ```
->
-> ### You do not have to report anything back, and that is new
->
-> This box used to end with *"then tell me whether anything arrives at 08:00"* —
-> which is why it sat here for three sessions: only you could see the answer. It
-> turns out production says it directly, and a session can read it. Measured on
-> 2026-08-08, before you install:
->
-> ```
-> registerPushToken     — ever called by a phone?   NO   (only deploy records)
-> ```
->
-> ### ⚠️ Corrected 2026-08-09 — we were reading the wrong counter, and there WAS a bug
->
-> This box used to add *"daily-question sweep — couples checked: 0 on every
-> hourly pass"* and conclude that no phone had ever handed over a token. **That
-> conclusion did not follow.** The sweep only evaluates couples whose own local
-> clock reads 08:00, so `checked: 0` is the expected reading for 23 hours out of
-> every 24 no matter what — and the hours that had been sampled were exactly
-> those. Four sessions repeated it.
->
-> Measured at the hour it actually means something (05:00 UTC = your 08:00):
->
-> ```
-> question_rollover: daily-question sweep complete
->         checked: 1   sent: 0   skippedNoToken: 2   suppressedQuiet: 0   failed: 0
-> ```
->
-> **Your server side is not waiting for anything — it is working.** It wakes at
-> your 08:00, finds your couple, works out that neither of you has answered yet,
-> and composes a notification for each of you. Then it stops, because neither
-> phone has ever given it an address to send to.
->
-> **And that was not only because nobody tapped Allow.** There was a real bug in
-> the app: on iOS, Apple does not hand the app its notification address the
-> instant you tap Allow — it arrives a moment later. The app asked once, at
-> exactly the wrong moment, and when that failed it gave up silently and never
-> asked again for the rest of that run. So on the old builds, tapping Allow had a
-> good chance of registering nothing at all, with nothing anywhere reporting a
-> problem. **Fixed in this change** (it now waits for Apple and retries, briefly
-> and in the background).
->
-> ### 🟢 Worth trying RIGHT NOW, before any of the below — it costs you two minutes
->
-> **Delete İkimiz from your phone, reinstall build 117 from TestFlight, sign in,
-> and tap Allow.** A *fresh install* has a real chance of working even on the
-> buggy build, and here is the honest reason why.
->
-> The app does two things: it asks Apple for your notification address once (that
-> is the broken part — it asks a moment too early and gives up), **and** it also
-> listens for Apple to announce a brand-new address. On a phone that has never
-> had one, that announcement fires the first time you grant permission — and the
-> listener is attached *before* the prompt, so it catches it. On an **upgrade**,
-> where an address already existed, nothing new is announced and there is nothing
-> to catch, which matches what we have seen for three builds.
->
-> So: **delete first, then reinstall.** Not an update — a delete and a fresh
-> install. If notifications start arriving tomorrow at 08:00, that was it.
->
-> Either way a session can tell within minutes whether your phone registered,
-> without you reporting anything.
->
-> ### ⚠️ The fix is merged, but it is NOT in any build you can install yet
->
-> Builds 115, 116 and 117 all carry the bug. **No build carrying the fix exists**
-> — it has to be produced, and producing one uploads a real binary to your
-> TestFlight, which a session will not do without your go-ahead.
->
-> **Say the word and it happens in one command:**
->
-> ```sh
-> gh workflow run release.yml --ref main
-> ```
->
-> Then install that build, open it to your paired home screen, and tap Allow.
-> A session confirms within minutes, without you reporting anything.
->
-> **Still unticked, still one page, still yours if you want them:**
-> `ASSOCIATED_DOMAINS` (item **2(d)**) and `APP_ATTEST`. Neither blocks
-> notifications.
 
-> **What changed since the last refresh (2026-08-08):**
+> **What changed since the last refresh (2026-08-09):**
 >
-> * 🔎 **We found out why the notifications feature quietly failed in August — and
->   built the thing that would have caught it.** Back then the whole push stack was
->   written, merged and green, two builds shipped, and the functions your phone
->   calls **had never been deployed to production.** Nothing anywhere compared the
->   code that is *running* to the code that is *finished*. That comparison now
->   exists for Cloud Functions, the way it already did for the security rules.
-> * 🟡 **It needs the same one thing from you as the rules check — item 2(e)(iv),
->   which now needs a second read-only role on the same account.** Until then both
->   checks show as SKIPPED rather than pretending to pass.
-> * ✅ **Your development backend was three functions behind and is now current.**
->   It was missing both notification-token functions. Deployed and verified.
-> * ℹ️ **Production is running exactly the right code** — that was checked, not
->   assumed. The new tool does report a difference, but it is a *housekeeping*
->   one: the last deploy was typed by hand from a laptop and swept 62 stray local
->   files into the upload. Harmless, and the real fix (**#206**) needs nothing
->   from you.
->
-> **From the 2026-08-06 refresh:**
->
-> * ✅ **The APNs key is uploaded to both projects** (you confirmed 2026-08-08).
->   That was the last thing anyone was waiting on. Item 4(a) is closed.
-> * ✅ **Your app icon shipped.** All 20 sizes, regenerated from the file you
->   chose and each verified changed. Build **117** was dispatched with your
->   authorisation on 2026-08-08 and carries it.
-> * 🔎 **Your Android icons had never been the brand at all** — still the default
->   blue Flutter logo from the first commit, through 116 builds. Fixed in the same
->   change, and CI now fails if any size stops matching your master.
-> * 🟡 **Turkish screenshots — we had the reason wrong, and now we don't.** Your
->   listing has no `tr` localization, but not because nobody clicked a button:
->   **Apple has been refusing to create it on every release since build 112**,
->   because another app already uses the name in Turkish. Six releases said so and
->   nobody read it. It needs a **decision** from you, not a click — item (B).
-> * ✅ **A security rule that was live in production was missing from dev** since
->   2026-08-01 — the one stopping a client from claiming another device's
->   notification token. Deployed and verified; both projects now match.
+> * ✅ **Your notification hours are now what you asked for** — the question
+>   announcement moved to **09:00** and the unanswered-day nudge to **22:00**.
+>   Both are on `main`; see the note under 4(a) about production still running
+>   the old hours until the server is redeployed.
+> * ⚠️ **The 22:00 nudge would have been silently swallowed.** Our own
+>   quiet-hours rule started at 22:00, so every 10 PM notification would have
+>   been composed and then dropped by our own guard — deployed, logged, and
+>   delivering nothing. The quiet window moved to **23:00–08:00** in the same
+>   change. It also means one less protected hour in your evening; if you would
+>   rather have it back, moving the nudge to 21:00 undoes that.
+> * ✅ **Build 119 shipped** with both notification bug fixes.
+> * ✅ **Closed items have been removed from this page**, as you asked. The
+>   history lives in `docs/past-prompts.md`.
 
 **Where things stand in one line:** the MVP is code-complete, both backends run
 current code and current rules, the invite site is live, your icon shipped, the
@@ -261,69 +110,6 @@ single thing left is **one install and one tap**.
 ---
 
 # 🔵 What a session is waiting on right now
-
-## (A) ✅ The app icon — ANSWERED 2026-08-05, **SHIPPED 2026-08-08**
-
-**Done.** The mark you chose is now every icon the app has: 15 iOS sizes, 5
-Android launcher sizes, and the 1024 App Store icon — all 20 regenerated from
-your file and each one verified changed at the byte level. It is on `main` and
-in **build 117**, which is **live on your TestFlight right now** —
-`processing=VALID`, `internal=IN_BETA_TESTING`, and Apple approved its beta
-review, so your external testers have it too.
-
-**Verified all the way to Apple, not just to the repo.** App Store Connect
-returns its own rendering of the icon inside the uploaded binary, and it is your
-mark:
-
-```
-icon: .../AppIcon60x60@2x.png  (120x120)
-```
-
-Chain: your file → the generator → the repo → Xcode's asset catalog → the signed
-binary (the icon inside `Runner.app` dropped 6 KB → 3 KB, which is the new file)
-→ Apple's own copy.
-
-Two things worth knowing, neither needing anything from you:
-
-* **Your file ships unmodified at 1024.** The store icon is pixel-identical to
-  the PNG you picked, with only the alpha channel stripped — Apple rejects a
-  marketing icon that carries one.
-* **The Android icons had never been the brand at all.** They were still the
-  default blue Flutter logo from the very first scaffold commit, through 116
-  builds. Nothing in the project could have told anyone; there was no generator,
-  so each size was produced by hand and nothing compared them. There is one now,
-  and CI fails if any size stops matching your master.
-
-*The discreet grey icon is untouched, verified byte-identical — different job,
-deliberately.*
-
-<details><summary>The record of how the choice was made (kept — it is why nobody should re-open it)</summary>
-
-You said the current icon reads as phallic and asked to revert to the previous
-one. **"The previous one" had three possible meanings and one of them would have
-shipped the default blue Flutter logo** (the literal previous commit is the m0.1
-scaffold), so you were asked to pick rather than guessed at.
-
-**Your answer: the pre-redesign brand mark** —
-`brandkit/branding-assets/icons/hayati-appicon-ios-1024.png`, the smaller,
-centred seeds with a pale dot that shipped before PR #94. A session swaps every
-size (15 iOS, 5 Android, plus the 1024 store icon) and it ships in the next
-build. Nothing further is needed from you.
-
-> **One thing that was flagged before you chose, recorded so nobody re-opens it.**
-> The mark you picked is the *same two-seed family* as the one you are objecting
-> to — smaller and centred, but the same paired-lobe shape. Three alternatives
-> without that silhouette are already drawn and QA'd in `redesign/icons/` (preview
-> at `redesign/icons/icon-preview.html`): **Whole Pomegranate** (*"reads as fruit
-> first, love second — the most glance-proof romantic option for phones checked by
-> family"*), **The Unfold** (*"fully non-romantic at a glance"*), and **Lit
-> Lattice** (held for v2). **Your call stands and the session will execute it** —
-> this note exists only so that if the smaller mark still reads wrong on the home
-> screen, you know three finished options are already sitting there.
-
-*The discreet grey icon stays exactly as it is — different job, deliberately.*
-
-</details>
 
 ## (B) 🟡 Add a **Turkish** localization to your App Store listing — measured, not guessed
 
@@ -377,15 +163,18 @@ fails to publish store metadata should not look green and silent.
 
 ---
 
-# 🟡 4(a). Push — **both pieces are done. One install is the whole remaining gap.**
+# 🟡 4(a). Push — **install build 119 and tap Allow. That is the whole gap.**
 
-> ### ✅ The APNs `.p8` — DONE 2026-08-08, both projects (you confirmed it)
-> ### ✅ The Push Notifications tick — DONE 2026-08-06
+> ### ⚠️ Your new hours are on `main` but NOT yet on the server
 >
-> **Every server-side and credential-side piece of push now exists.** Verified
-> in production on 2026-08-08: all 13 Functions deployed and current with
-> `main`, `registerPushToken` live, and all three per-sweep summary lines
-> present on every hourly pass.
+> You asked for the question at **09:00** and the unanswered nudge at **22:00**.
+> Both are merged. **Production is still running the old 08:00 / 16:00 hours**,
+> because Cloud Functions here are deployed by a hand-typed command rather than a
+> workflow (that gap is issue #206), and deploying to production is something a
+> session will not do without asking you.
+>
+> Say the word and it is one command. Until then, expect the question push at
+> 08:00 and the nudge at 16:00.
 >
 > ### What is left is one thing, and only your phone can do it
 >
@@ -417,102 +206,6 @@ fails to publish store metadata should not look green and silent.
 > and the app asked once, at the wrong moment, then gave up silently. Use a build
 > made after 2026-08-09.
 
-<details><summary>The original two-piece instructions (kept for reference; both pieces are done)</summary>
-
-**This is why the app never notified you.** It is not a bug in the notification
-logic — that logic is written, tested and correct. It is that the phone was never
-given the plumbing to receive a push, and Firebase was never given the key it
-needs to talk to Apple. Two pieces, both yours:
-
-**1. An APNs Authentication Key (~3 min).** Apple Developer portal →
-Certificates, Identifiers & Profiles → **Keys** → **+** → tick **Apple Push
-Notifications service (APNs)** → Continue → Register → **Download the `.p8`**
-(you can only download it once). Note the **Key ID** shown on that page and your
-**Team ID** (`UH7MXG7Z94`). Then Firebase console → `hayatiapp-prod` → ⚙ Project
-settings → **Cloud Messaging** → **Apple app configuration** → upload the `.p8`
-with the Key ID and Team ID. **Do the same for `hayatiapp-dev`** — the same key
-works for both.
-
-**2. Tick Push Notifications on the App ID (~1 min).** Apple Developer portal →
-**Identifiers** → `com.beyondkaira.hayati` → tick **Push Notifications** → Save.
-
-> ### ✅ DONE 2026-08-06 — ticked, and the entitlement is already in a shipped build
->
-> You authorised the API path; `PUSH_NOTIFICATIONS` was enabled from CI
-> ([run 31130371860](https://github.com/aytekXR/hayati-mobile-app/actions/runs/31130371860))
-> and the verification read in the same run returned exit 0. `aps-environment`
-> then landed, the provisioning profile regenerated, and **build 115 signed and
-> uploaded** — the first build in this app's history to carry a push entitlement.
->
-> Undo handle, if it is ever needed: capability id
-> `Q344R7M7MY_PUSH_NOTIFICATIONS`.
->
-> <details><summary>The measurement that stood here before (kept, because it is what made the fix safe)</summary>
->
-> The probe ran green against Apple's portal
-> ([run 31054773143](https://github.com/aytekXR/hayati-mobile-app/actions/runs/31054773143))
-> and reported **exit 1 — capability absent**. Not exit 2, so this is a real
-> read-out and not a permissions failure: the API key *can* see the App ID, and
-> what it saw was this.
->
-> ```
-> capabilities ticked on com.beyondkaira.hayati (the portal's own list):
->   - APPLE_ID_AUTH
->   - IN_APP_PURCHASE
->
-> requested and ABSENT:
->   MISSING PUSH_NOTIFICATIONS     <- this item
->   MISSING ASSOCIATED_DOMAINS     <- item 2(d)
->   MISSING APP_ATTEST
-> ```
->
-> **All three are one visit and one tick each**, on the same portal page. You are
-> already going there for Push Notifications; ticking the other two while you are
-> in there costs nothing and closes item 2(d) at the same time.
->
-> This also retired the last of the *"a session cannot read the portal, so nobody
-> knows"* bullets.
->
-> </details>
-
-**Why the second one matters more than it looks.** The app has to declare a push
-entitlement, and that entitlement must also exist in the **provisioning
-profile**. Our release lane fetches profiles **read-only on purpose** (so CI can
-never mint credentials), which means it cannot add the capability itself — a
-build that claims push without the capability **fails to sign**. That is exactly
-what happened with universal links and cost a release (ADR-040). So a session
-will not add the entitlement until the tick is confirmed.
-
-> ### ✅ You no longer have to *report* piece 2 — a session can now measure it
->
-> Session 062 built `appid-capabilities.yml`, which reads the App ID's capability
-> list straight out of Apple's portal over the App Store Connect API, using the
-> same key the release lane already holds. **Just do the tick; nobody needs to
-> ask you whether you did.**
->
-> ```sh
-> gh workflow run appid-capabilities.yml
-> ```
->
-> The same one dispatch also answers the two questions that used to ride along
-> with this item — **Associated Domains** (item 2(d)) and **App Attest** — so
-> those bullets are gone from your list too. They had been recorded as *"a
-> session cannot read the portal, so nobody knows"* for months, and that turned
-> out to be a missing tool rather than a missing permission.
->
-> If the workflow reports **could not measure** (exit 2), that means our API key
-> is not allowed to read Certificates & Identifiers — **not** that the capability
-> is off. That distinction is built into the tool on purpose, because reporting
-> "not ticked" when nobody actually looked would send a session off to build
-> around a blocker that may not exist.
-
-**Piece 1 — the APNs `.p8`.** Firebase's Cloud Messaging settings are
-console-only: there is no API a session can read them from, `gcloud` is not
-installed on the session machine and there is no application-default credential.
-So this one was reported, not verified — **you confirmed it on 2026-08-08 for
-both projects**, and it is closed.
-
-</details>
 
 ### The order matters, and it is not reorderable
 
@@ -530,7 +223,7 @@ place in the system to find out, because our iOS CI check builds
 your partner answers, and a reminder at 16:00 if you have not. Those are the three
 you asked for.
 
-> ### ✅ All three are now BUILT — they are waiting on this checkbox and nothing else
+> ### ✅ All three notifications are BUILT, DEPLOYED and RUNNING
 >
 > As of 2026-08-06 the server composes and routes all three: the 08:00 question, the
 > partner-answered nudge, and the 16:00 reminder. The 16:00 one deliberately fires
@@ -988,28 +681,6 @@ Please eyeball each of these on a TestFlight build:
 Check enforcement stays OFF in both consoles until on-device attestation is
 verified), and **Universal links** (2(d)).
 
-> ### ✅ ~~One thing nobody can settle from a laptop~~ — SETTLED 2026-08-09, and it needs nothing from you
->
-> This asked you to open the Google Cloud console and confirm the hourly rollover
-> job is `ENABLED` on `0 * * * *`. It was recorded for months as unverifiable
-> because `gcloud` is not installed here and there is no application-default
-> credential.
->
-> **It never needed `gcloud`.** The job's own output is in the Functions log, and
-> a job that is not running writes nothing. Measured:
->
-> ```
-> 43 distinct hourly sweeps, 2026-08-07T08:00Z → 2026-08-09T02:00Z, ZERO gaps
-> ```
->
-> Forty-three consecutive hours with no missing hour is not consistent with a
-> disabled schedule. **The scheduler is enabled and firing on the hour.** Nothing
-> for you to click, and one fewer console visit on your list.
->
-> *(Third time this session that a "nobody can measure this" turned out to be
-> measurable with a tool already in the repo. Worth a habit: before recording an
-> unknown, ask what the thing would EMIT if it were working.)*
-
 ---
 
 # Activation infrastructure — still unbought, still gating the funnel
@@ -1259,13 +930,11 @@ these.
 
 ---
 
-# Retired item numbers still cited by code
+---
 
-Kept only so a message printed by a tool points somewhere real. Nothing here needs
-you.
-
-| Number | Cited by | Status |
-|---|---|---|
-| **2(c)** — TestFlight external submission | `tool/ci/testflight_testers.py:1291` (prints only when the four Beta App Review contact fields are missing) | **Closed 2026-08-05.** Submitted 2026-08-01, approved by Apple, build 113 `IN_BETA_TESTING`, invitations sent. The contact fields are set and held as `release`-environment secrets. |
-| **#140** — merged-vs-deployed rules | ADR-041, `rules_drift.py` | **Closed 2026-08-01.** Residuals are #165 (above) and #166. |
-| **#130** — seasonal vocabulary parity | ADR-026 D3 | **Closed 2026-08-02** by PR #171. |
+*Closed items are not kept here.* This page lists only what is still open; the
+session-by-session record of everything that closed lives in
+`docs/past-prompts.md`, and the retired-but-still-cited item numbers (2(c), #140,
+#130) moved there too — `testflight_testers.py` still prints 2(c) when the Beta
+App Review contact fields are missing, so the number stays valid even though the
+item does not.

--- a/docs/past-prompts.md
+++ b/docs/past-prompts.md
@@ -2858,3 +2858,42 @@ release).
 tests including the no-source regression.
 
 **The fix is in the app binary, so it needs a new TestFlight build**, and dispatching the release lane uploads a real binary to the founder's TestFlight — `session-context.md` §7, a founder ask. **Builds 115–117 all carry the bug**; tapping Allow on them may register nothing. The operator page now says use a build made after 2026-08-09 and explains why, replacing four sessions of "just tap Allow".
+
+---
+
+## Session 067 — 2026-08-10 — **the founder set the notification hours, and the quiet window would have eaten the one they cared most about** *(first-hand)*
+
+**Objective (founder directive): questions at 09:00, and notifications only for a new question, a partner answering, and a 22:00 nudge if still unanswered.** Plus three documentation asks: where the roadmap and implementation plan stand, whether the handoff is current, and strip the closed items out of `operator-expected.md`.
+
+### One line of the request was materially ambiguous, so it was asked rather than guessed
+
+*"Questions should be sent at 9:00 AM, not at midnight"* has two readings: move the **announcement**, or move the **assignment**. They are not close in cost — `dayKey`, the streak, the reveal decision and both push passes are keyed on the local-midnight boundary, so moving assignment opens a nine-hour window per day with no question and no defined app state. **The founder chose the announcement.** A second question — the system has FOUR push kinds and the request named three — settled that both partner pushes stay, because `partnerAnswered` and `reveal` are the same event from opposite sides.
+
+### The finding: the 22:00 nudge would have shipped and delivered nothing
+
+`isQuietLocalHour` was `hour >= 22 || hour < 8`, and `deliverSweepPush` re-checks it per recipient as defense in depth. **22 was the FIRST QUIET HOUR.** Re-pointing the nudge to 22:00 alone would have had every one of those pushes composed, counted, and then dropped by our own guard into `suppressedQuiet` — on every couple, every night, with three healthy summary lines in the log and a green deploy.
+
+Caught by reading the guard *before* changing the constant. → the window moved to **23:00–08:00** in the same change (ADR-045 D3), making 22:00 the last legal hour.
+
+**The cost is stated rather than buried:** the founder asked for a 10 PM push and therefore for one fewer protected evening hour. Reversible with one constant if they want it back.
+
+### The fragility moved rather than vanished
+
+ADR-042 D3 had the daily question sitting exactly on the 08:00 edge, documented and tested as *"the thing most likely to silently kill this feature"*. After ADR-045, 09:00 has an hour of slack and **22:00 is flush against the new 23:00 edge** — the same coupling, at the other end of the day. Asserted in three files now, and one of those assertions is the one that matters most:
+
+> **Testing "not quiet" is not testing "the right hour."** 08:00 is still perfectly legal. Only a test pinned to the pass's OWN hour catches a constant that moved in one file and not the other — which is exactly what happened: `question-rollover-handler.test.ts` hardcodes its instants instead of importing the constants, so the first grep for `DAILY_QUESTION_LOCAL_HOUR` missed it entirely and the emulator suite is what found it.
+
+Three tests failed on the first run, all mine, all consequences of the retime: a sub-hour Kathmandu fixture pinned to 08:45, and the two handler fixtures. Two inline comments were then corrected a second time, because the first patch swapped which pass has no work at which hour.
+
+### The doc asks
+
+* **`operator-expected.md` stripped of closed items** as requested — 341 lines removed. The app-icon section (shipped), the closed APNs/portal-tick boxes, the historical two-piece instructions, the Cloud Scheduler item settled the day before, and the retired-number table (moved to this file, with a pointer left behind because `testflight_testers.py` still prints item 2(c)). The header block had also **accumulated across incremental edits** — it still told the founder to reinstall build 117 — so it was rewritten once rather than patched again.
+* **Handoff regenerated** for S068 with the #204 objective it has now deferred twice, and the state table carries the new hours plus the fact that **production still runs the old ones**.
+
+### Proven
+
+`54 test files, 1071 tests pass` · functions coverage **97.45%** (gate 80/85) · `tsc --noEmit` clean · eslint clean.
+
+### Operator dependencies
+
+**Two, both stated on the page.** The founder's install-and-tap for build 119 (unchanged), and a **prod Functions redeploy** for the new hours to take effect — production announces at 08:00 and nudges at 16:00 until then, which is exactly the merged-vs-running gap ADR-043's checker exists to make visible.

--- a/docs/resume-prompt.md
+++ b/docs/resume-prompt.md
@@ -1,51 +1,45 @@
-# Resume Prompt — Session 067
+# Resume Prompt — Session 068
 
 > **This file contains ONE objective. That objective is the session; nothing else is.**
 > (`project-rules.md` #1, `session-rules.md` §1.)
 >
-> Before starting, read the two companions:
-> * **`session-context.md`** — toolchain, machine, review discipline, binding
->   invariants, and the never-without-asking list.
-> * **`session-lessons.md`** — the institutional lessons, now numbered to **98**.
+> Read `session-context.md` (toolchain, machine, review discipline, the
+> never-without-asking list) and `session-lessons.md` (numbered to **99**) first.
+> Re-derive the session number from `git log`.
+
+**Objective: make a failed `deliver` VISIBLE — the engineering half of #204.**
+
+> ⚠️ **S066 and S067 both deferred this**, and the reason each time was a live
+> founder directive, not neglect: S066 fixed the two notification bugs
+> (ADR-044 + #215) and S067 re-pointed the notification hours (ADR-045) and
+> cleaned the operator page. The measurement phase is **already done and recorded
+> as a comment on #204** — read it before designing:
 >
-> Re-derive the session number from `git log`; a session on another machine can consume it.
+> * the step already exits 1 with an `##[error]`; it has **no `id`**, so
+>   `steps.<id>.outcome` is unreachable;
+> * `slack_notify.sh` derives everything from job-level `NEEDS_JSON`, so a
+>   step-level failure is structurally invisible to it;
+> * **ADR-024 D1 is binding** — all notifier policy lives in that one tested
+>   script and the notifier has **no vote** on the build. So the fix cannot be
+>   "make the step fail" and cannot be a bespoke notification path.
 
-**Objective: make a failed `deliver` VISIBLE, so a green release can never again
-mean "store metadata silently did not land" — the engineering half of #204.**
-
-> ⚠️ **S066 did not run this objective.** A founder directive arrived mid-session
-> — *"the app is not sending notifications, fix it"* — and superseded it. That
-> work is done and merged (ADR-044); this objective is unchanged and inherits
-> S066's completed measurement phase, which is **recorded as a comment on #204**:
-> the step already exits 1 with an `##[error]`, it has **no `id`** (so
-> `steps.<id>.outcome` is unreachable), and `slack_notify.sh` derives everything
-> from job-level `NEEDS_JSON`, so a step-level failure is structurally invisible
-> to it. Read that comment before designing.
-
-This is not the Turkish-name decision. That half is the founder's and is
-correctly stated on the operator page; **do not touch it and do not re-ask it.**
-
-The defect is ours: `fastlane store_metadata (deliver per locale)` has failed
-**identically on every release since build 112** — six of them — and the run is
-green and Slack says nothing. `continue-on-error: true` is **right** there
-(ADR-020 D8) — lesson **69**: *`continue-on-error` is not the bug; an UNREAD
+`fastlane store_metadata (deliver per locale)` has failed identically on **every
+release since build 112** — now nine of them, 112 through 119 — and every run was
+green and Slack said nothing. `continue-on-error: true` is **right** there
+(ADR-020 D8); lesson **69**: *`continue-on-error` is not the bug; an UNREAD
 failure is.* It has already produced a wrong instruction to the founder twice
 (lesson **91**).
 
-**ADR-024 D1 is binding**: all notifier policy lives in `tool/ci/slack_notify.sh`
-and the notifier has **no vote** on the build. So the fix cannot be "make the
-step fail", and it cannot be a bespoke notification path.
-
-**Do not grep for Apple's error string.** That is the same defect one level down
-— it goes quiet the day the message changes, and quiet reads as fine. Assert
+**Do not grep for Apple's error string.** That is the same defect one level down —
+it goes quiet the day the message changes, and quiet reads as fine. Assert
 **positive evidence of publication per locale** (expected set from
-`fastlane/metadata/*/`, actual from what deliver says it uploaded) and treat
-*absence of evidence* as a finding (lesson **65**), with the repo's exit taxonomy.
+`fastlane/metadata/*/`, actual from what deliver reports) and treat *absence of
+evidence* as a finding (lesson **65**), with the repo's exit taxonomy.
 
-⚠️ **You cannot dispatch `release.yml` to test this** (§7). The last six runs'
+⚠️ **You cannot dispatch `release.yml` to test this** (§7). The last nine runs'
 logs are the fixture source: `gh api repos/:owner/:repo/actions/jobs/<id>/logs`,
-**never** `gh run view --job --log` (lesson **65**). Job ids: `93165024416` (117),
-`92747059901` (116), `92728958753` (115).
+**never** `gh run view --job --log` (lesson **65**). Job ids: `93254284862` (119),
+`93165024416` (117), `92747059901` (116).
 
 ## 1. Where things actually stand *(measured 2026-08-09 — re-measure, do not inherit)*
 
@@ -56,8 +50,9 @@ logs are the fixture source: `gh api repos/:owner/:repo/actions/jobs/<id>/logs`,
 | **`hayatiapp-prod` Functions** | Running **this ref's source**, but hand-deployed from a laptop that swept in 62 gitignored files, so it does not equal a clean checkout. A **process** gap, not wrong code. That is **#206**, and the tool says so in those words. |
 | **Push, server side** | **DONE and RUNNING.** All 13 exports deployed to prod; all three per-sweep summary lines on every hourly pass. |
 | **Push, server side — MEASURED PROPERLY at last** | At the couple's OWN 08:00 (05:00Z; they are UTC+3, derived from `assigned: 1` at 21:00Z = local midnight) the sweep logs `checked:1  sent:0  skippedNoToken:2` and names both recipient uids. **Everything above the token lookup is verified working in production.** Reading `checked: 0` at any other hour says nothing — the pass is gated on couple-local hour 8 (lesson **97**). |
+| **Notification hours** | **CHANGED on `main`, ADR-045**: question announcement **09:00** (was 08:00), unanswered nudge **22:00** (was 16:00), quiet window **23:00–08:00** (was 22:00) — the window HAD to move or the 22:00 nudge would have been swallowed by our own guard. **Production still runs the OLD hours** until Functions are redeployed (#206; a prod deploy is a §7 ask). `functions_drift.py` is what makes that visible. |
 | **Push, device side** | **Was a real BUG, not just a missing tap** (ADR-044, merged S066). iOS delivers the APNs token *after* `requestPermission()` returns; capture asked once, in that window, caught the throw and never retried. **Builds 115–117 all carry it.** Fixed with a bounded retry. `registerPushToken` still has **zero device invocations** — re-measure with `firebase functions:log --only registerPushToken`. |
-| **What push now needs** | **A NEW BUILD.** The fix is in the binary and dispatching `release.yml` is a founder ask (§7). Until a post-2026-08-09 build is installed and the prompt accepted, nothing can arrive. |
+| **What push now needs** | **The founder's install + tap. Build 119 is live** (`internal=IN_BETA_TESTING`) and carries BOTH fixes — ADR-044's token-capture retry and #215's foreground presentation. `registerPushToken` still has **zero device invocations**; re-measure with `firebase functions:log --only registerPushToken`. |
 | **Build 117** | Live, `external=IN_BETA_TESTING`, carries the icon and the whole push slice. |
 | **Deployed rules** | Both projects matched `main` on 2026-08-08. Re-measure with `rules_drift.py --from-firebase-cli`. |
 | **`functions-drift` / `rules-drift` in CI** | Both **visibly SKIPPED** by design — one absent secret (operator **2(e)(iv)**, whose instructions changed this session: the same account now needs **Cloud Functions Viewer** too). |

--- a/functions/src/notifications/at-risk.ts
+++ b/functions/src/notifications/at-risk.ts
@@ -29,14 +29,28 @@ import { localHour } from './local-hour';
 import type { MessagingPort } from './messaging-port';
 import { SweepPushOutcome, deliverSweepPush, nonAnswerers } from './sweep-push';
 
-// The couple-LOCAL wall-clock hour the nudge fires on (ADR-042 D4, re-pointed from
-// 20): once per zone per day — only the sweep whose bucket-local hour reads 16
-// pushes. 16 is comfortably OUTSIDE the 22:00–08:00 quiet window (deliverSweepPush
-// re-checks anyway, defense in depth), unlike the daily-question pass at hour 8
-// which sits exactly on the boundary. Sub-hour-offset zones (Asia/Kathmandu +05:45)
-// land on the hourly sweep whose local clock reads 16:xx, exactly as their midnight
-// bucket does. DST transitions never occur at 16:xx in practice.
-export const AT_RISK_LOCAL_HOUR = 16;
+// The couple-LOCAL wall-clock hour the nudge fires on — **22** since ADR-045
+// (founder, 2026-08-10: "at 10:00 PM, if the question still hasn't been
+// answered"), re-pointed from the 16 of ADR-042 D4, which was itself re-pointed
+// from 20. Once per zone per day: only the sweep whose bucket-local hour reads 22.
+//
+// ⚠️ **22 IS THE BOUNDARY NOW — this constant and the quiet window are coupled.**
+// The window was 22:00–08:00, which made 22 the FIRST QUIET hour: shipping this
+// change alone would have had `deliverSweepPush`'s defense-in-depth guard swallow
+// every nudge and tally it in `suppressedQuiet`. The feature would have deployed,
+// logged cleanly, and delivered nothing. So ADR-045 moved the window to
+// 23:00–08:00 in the same change, making 22 the LAST legal hour.
+//
+// That is the same fragility the daily-question pass used to carry at 08:00, now
+// at the other end of the day: move either this constant or `isQuietLocalHour` by
+// one, in either direction, and the nudge dies silently while every unrelated test
+// stays green. Both directions are asserted in `at-risk.test.ts` and
+// `local-hour.test.ts`.
+//
+// Sub-hour-offset zones (Asia/Kathmandu +05:45) land on the hourly sweep whose
+// local clock reads 22:xx, exactly as their midnight bucket does. DST transitions
+// never occur at 22:xx in practice.
+export const AT_RISK_LOCAL_HOUR = 22;
 
 /** The at-risk sweep counters the handler logs and the tests assert on. */
 export interface AtRiskSummary {

--- a/functions/src/notifications/daily-question.ts
+++ b/functions/src/notifications/daily-question.ts
@@ -23,22 +23,29 @@ import type { MessagingPort } from './messaging-port';
 import { deliverSweepPush, nonAnswerers } from './sweep-push';
 
 /**
- * The couple-LOCAL wall-clock hour the daily-question push fires on (ADR-042 D3):
- * once per zone per day — only the sweep whose bucket-local hour reads 8 pushes.
+ * The couple-LOCAL wall-clock hour the daily-question push fires on — **9**
+ * since ADR-045 (founder, 2026-08-10: *"questions should be sent at 9:00 AM"*),
+ * re-pointed from the 8 ADR-042 D3 chose. Once per zone per day: only the sweep
+ * whose bucket-local hour reads 9 pushes.
  *
- * ⚠️ **8 is the boundary of the quiet window, not a value inside it.**
- * `isQuietLocalHour` is `hour >= 22 || hour < 8` — right-open at 08:00 — so hour 8
- * is the FIRST legal hour of the day and this push is the first thing the policy
- * allows. That is elegant and it is fragile: moving either the window or this
- * constant by one silently suppresses the entire feature while every unrelated
- * test stays green. Both directions are asserted in `daily-question.test.ts` and
- * mutation-checked, because a feature that fails by going quiet cannot be noticed
- * by its absence.
+ * **What moved and what deliberately did NOT.** Only the ANNOUNCEMENT moved. The
+ * rollover still assigns the day's question at local **midnight**, so the app
+ * shows the new question to anyone who opens it before 09:00 — the founder chose
+ * that explicitly over moving the assignment, because `dayKey`, the streak, the
+ * reveal and this pass are all keyed on the local-midnight boundary and moving it
+ * would have created a nine-hour window with no question and no defined state.
+ *
+ * **9 is no longer adjacent to the quiet window, and that is a small win.** Under
+ * ADR-042 D3 this constant sat exactly on the 08:00 boundary — the first legal
+ * hour — where a one-hour drift in either the window or the constant silently
+ * killed the feature. At 9 there is an hour of slack on this side. The fragile
+ * end has MOVED, not vanished: it is now the 22:00 nudge sitting against the new
+ * 23:00 window edge (`at-risk.ts`), and it is asserted there.
  *
  * Sub-hour-offset zones (Asia/Kathmandu +05:45) land on the hourly sweep whose
- * local clock reads 08:xx, exactly as their midnight bucket does.
+ * local clock reads 09:xx, exactly as their midnight bucket does.
  */
-export const DAILY_QUESTION_LOCAL_HOUR = 8;
+export const DAILY_QUESTION_LOCAL_HOUR = 9;
 
 /** The daily-question sweep counters the handler logs and the tests assert on. */
 export interface DailyQuestionSummary {

--- a/functions/src/notifications/local-hour.ts
+++ b/functions/src/notifications/local-hour.ts
@@ -46,12 +46,25 @@ export function localHour(instant: Date, timeZone: string): number {
 }
 
 /**
- * True inside the couple-local quiet window 22:00–08:00 (ADR-012: pushes in this
- * window are SUPPRESSED, not queued — no scheduling infra this session). The
- * window is right-open at 08:00: hours 22, 23, 0..7 are quiet; 8 and 21 are not.
- * The streak-at-risk push fires at local hour 20, outside the window by
- * construction.
+ * True inside the couple-local quiet window **23:00–08:00** (ADR-012: pushes in
+ * this window are SUPPRESSED, not queued — no scheduling infra). The window is
+ * right-open at 08:00: hours 23, 0..7 are quiet; 8 and 22 are not.
+ *
+ * ⚠️ **The window opens at 23, not 22, and that is a founder decision, not a
+ * rounding.** (ADR-045, 2026-08-10.) The unanswered-day nudge was re-pointed to
+ * local **22:00** at the founder's request — *"at 10:00 PM, if the question
+ * still hasn't been answered"* — and 22:00 was previously the FIRST quiet hour,
+ * so `deliverSweepPush`'s defense-in-depth guard would have swallowed every one
+ * of those pushes and counted them in `suppressedQuiet`. The feature would have
+ * shipped, logged, and delivered nothing.
+ *
+ * So the boundary moved by exactly one hour, and 22:00 is now the **last legal
+ * hour** — the mirror of 08:00 being the first. Both ends are now load-bearing
+ * and both are asserted in `local-hour.test.ts` and in the two sweep tests:
+ * widening or narrowing this window silently kills a feature at whichever end
+ * moved, and a feature that fails by going quiet cannot be noticed by its
+ * absence.
  */
 export function isQuietLocalHour(hour: number): boolean {
-  return hour >= 22 || hour < 8;
+  return hour >= 23 || hour < 8;
 }

--- a/functions/test/emulator/at-risk.test.ts
+++ b/functions/test/emulator/at-risk.test.ts
@@ -5,7 +5,12 @@
 // injected port.
 //
 // ⚠️ ADR-042 D4 changed two things this suite used to pin, on purpose:
-//   * the hour moved 20 → 16, because the founder asked for 16:00;
+//   * the hour moved 20 → 16, because the founder asked for 16:00 — and ADR-045
+//     (2026-08-10) moved it again, 16 → 22, for "at 10:00 PM, if the question
+//     still hasn't been answered". 22 was the FIRST QUIET hour before that
+//     change, so ADR-045 moved the quiet window to 23:00–08:00 in the same diff;
+//     without that, every nudge would have been swallowed by the defense-in-depth
+//     guard and tallied in `suppressedQuiet` — deployed, logged, and silent;
 //   * the `streak.count > 0` gate is GONE, because the nudge now protects a
 //     RELATIONSHIP rather than a streak and must reach couples who have neither.
 // The tests that asserted the old rules were not relaxed — they were INVERTED to
@@ -23,6 +28,7 @@ import {
   deliverAtRiskPush,
   runStreakAtRisk,
 } from '../../src/notifications/at-risk';
+import { isQuietLocalHour } from '../../src/notifications/local-hour';
 import { composePush } from '../../src/notifications/payload-policy';
 import { bucketCouplesByTimezone } from '../../src/rollover/rollover-service';
 import { clearNoTriggerFirestore, noTriggerFirestore } from '../support/admin';
@@ -39,13 +45,15 @@ const UID_B = 'uid-b';
 const TZ = 'Europe/Istanbul';
 const DAY_KEY = '20260710';
 
-// 2026-07-10T13:00:00Z: Istanbul (+03) reads 16:00 → the nudge fires;
-// New York (EDT −04) reads 09:00 at the SAME instant → it does not.
-const AT = new Date('2026-07-10T13:00:00Z');
-// Asia/Kathmandu is +05:45: 11:00Z reads 16:45 → the sub-hour zone catches its
-// hour-16 sweep on the same run its local clock crosses 16:xx.
-const KTM_AT = new Date('2026-07-10T11:00:00Z');
-// Istanbul 23:00 — inside the 22:00–08:00 quiet window (defense-in-depth check).
+// 2026-07-10T19:00:00Z: Istanbul (+03) reads 22:00 → the nudge fires;
+// New York (EDT −04) reads 15:00 at the SAME instant → it does not.
+const AT = new Date('2026-07-10T19:00:00Z');
+// Asia/Kathmandu is +05:45: 16:30Z reads 22:15 → the sub-hour zone catches its
+// hour-22 sweep on the same run its local clock crosses 22:xx.
+const KTM_AT = new Date('2026-07-10T16:30:00Z');
+// Istanbul 23:00 — inside the 23:00–08:00 quiet window (defense-in-depth check),
+// and now exactly ONE HOUR after the nudge: the tightest possible proof that the
+// window and AT_RISK_LOCAL_HOUR did not drift into each other (ADR-045).
 const QUIET_AT = new Date('2026-07-10T20:00:00Z');
 
 interface StreakSeed {
@@ -103,8 +111,18 @@ beforeEach(async () => {
 });
 
 describe('runStreakAtRisk — hour-16 gate (ADR-042 D4)', () => {
-  it('AT_RISK_LOCAL_HOUR is 16 — the hour the founder asked for, not the streak hour', () => {
-    expect(AT_RISK_LOCAL_HOUR).toBe(16);
+  it('AT_RISK_LOCAL_HOUR is 22 — the hour the founder asked for (ADR-045)', () => {
+    expect(AT_RISK_LOCAL_HOUR).toBe(22);
+  });
+
+  // ⚠️ THE coupling this suite now owns. 22 used to be the first QUIET hour; the
+  // window moved to 23 in the same change so the nudge could exist at all. Move
+  // either constant by one, in either direction, and the feature dies silently
+  // while every unrelated test stays green — precisely how a push feature fails
+  // without anyone noticing.
+  it('hour 22 is NOT quiet, and 23 IS — the nudge sits on the LAST legal hour', () => {
+    expect(isQuietLocalHour(AT_RISK_LOCAL_HOUR)).toBe(false);
+    expect(isQuietLocalHour(AT_RISK_LOCAL_HOUR + 1)).toBe(true);
   });
 
   it('fires ONLY for the bucket at couple-local hour 16; a same-instant off-16 zone and a corrupt zone are untouched', async () => {
@@ -143,12 +161,12 @@ describe('runStreakAtRisk — hour-16 gate (ADR-042 D4)', () => {
     await seedUser(UID_B);
     const buckets = await bucketCouplesByTimezone(db);
 
-    // At AT (13:00Z) Kathmandu is 18:45 (hour 18) → nothing.
+    // At AT (19:00Z) Kathmandu is 00:45 next day (hour 0) → nothing.
     const offSummary = await runStreakAtRisk(db, AT, new FakeMessagingPort(), buckets);
     expect(offSummary.checked).toBe(0);
     expect(offSummary.sent).toBe(0);
 
-    // At KTM_AT (11:00Z) Kathmandu is 16:45 (hour 16) → fires.
+    // At KTM_AT (16:30Z) Kathmandu is 22:15 (hour 22) → fires.
     const port = new FakeMessagingPort();
     const summary = await runStreakAtRisk(db, KTM_AT, port, buckets);
     expect(summary.checked).toBe(1);

--- a/functions/test/emulator/daily-question.test.ts
+++ b/functions/test/emulator/daily-question.test.ts
@@ -1,14 +1,17 @@
-// The hour-8 daily-question push pass (ADR-042 D3) — the founder's first ask:
-// "It needs to be send new questions at 08.00 TSI with a question."
+// The hour-9 daily-question push pass — ADR-045 (founder, 2026-08-10: "questions
+// should be sent at 9:00 AM, not at midnight"), re-pointed from the 08:00 of
+// ADR-042 D3 ("It needs to be send new questions at 08.00 TSI with a question").
 //
 // Two things this suite exists to pin, beyond the ordinary eligibility rules:
 //
-//   1. **08:00 sits exactly on the quiet-hours boundary.** `isQuietLocalHour` is
-//      `hour >= 22 || hour < 8` — right-open, so hour 8 is the FIRST legal hour of
-//      the day and this push is the first thing allowed. An off-by-one in either
-//      direction silently suppresses the entire feature with every other test
-//      green, so the boundary is asserted here in both directions and
-//      mutation-checked in the session log.
+//   1. **The hour is once-per-zone-per-day, and it is now an hour clear of the
+//      quiet window.** Under ADR-042 D3 this pass sat exactly on the 08:00 edge —
+//      the first legal hour — where an off-by-one in either the constant or the
+//      window silently suppressed the whole feature with every other test green.
+//      At 09:00 there is slack on this side. The fragile end did not vanish, it
+//      MOVED: the 22:00 nudge now sits against the new 23:00 edge, and that is
+//      asserted in `at-risk.test.ts`. Only the ANNOUNCEMENT moved to 09:00 — the
+//      rollover still assigns at local midnight (ADR-045 D1).
 //   2. **Zero additional couples reads.** The pass iterates the SAME CoupleBuckets
 //      the assignment pass used. ADR-012 D3's hard constraint is one couples read
 //      per sweep and ADR-042 does not amend it.
@@ -31,13 +34,17 @@ const CID = 'dq-couple';
 const UID_A = 'dq-a';
 const UID_B = 'dq-b';
 
-// 2026-07-09T05:00:00Z is 08:00 in Europe/Istanbul (UTC+3) — the hour under test.
-const AT_08 = new Date('2026-07-09T05:00:00Z');
-// 07:00 local — one hour EARLIER, and inside quiet hours. If the boundary ever
-// moves the wrong way this is the instant that starts delivering.
-const AT_07 = new Date('2026-07-09T04:00:00Z');
-// 09:00 local — one hour later, legal but not this pass's hour.
+// 2026-07-09T06:00:00Z is 09:00 in Europe/Istanbul (UTC+3) — the hour under test.
 const AT_09 = new Date('2026-07-09T06:00:00Z');
+// 08:00 local — one hour EARLIER. Since ADR-045 this hour is LEGAL (the quiet
+// window ends at 08:00) but is no longer this pass's hour: the assertion is that
+// the pass is pinned to its own hour, not merely to "not quiet".
+const AT_08 = new Date('2026-07-09T05:00:00Z');
+// 10:00 local — one hour later, legal but not this pass's hour either.
+const AT_10 = new Date('2026-07-09T07:00:00Z');
+// 07:00 local — inside quiet hours at BOTH ends of this change, so it stays the
+// instant that proves a wrong-way boundary drift starts delivering.
+const AT_07 = new Date('2026-07-09T04:00:00Z');
 const DAY_KEY = '20260709';
 
 // The buckets are built by hand exactly as bucketCouplesByTimezone would produce
@@ -88,30 +95,43 @@ beforeEach(async () => {
   await seedUser(UID_B);
 });
 
-describe('the 08:00 boundary — the thing most likely to silently kill this feature', () => {
-  it('DAILY_QUESTION_LOCAL_HOUR is 8', () => {
-    expect(DAILY_QUESTION_LOCAL_HOUR).toBe(8);
+describe('the 09:00 hour — the thing most likely to silently kill this feature', () => {
+  it('DAILY_QUESTION_LOCAL_HOUR is 9 — the hour the founder asked for (ADR-045)', () => {
+    expect(DAILY_QUESTION_LOCAL_HOUR).toBe(9);
   });
 
-  // The two assertions that matter, stated as the policy rather than as arithmetic.
-  it('hour 8 is NOT quiet, and hour 7 IS — the push sits one minute inside the legal day', () => {
+  it('hour 9 is NOT quiet, and now has an hour of slack below it', () => {
     expect(isQuietLocalHour(DAILY_QUESTION_LOCAL_HOUR)).toBe(false);
-    expect(isQuietLocalHour(DAILY_QUESTION_LOCAL_HOUR - 1)).toBe(true);
+    expect(isQuietLocalHour(DAILY_QUESTION_LOCAL_HOUR - 1)).toBe(false); // 08:00, legal
+    expect(isQuietLocalHour(DAILY_QUESTION_LOCAL_HOUR - 2)).toBe(true); // 07:00, quiet
   });
 
-  it('hour 22 IS quiet — the other end of the window, so a widening cannot pass unnoticed', () => {
-    expect(isQuietLocalHour(22)).toBe(true);
-    expect(isQuietLocalHour(21)).toBe(false);
+  it('hour 23 IS quiet and 22 is NOT — the other end, where the 22:00 nudge now sits', () => {
+    expect(isQuietLocalHour(23)).toBe(true);
+    expect(isQuietLocalHour(22)).toBe(false);
   });
 
-  it('fires at the couple-local 08:00 sweep', async () => {
+  it('fires at the couple-local 09:00 sweep', async () => {
+    await seedDay();
+    const port = new FakeMessagingPort();
+
+    const summary = await runDailyQuestion(db, AT_09, port, oneCouple());
+
+    expect(summary.sent).toBe(2);
+    expect(port.sent).toHaveLength(2);
+  });
+
+  // The pass must be pinned to ITS hour, not merely to "any legal hour" — 08:00 is
+  // legal and is exactly where this pass used to fire, so a half-applied re-point
+  // would show up here and nowhere else.
+  it('does NOT fire at 08:00 — legal, and its OLD hour, but not its hour any more', async () => {
     await seedDay();
     const port = new FakeMessagingPort();
 
     const summary = await runDailyQuestion(db, AT_08, port, oneCouple());
 
-    expect(summary.sent).toBe(2);
-    expect(port.sent).toHaveLength(2);
+    expect(summary.sent).toBe(0);
+    expect(port.sent).toHaveLength(0);
   });
 
   it('does NOT fire at 07:00 — and if the boundary ever moves, the quiet guard still catches it', async () => {
@@ -124,11 +144,11 @@ describe('the 08:00 boundary — the thing most likely to silently kill this fea
     expect(port.sent).toHaveLength(0);
   });
 
-  it('does NOT fire at 09:00 — once per zone per day, not every legal hour', async () => {
+  it('does NOT fire at 10:00 — once per zone per day, not every legal hour', async () => {
     await seedDay();
     const port = new FakeMessagingPort();
 
-    const summary = await runDailyQuestion(db, AT_09, port, oneCouple());
+    const summary = await runDailyQuestion(db, AT_10, port, oneCouple());
 
     expect(summary.sent).toBe(0);
   });
@@ -137,10 +157,10 @@ describe('the 08:00 boundary — the thing most likely to silently kill this fea
     await seedDay();
     const port = new FakeMessagingPort();
 
-    // At AT_08, Istanbul reads 08:00 and London reads 06:00.
+    // At AT_09, Istanbul reads 09:00 and London reads 07:00.
     const summary = await runDailyQuestion(
       db,
-      AT_08,
+      AT_09,
       port,
       buckets([
         [TZ, [bucketed(CID, [UID_A, UID_B])]],
@@ -152,13 +172,14 @@ describe('the 08:00 boundary — the thing most likely to silently kill this fea
     expect(summary.sent).toBe(2);
   });
 
-  it('a sub-hour-offset zone (Asia/Kathmandu +05:45) fires on its 08:45 sweep', async () => {
+  it('a sub-hour-offset zone (Asia/Kathmandu +05:45) fires on its 09:45 sweep', async () => {
     await seedDay();
     const port = new FakeMessagingPort();
-    // 03:00Z is 08:45 in Kathmandu.
+    // 04:00Z is 09:45 in Kathmandu — hour 9, the same sweep its local clock
+    // crosses 09:xx on, exactly as its midnight bucket behaves.
     const summary = await runDailyQuestion(
       db,
-      new Date('2026-07-09T03:00:00Z'),
+      new Date('2026-07-09T04:00:00Z'),
       port,
       oneCouple('Asia/Kathmandu'),
     );
@@ -172,7 +193,7 @@ describe('eligibility and recipient selection', () => {
     await seedDay();
     const port = new FakeMessagingPort();
 
-    const summary = await runDailyQuestion(db, AT_08, port, oneCouple());
+    const summary = await runDailyQuestion(db, AT_09, port, oneCouple());
 
     expect(summary.checked).toBe(1);
     expect(summary.sent).toBe(2);
@@ -185,7 +206,7 @@ describe('eligibility and recipient selection', () => {
     await seedAnswer(UID_A);
     const port = new FakeMessagingPort();
 
-    const summary = await runDailyQuestion(db, AT_08, port, oneCouple());
+    const summary = await runDailyQuestion(db, AT_09, port, oneCouple());
 
     expect(summary.sent).toBe(1);
     expect(port.sent[0].token).toBe(`token-${UID_B}`);
@@ -195,7 +216,7 @@ describe('eligibility and recipient selection', () => {
     await seedDay({ revealedAt: Timestamp.now() });
     const port = new FakeMessagingPort();
 
-    const summary = await runDailyQuestion(db, AT_08, port, oneCouple());
+    const summary = await runDailyQuestion(db, AT_09, port, oneCouple());
 
     expect(summary.sent).toBe(0);
     expect(summary.checked).toBe(0);
@@ -207,7 +228,7 @@ describe('eligibility and recipient selection', () => {
   it('NO day doc → a counted skippedNoDay, and nothing sent', async () => {
     const port = new FakeMessagingPort();
 
-    const summary = await runDailyQuestion(db, AT_08, port, oneCouple());
+    const summary = await runDailyQuestion(db, AT_09, port, oneCouple());
 
     expect(summary.skippedNoDay).toBe(1);
     expect(summary.sent).toBe(0);
@@ -218,7 +239,7 @@ describe('eligibility and recipient selection', () => {
     const port = new FakeMessagingPort();
 
     // No streak field anywhere — the daily question is not a streak feature.
-    const summary = await runDailyQuestion(db, AT_08, port, oneCouple());
+    const summary = await runDailyQuestion(db, AT_09, port, oneCouple());
 
     expect(summary.sent).toBe(2);
   });
@@ -230,7 +251,7 @@ describe('failure isolation — a sweep must survive every couple', () => {
     await db.collection('users').doc(UID_A).set({});
     const port = new FakeMessagingPort();
 
-    const summary = await runDailyQuestion(db, AT_08, port, oneCouple());
+    const summary = await runDailyQuestion(db, AT_09, port, oneCouple());
 
     expect(summary.skippedNoToken).toBe(1);
     expect(summary.sent).toBe(1);
@@ -242,7 +263,7 @@ describe('failure isolation — a sweep must survive every couple', () => {
 
     const summary = await runDailyQuestion(
       db,
-      AT_08,
+      AT_09,
       port,
       buckets([[TZ, [bucketed(CID, 'not-an-array')]]]),
     );
@@ -265,7 +286,7 @@ describe('failure isolation — a sweep must survive every couple', () => {
 
     const summary = await runDailyQuestion(
       db,
-      AT_08,
+      AT_09,
       port,
       buckets([
         [TZ, [bucketed(CID, 'not-an-array'), bucketed('dq-couple-2', ['dq-c', 'dq-d'])]],
@@ -282,7 +303,7 @@ describe('failure isolation — a sweep must survive every couple', () => {
     port.failOn(`token-${UID_A}`);
     port.failOn(`token-${UID_B}`);
 
-    const summary = await runDailyQuestion(db, AT_08, port, oneCouple());
+    const summary = await runDailyQuestion(db, AT_09, port, oneCouple());
 
     expect(summary.sent).toBe(0);
     expect(summary.failed).toBe(2);
@@ -306,7 +327,7 @@ describe('the read budget (ADR-012 D3 — not amended by ADR-042)', () => {
       },
     }) as Firestore;
 
-    await runDailyQuestion(spied, AT_08, port, oneCouple());
+    await runDailyQuestion(spied, AT_09, port, oneCouple());
 
     // `collection('couples')` is used to REACH a known couple's day doc by id,
     // which is a document read; what must never happen is a .get() on the

--- a/functions/test/emulator/question-rollover-handler.test.ts
+++ b/functions/test/emulator/question-rollover-handler.test.ts
@@ -13,13 +13,16 @@ import { makeQuestionRolloverHandler } from '../../src/rollover/question-rollove
 import { adminFirestore, clearFirestoreData } from '../support/admin';
 import { FakeMessagingPort } from '../support/fake-messaging-port';
 
-// 2026-07-10T17:00:00Z reads 20:00 in Istanbul — the couple-local hour the
-// piggybacked at-risk pass fires on (ADR-012 D3). SCHEDULE_TIME (02:00Z, 05:00
-// local) is off-hour, so the existing sweeps above never trip the at-risk pass.
-// 13:00Z is 16:00 in Europe/Istanbul — the nudge hour since ADR-042 D4 (was 20).
-const AT_RISK_TIME = '2026-07-10T13:00:00Z';
-// 05:00Z is 08:00 in Europe/Istanbul — the daily-question hour (ADR-042 D3).
-const DAILY_QUESTION_TIME = '2026-07-10T05:00:00Z';
+// SCHEDULE_TIME (02:00Z, 05:00 local) is off-hour, so the ordinary sweeps above
+// never trip either push pass.
+// 19:00Z is 22:00 in Europe/Istanbul — the nudge hour since ADR-045 (was 16 under
+// ADR-042 D4, and 20 before that). 22 is the LAST hour before the 23:00 quiet
+// window, which moved in the same change so this push could exist at all.
+const AT_RISK_TIME = '2026-07-10T19:00:00Z';
+// 06:00Z is 09:00 in Europe/Istanbul — the daily-question hour since ADR-045
+// (was 08:00 under ADR-042 D3). Only the ANNOUNCEMENT moved; rollover still
+// assigns at local midnight.
+const DAILY_QUESTION_TIME = '2026-07-10T06:00:00Z';
 
 const db = adminFirestore();
 const couples = db.collection('couples');
@@ -111,7 +114,7 @@ describe('makeQuestionRolloverHandler', () => {
     await expect(handler(scheduledEvent(SCHEDULE_TIME))).rejects.toThrow('couples unlistable');
   });
 
-  it('drives all three passes off ONE couples read: logs every summary, and nudges at hour 16', async () => {
+  it('drives all three passes off ONE couples read: logs every summary, and nudges at hour 22', async () => {
     // A couple mid-streak with today's day doc still unrevealed and no answers yet
     // → both members are at-risk recipients. No answer docs are seeded, so the live
     // answerReveal trigger never fires here.
@@ -146,8 +149,9 @@ describe('makeQuestionRolloverHandler', () => {
       'question_rollover: at-risk sweep complete',
       expect.objectContaining({ checked: 1, sent: 2 }),
     );
-    // The third pass ran too and found nothing to do at 16:00 — ADR-012 D3's ONE
-    // couples read is shared by all three, so a pass that has no work still logs.
+    // The daily-question pass ran too and found nothing to do at 22:00 — ADR-012
+    // D3's ONE couples read is shared by all three, so a pass with no work still
+    // logs its summary.
     expect(infoSpy).toHaveBeenCalledWith(
       'question_rollover: daily-question sweep complete',
       expect.objectContaining({ checked: 0, sent: 0 }),
@@ -156,7 +160,7 @@ describe('makeQuestionRolloverHandler', () => {
   });
 
   // ADR-042 D3. Same shared buckets, different hour, different kind.
-  it('announces the daily question at hour 8, off the SAME single couples read', async () => {
+  it('announces the daily question at hour 9, off the SAME single couples read', async () => {
     await couples.doc('ist').set({
       memberUids: ['uid-a', 'uid-b'],
       timezone: 'Europe/Istanbul',
@@ -182,7 +186,7 @@ describe('makeQuestionRolloverHandler', () => {
       'question_rollover: daily-question sweep complete',
       expect.objectContaining({ checked: 1, sent: 2 }),
     );
-    // And the nudge pass, sharing the same buckets, correctly did nothing at 08:00.
+    // And the nudge pass, sharing the same buckets, correctly did nothing at 09:00.
     expect(infoSpy).toHaveBeenCalledWith(
       'question_rollover: at-risk sweep complete',
       expect.objectContaining({ checked: 0, sent: 0 }),

--- a/functions/test/unit/local-hour.test.ts
+++ b/functions/test/unit/local-hour.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { AT_RISK_LOCAL_HOUR } from '../../src/notifications/at-risk';
+import { DAILY_QUESTION_LOCAL_HOUR } from '../../src/notifications/daily-question';
 import { isQuietLocalHour, localHour } from '../../src/notifications/local-hour';
 
 // M3.4 (ADR-012 decision 3). localHour is the sibling of localDayKey — same
@@ -88,21 +90,38 @@ describe('localHour', () => {
 });
 
 describe('isQuietLocalHour', () => {
-  it('is quiet for 22:00–08:00 couple-local and open otherwise (full boundary table)', () => {
-    const quiet = new Set([22, 23, 0, 1, 2, 3, 4, 5, 6, 7]);
+  it('is quiet for 23:00–08:00 couple-local and open otherwise (full boundary table)', () => {
+    const quiet = new Set([23, 0, 1, 2, 3, 4, 5, 6, 7]);
     for (let hour = 0; hour <= 23; hour += 1) {
       expect(isQuietLocalHour(hour)).toBe(quiet.has(hour));
     }
   });
 
-  it('is right-open at 08:00 and left-open at 22:00 (the exact boundaries)', () => {
+  it('is right-open at 08:00 and left-open at 23:00 (the exact boundaries)', () => {
     expect(isQuietLocalHour(7)).toBe(true); // still quiet
     expect(isQuietLocalHour(8)).toBe(false); // window ends at 08:00
-    expect(isQuietLocalHour(21)).toBe(false); // not yet quiet
-    expect(isQuietLocalHour(22)).toBe(true); // window opens at 22:00
+    expect(isQuietLocalHour(22)).toBe(false); // the nudge hour — MUST stay open
+    expect(isQuietLocalHour(23)).toBe(true); // window opens at 23:00
   });
 
-  it('leaves the hour-20 streak-at-risk sweep outside the quiet window', () => {
-    expect(isQuietLocalHour(20)).toBe(false);
+  // ADR-045. The window moved 22 -> 23 for exactly one reason: the founder asked
+  // for a 22:00 nudge, and 22 used to be the first QUIET hour. Had the window not
+  // moved with it, deliverSweepPush's defense-in-depth guard would have swallowed
+  // every nudge into `suppressedQuiet` — deployed, logged, and silent.
+  it('leaves BOTH scheduled sweep hours open — 09:00 question and 22:00 nudge', () => {
+    expect(isQuietLocalHour(DAILY_QUESTION_LOCAL_HOUR)).toBe(false);
+    expect(isQuietLocalHour(AT_RISK_LOCAL_HOUR)).toBe(false);
+  });
+
+  // The two constants are COUPLED to this window, so assert the coupling rather
+  // than the values alone: a drift of one hour in either direction, at either
+  // end, kills a feature silently while every unrelated test stays green.
+  it('the nudge sits on the LAST legal hour — one later is quiet', () => {
+    expect(isQuietLocalHour(AT_RISK_LOCAL_HOUR + 1)).toBe(true);
+  });
+
+  it('the question sits an hour clear of the morning edge — its old 08:00 seat was the boundary', () => {
+    expect(isQuietLocalHour(DAILY_QUESTION_LOCAL_HOUR - 1)).toBe(false);
+    expect(isQuietLocalHour(DAILY_QUESTION_LOCAL_HOUR - 2)).toBe(true);
   });
 });


### PR DESCRIPTION
Founder directive: questions at **9:00 AM** not midnight; notifications only for a new question, a partner answering, and a **22:00** nudge if still unanswered.

## Asked rather than guessed, on the one line that was materially ambiguous

*"Sent at 9:00, not at midnight"* can mean the **announcement** or the **assignment**, and they are not close in cost — `dayKey`, the streak, the reveal decision and both push passes are keyed on the local-midnight boundary, so moving assignment opens a nine-hour window per day with no question and no defined app state. **The founder chose the announcement.**

A second question settled that **both** partner pushes stay: `partnerAnswered` and `reveal` are the same event from opposite sides, and dropping `reveal` would leave the first answerer with no notification when their partner finishes.

## The finding: the 22:00 nudge would have shipped and delivered nothing

`isQuietLocalHour` was `hour >= 22 || hour < 8`, and `deliverSweepPush` re-checks it per recipient as defense in depth. **22 was the FIRST QUIET HOUR.**

Re-pointing the nudge to 22:00 alone would have had every one of those pushes composed, counted, and then dropped by our own guard into `suppressedQuiet` — every couple, every night, with three healthy summary lines in the log and a green deploy.

Caught by **reading the guard before changing the constant**. The window moved to **23:00–08:00** in the same change, making 22:00 the last legal hour.

**The cost is stated rather than buried:** a 10 PM push means one fewer protected evening hour. Reversible with one constant if the founder wants it back.

## The fragility moved rather than vanished

ADR-042 D3 had the daily question sitting exactly on the 08:00 edge, documented and tested as *"the thing most likely to silently kill this feature"*. Now **09:00 has an hour of slack** and **22:00 is flush against the new 23:00 edge** — the same coupling, at the other end of the day, asserted in three files.

And the assertion that matters most:

> **Testing "not quiet" is not testing "the right hour."** 08:00 is still perfectly legal. Only a test pinned to the pass's *own* hour catches a constant that moved in one file and not another.

Which is exactly what happened: `question-rollover-handler.test.ts` hardcodes its instants instead of importing the constants, so the first grep for `DAILY_QUESTION_LOCAL_HOUR` missed it entirely and the **emulator suite** is what found it. Three failures on the first run, all mine.

## Also in this diff (founder asks)

* **`operator-expected.md` stripped of closed items** — 341 lines removed, and the header block rewritten once rather than patched again: it had accumulated across edits and still told the founder to reinstall build 117.
* **Handoff regenerated** for S068, carrying the new hours *and* the fact that production still runs the old ones.

## Proven

`54 test files, 1071 tests pass` · functions coverage **97.45%** (gate 80/85) · `tsc --noEmit` clean · eslint clean.

## Not done here

**Production still announces at 08:00 and nudges at 16:00** until Functions are redeployed — they are deployed by a hand-typed command (#206) and a prod deploy is a founder ask (`session-context.md` §7). That is precisely the merged-vs-running gap ADR-043's checker exists to surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)