### PR TITLE
docs(s072): the close record with the CI result it would otherwise be missing

### DIFF
--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -15,7 +15,7 @@
 > when the list around it shrinks. Read top-to-bottom for priority. Numbers that
 > have closed but are still cited by code are listed at the very bottom.
 
-_Last refreshed: **2026-08-17** (Session 071)._
+_Last refreshed: **2026-08-17** (Session 072)._
 
 > ### ✅ RESOLVED — billing is back, and your question is arriving again
 >

--- a/docs/past-prompts.md
+++ b/docs/past-prompts.md
@@ -3256,7 +3256,13 @@ if: ${{ inputs.project != 'prod' && github.ref != 'refs/heads/main' }}
 **Dev blocked from a branch, prod admitted from anywhere — the guard inverted into precisely the hole it was added to close, passing a lint that only looked for vocabulary.** The rule now asserts the **operators**, and the test covering it was *confirmed red against the old form* rather than merely added. Two more from the same review: the concurrency group must key on the input that selects the **target** (one keyed on `confirm_prod` interpolates faithfully and serializes the wrong pairs), and **comments are stripped before scanning** — every lane now carries a header quoting the guard, so a lint reading prose would go green on the remediation note somebody leaves when they *delete* it.
 
 **Commits:** `49198fe` (ADR + the two lanes + the lint), `0c73b7f` (docs) — PR **#230**.
-**CI:** green (PR + post-merge `main`).
+**CI:** green, **both runs watched to conclusion**. PR run `32021507864` — all
+jobs green, `quality` included, which is where the new lint and its self-tests
+run. Post-merge `main` run `32022632099` — green including `integration-emulator`
+at **23m11s** (11:02:11→11:25:22Z). With S071's 31m37s that is **two consecutive
+runs today inside the 50-minute budget**, which is evidence for **#208** rather
+than a reason to close it: the issue is about a job that hung *silently*, and two
+healthy runs do not disprove an intermittent hang.
 **Docs touched:** `docs/adr/050-*` (new), `architecture.md` §9, `test-suite.md`, `resume-prompt.md`, `past-prompts.md`.
 
 **Verification, and the honest bound on it.** The lint is red on the real tree before the fixes (4 violations) and green after, with `deploy-functions.yml` green throughout as the positive control. **15 mutants, each reddening a named check**, anchors asserted present-and-unique before every edit and the file diffed byte-identical against a pre-mutation copy afterwards. One mutant survived and was **wrong** — "break after the first violation" loses nothing when the first lane is clean — and was replaced with `lanes.take(1)`, which the lane-coverage check catches.


### PR DESCRIPTION
The Session 072 close record, completed with what was measured after #230 merged.

- **PR run `32021507864`** — green, `quality` included, which is where
  `deploy_lane_lint` and its self-tests run.
- **Post-merge `main` run `32022632099`** — green including
  **`integration-emulator`** at **23m11s** (11:02:11→11:25:22Z).

With S071's 31m37s that is **two consecutive runs inside the 50-minute budget**.
Recorded as evidence for **#208** and explicitly *not* as a reason to close it:
that issue is about a job that hung **silently**, and two healthy runs do not
disprove an intermittent hang. Reading them as if they did is the same shape as
reading a skipped job's green as a passing one.

`operator-expected.md` is stamped for S072 with no content change — ADR-050 adds
no operator dependency and removes none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)