### PR TITLE
docs(s080): close the checkpoint — merged, verified, and the visible-skip design confirmed on main

### DIFF
--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -1,12 +1,12 @@
 # Operator Checkpoint
 
-**Last Updated:** 2026-08-18 02:10 UTC
+**Last Updated:** 2026-08-18 02:40 UTC
 
 ## Current Status
 
 - Session: **080**
 - Goal: **#129 — the release lane installs the lock it was given, and CI verifies that lock for the first time**
-- Status: **On Track**
+- Status: **Complete** (S080 merged and verified on `main`)
 - Completion: **~60%** of the iOS MVP as specified, to public launch
 - Production Readiness: **Beta Ready**
 
@@ -214,7 +214,13 @@ Nothing blocks the *next session's engineering*. These block **launch**:
 
 ## Next Step
 
-Merge PR for **#129** once CI concludes, then watch the post-merge `main` run.
+Begin **S081 / #239** — the analytics contract, port and emitters.
+
+S080 is closed: `9318c44` on `main`, **#129 CLOSED**, post-merge run green on
+every job including `integration-emulator`. The new `gemfile-lock-verify` check
+reported **`skipped`** on both the PR and `main` — visible in the checks list
+rather than absent, which was the whole point of gating it with a job-level `if:`
+instead of a workflow paths filter.
 
 ## Next Session Goal
 


### PR DESCRIPTION
Squares `operator-expected.md` with reality now that #129 has landed.

- **Session 080 → Complete.** `9318c44` on `main`, **#129 CLOSED**, post-merge run
  green on every job including `integration-emulator`.
- **Next Step** becomes S081 / **#239** (analytics) rather than "merge the #129 PR".

It also records the one thing worth keeping from this slice: the new
`gemfile-lock-verify` check reported **`skipped`** on both the PR and `main` —
**visible in the checks list rather than absent**. That was the entire reason the
design review rejected a workflow paths filter in favour of a job-level `if:`, and
it is now demonstrated rather than argued.

*(This commit was initially made on `main` by mistake; branch protection rejected
the push, which is the protection working. Moved to a branch.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)