### PR TITLE
docs(#243): the gate nobody can compute, and the identifier that would not fix it (ADR-062) — plus the S087 handoff

### DIFF
--- a/docs/adr/062-the-gate-nobody-can-compute-and-the-identifier-that-would-not-fix-it.md
+++ b/docs/adr/062-the-gate-nobody-can-compute-and-the-identifier-that-would-not-fix-it.md
@@ -1,0 +1,177 @@
+# ADR-062: the gate nobody can compute, and the identifier that would not fix it
+
+- **Status:** Proposed
+- **Date:** 2026-08-26 (Session 086)
+- **Deciders:** session agent records the options; **the founder decides** — minting an identifier is collection, and the definitional question in Finding 3 is a product call
+- **Related:** **ADR-057 D3** (no uid or `coupleId` on any client event, ever) and **D7** (which filed this), **ADR-060 D3** (which held D3's line at the one server seam where both identifiers were in scope, and handed the *relaxation* here), **ADR-007** (gates are decision instruments, not build blockers), **ADR-013 D5** (the couple-scoped entitlement mirror), **ADR-006** (iOS-first, so the Gate reads come from one platform), issues **#243** (this one), **#226**, **#242**, **#247**, `docs/mvp.md` Gate 3, `docs/dpa-inventory.md`
+
+> **Review status, stated prospectively.** Written and committed **before** any
+> other work (`session-context.md` §5 item 1, lesson 115). Neither review pass has
+> run at the time of this commit. **Nothing is built by this ADR and no identifier
+> is minted** — the deliverable is the decision record itself.
+
+## Context — four measurements, and two of them move the question
+
+`mvp.md` Gate 3: **`trial→paid ≥30%; install→paid ≥2%`**. #243 says the second is
+uncomputable because the two emitters share no identity. That is true. It is also
+not the whole problem, and the identity question is not the first one to answer.
+
+### 1. There is genuinely no join, and the missing one was removed on purpose
+
+`install` is a **client** event fired at first launch, before an account exists.
+`paid` is a **server** event, emitted from `processRevenueCatEvent`'s `applied`
+outcome (ADR-060 D1). ADR-057 D3 forbids a uid or `coupleId` on any client event
+**ever** — stronger than ADR-016 requires, and deliberately so, because this is a
+domestic-violence-aware product. ADR-060 D3 then held that line at the one server
+seam where both identifiers were in hand, and explicitly handed the *relaxation*
+to this issue rather than taking it silently.
+
+So the absence is a decision that has now been reaffirmed twice. Reversing it
+should cost at least as much argument as making it did.
+
+### 2. The three denominators are not the same thing, and no identifier fixes that
+
+This is the measurement that reframes the issue, and it was found by asking what
+each event **counts** rather than what it is keyed by:
+
+| | counts one per | source |
+|---|---|---|
+| `install` | **device** | `DeviceFlag.install`, once per phone (ADR-057 D4, re-confirmed S085) |
+| `signup` | **uid** | `AccountFlag.signup`, once per account per device |
+| `paired` | **uid** | both partners' devices emit; ADR-057 D4 says so explicitly — *"this counts users paired, never couples"* |
+| `paid` | **couple** | the entitlement mirror is `subscriptions/{coupleId}` (ADR-013 D5); one purchase entitles both members |
+
+**`install→paid` divides a couple count by a device count.** A couple who both
+install and then subscribe once is **two** installs and **one** `paid`. Read
+naively, the gate's own arithmetic halves itself for exactly the users the product
+is for — and the error is invisible, because both numbers are individually
+correct.
+
+**A distinct id does not fix this.** Joining devices to accounts tells you which
+installs became which users; it does not tell you whether the founder means *"2%
+of installs produce a payment"* or *"2% of installs become a paying user"*, and
+with a couple-scoped subscription those differ by **2×** on the paired population.
+A 2× definitional ambiguity dominates every estimator question below, and it is
+free to resolve now, while nothing depends on the answer.
+
+### 3. For a go/no-go threshold, the join may not be needed at all
+
+Gate 3 is a **decision instrument for launch and spend posture** (ADR-007), not a
+product feature. The question it answers is *"do enough installs turn into
+revenue to make acquisition spend viable?"* — and a **ratio of two counts over a
+lagged window** answers that without any identity:
+
+> installs in window *W* · payments in window *W + lag*
+
+The bias is nameable and, decisively, **runs the safe way**. While installs are
+growing — which is the only regime a launch gate is read in — the denominator
+carries users who have not yet had time to convert, so the ratio **understates**
+conversion. A conservative estimator for a go/no-go gate fails toward *"do not
+spend yet"*. It cannot green-light spending that a true cohort read would have
+refused. With flat installs it converges on the cohort figure.
+
+What it cannot do, stated so nobody discovers it later: it cannot attribute by
+acquisition channel, cannot answer *"of the users who installed in week 1, what
+share paid by week 8"* exactly, and inherits Finding 2's ambiguity like every
+other option. **None of those is what a ≥2% launch threshold is for.**
+
+### 4. Nothing is measurable today under ANY option, and that is the real critical path
+
+Prod ships a **no-op sink** (ADR-057 D2c). No `install` count exists anywhere, on
+any device. The server three have **no emitter at all** (ADR-060 built nothing,
+and `ProcessOutcome` must grow first). The vendor adapter is gated behind a legal
+change that is founder/lawyer-blocked (#226, #247).
+
+So `install→paid` is not blocked *first* on identity. It is blocked on a sink, an
+emitter, and a legal revision — all three of which every option below needs
+equally. **Minting an identifier today would buy nothing that could be read.**
+
+## Decision 1 — Recommend the aggregate ratio; mint no identifier
+
+**Compute Gate 3's `install→paid` as a lagged window ratio of two counts, and
+record the estimator's bias beside the number.** No device identifier, no alias,
+no change to `PrivacyInfo.xcprivacy`, no new row in `docs/dpa-inventory.md`, no
+legal-version bump beyond the one #226 already owes.
+
+The reasoning is not that the ratio is as good as a cohort join. It is that:
+
+* the join's **only** advantage over the ratio is precision the threshold does not
+  use, and channel attribution the MVP does not buy;
+* the ratio's error runs **toward refusing spend**, which is the direction a gate
+  should fail in;
+* and the join's cost is the one identifier in this system that **survives
+  sign-out** — see Decision 3.
+
+## Decision 2 — Ask the founder the definitional question FIRST, because it is free and it is larger
+
+Before any identifier is considered, `mvp.md`'s `install→paid` needs one sentence
+saying whether the numerator is **payments** or **paying users**. On the paired
+population those differ by 2× (Finding 2), which is 100% of the threshold's own
+value — a gate that reads 2% under one definition reads 4% under the other.
+
+This is a **product** question with no privacy cost and no engineering
+prerequisite, and answering it may well settle #243 on its own: if the founder's
+intent is a coarse *"is acquisition viable"* read, Decision 1 is sufficient and
+the identifier never comes up again.
+
+**This ADR does not edit `mvp.md`.** Gate thresholds and their definitions are the
+founder's (ADR-007); a session that quietly rewrote one would be deciding launch
+posture by commit.
+
+## Decision 3 — If an identifier is ever minted, these are its costs, priced now
+
+Recorded so the option is refusable on evidence rather than on unease, and so a
+later session does not re-derive it:
+
+* **It is collection.** `PrivacyInfo.xcprivacy` today declares
+  `NSPrivacyTracking=false` with an **empty** `NSPrivacyTrackingDomains`, and its
+  `NSPrivacyCollectedDataTypes` list mirrors the future App Privacy answers. A
+  persistent cross-session device identifier interacts with both, and the manifest
+  already carries **one unresolved judgement call** (the Sensitive Info question,
+  issue #55) that the founder has to answer at submission anyway.
+* **It needs a `docs/legal/` line and a processor row**, which means a
+  `CURRENT_LEGAL_VERSION` bump, which **re-gates consent for every existing
+  user** — the same cost that has held #226 still since S082, paid a second time
+  if it is not folded into that revision.
+* **It survives sign-out.** Every other identifier in this system dies with the
+  session or the account; ADR-061 has just made the account-scoped device flags
+  die with the account too. A device id would be the **only** thing that persists
+  across both — in a product whose threat model is *a partner holding the phone*.
+  That is not a reason it can never exist; it is the reason it cannot be inherited
+  from an SDK default.
+* **It reopens a line held twice.** ADR-057 D3 and ADR-060 D3 both refused an
+  identifier on an event. A third document permitting one should supersede them
+  explicitly rather than sit beside them.
+
+## Decision 4 — The install-time server ping is refused, and not on privacy grounds
+
+The issue's third option — a server call at first launch — is worse than both
+others on its own terms. It **is** the distinct id, with extra steps: an
+unauthenticated write surface reachable before any account exists, which must be
+rate-limited and abuse-resisted (this repo already has `#115`, an invoker-policy
+problem on a *authenticated* endpoint), and which produces a record that is either
+identifier-bearing (Decision 3's costs, plus a network leg) or anonymous (in which
+case it is Decision 1's count, arrived at expensively).
+
+It is listed in #243 as a real alternative and it is priced here so that listing
+does not read as an open question.
+
+## Consequences
+
+* **#243 does not close.** It stays open for **Decision 2's one sentence**, which
+  only the founder can write. The engineering side of it is now decided.
+* **Gate 3's `trial→paid ≥30%` is unaffected** and always was — both events are
+  server-side (ADR-060). **Gate 2 is unaffected** — both events are client-side and
+  uid-keyed. **One threshold of four** was ever at stake, and this ADR does not
+  leave it unmeasurable: it leaves it measurable with a stated bias.
+* **The estimator's bias must be reported with the number, every time.** A ratio
+  quoted without its lag and its growth assumption is a cohort figure that is
+  quietly wrong, and this ADR is the only place that says so — there is no test
+  that can enforce it, because nothing is computing it yet.
+* **Finding 2 is a live defect in a document, not a hypothetical.** `mvp.md`'s
+  Gate 3 line is ambiguous *today*, and would have been read wrong by whoever
+  first built the funnel — including under the identifier option. It is now
+  written down before anyone acts on it.
+* **Nothing here unblocks measurement.** The sink, the emitter and the legal
+  revision remain the critical path (Finding 4), and all three are ahead of this
+  decision, not behind it.

--- a/docs/adr/062-the-gate-nobody-can-compute-and-the-identifier-that-would-not-fix-it.md
+++ b/docs/adr/062-the-gate-nobody-can-compute-and-the-identifier-that-would-not-fix-it.md
@@ -1,14 +1,49 @@
 # ADR-062: the gate nobody can compute, and the identifier that would not fix it
 
 - **Status:** Proposed
-- **Date:** 2026-08-26 (Session 086)
+- **Date:** 2026-08-26 (Session 086) · **Revision 2, 2026-08-27** — the design review refuted revision 1's central bias claim, and the recommendation changed with it
 - **Deciders:** session agent records the options; **the founder decides** — minting an identifier is collection, and the definitional question in Finding 3 is a product call
 - **Related:** **ADR-057 D3** (no uid or `coupleId` on any client event, ever) and **D7** (which filed this), **ADR-060 D3** (which held D3's line at the one server seam where both identifiers were in scope, and handed the *relaxation* here), **ADR-007** (gates are decision instruments, not build blockers), **ADR-013 D5** (the couple-scoped entitlement mirror), **ADR-006** (iOS-first, so the Gate reads come from one platform), issues **#243** (this one), **#226**, **#242**, **#247**, `docs/mvp.md` Gate 3, `docs/dpa-inventory.md`
 
-> **Review status, stated prospectively.** Written and committed **before** any
-> other work (`session-context.md` §5 item 1, lesson 115). Neither review pass has
-> run at the time of this commit. **Nothing is built by this ADR and no identifier
-> is minted** — the deliverable is the decision record itself.
+> **Review status.** Revision 1 was written and committed **before** any other work
+> (`session-context.md` §5 item 1, lesson 115). **Revision 2 folds the design
+> review** — 4 lenses × 2 independent verifiers, `agents_error=0`,
+> `agents_empty_result=0`, 6 findings, 6 verified, **0 dropped unverified**, 3
+> surviving. There is no built diff to review: **nothing is built by this ADR and
+> no identifier is minted.**
+
+## Revision 2 — the review refuted the argument the recommendation rested on
+
+Revision 1's Finding 3 said an aggregate ratio's error *"runs the safe way"* under
+growth, and Decision 1 recommended a **lagged** window ratio on that basis. **Both
+verifiers refuted it, at high confidence, and they are right.**
+
+The dilution argument — *"the denominator carries users who have not yet had time
+to convert"* — is a property of the **same-window** ratio (lag 0). Applying a lag
+is precisely what removes it. Worse, with a distributed conversion lag and growing
+installs, the lagged numerator collects payments from **later, larger cohorts**
+than its denominator, so by Jensen's inequality it **overstates** — the opposite
+of safe, in the one direction a spend gate must not fail.
+
+Worked, because the sign of an error is not a thing to reason about loosely. A
+product whose true cohort conversion is **1.5%** — which should **fail** a ≥2%
+gate — with installs doubling per window and half the cohort converting after one
+window and half after two:
+
+| lag | reads | vs truth | gate verdict |
+|---|---|---|---|
+| **0 (same window)** | 0.56% | understates | **fails** ✅ correct |
+| 1 | 1.13% | understates | fails ✅ |
+| **2** | **2.25%** | **overstates** | **PASSES** ❌ **wrong — green-lights spend** |
+| 3 | 4.50% | overstates | PASSES ❌ |
+
+With flat installs every lag is exact, which is why the error is invisible in a
+steady state and appears exactly when a launch is working.
+
+**So the recommendation inverts**: the gate's decision number is the
+**same-window** ratio, *because* it is the one that cannot falsely pass. Revision
+1 had the right instinct — prefer the estimator that fails safe — and named the
+wrong estimator.
 
 ## Context — four measurements, and two of them move the question
 
@@ -36,7 +71,7 @@ each event **counts** rather than what it is keyed by:
 
 | | counts one per | source |
 |---|---|---|
-| `install` | **device** | `DeviceFlag.install`, once per phone (ADR-057 D4, re-confirmed S085) |
+| `install` | **device installation** | `DeviceFlag.install` (ADR-057 D4, re-confirmed S085). Not "once per phone": D4 records the honest bound that **a reinstall re-emits**, because the key lives in `SharedPreferences`, which app deletion removes |
 | `signup` | **uid** | `AccountFlag.signup`, once per account per device |
 | `paired` | **uid** | both partners' devices emit; ADR-057 D4 says so explicitly — *"this counts users paired, never couples"* |
 | `paid` | **couple** | the entitlement mirror is `subscriptions/{coupleId}` (ADR-013 D5); one purchase entitles both members |
@@ -54,26 +89,38 @@ with a couple-scoped subscription those differ by **2×** on the paired populati
 A 2× definitional ambiguity dominates every estimator question below, and it is
 free to resolve now, while nothing depends on the answer.
 
-### 3. For a go/no-go threshold, the join may not be needed at all
+### 3. For a go/no-go threshold, the join is not needed — but WHICH aggregate matters
 
 Gate 3 is a **decision instrument for launch and spend posture** (ADR-007), not a
-product feature. The question it answers is *"do enough installs turn into
-revenue to make acquisition spend viable?"* — and a **ratio of two counts over a
-lagged window** answers that without any identity:
+product feature. The question it answers is *"do enough installs turn into revenue
+to make acquisition spend viable?"* — and a **ratio of two counts** answers that
+without any identity.
 
-> installs in window *W* · payments in window *W + lag*
+**But the choice of window is not a detail, and revision 1 got it backwards.**
+Write `w[k]` for the share of a cohort that converts `k` windows after install,
+`c = sum(w)` for the true cohort rate, and let installs grow at `g` per window.
+The ratio taken with lag `L` is:
 
-The bias is nameable and, decisively, **runs the safe way**. While installs are
-growing — which is the only regime a launch gate is read in — the denominator
-carries users who have not yet had time to convert, so the ratio **understates**
-conversion. A conservative estimator for a go/no-go gate fails toward *"do not
-spend yet"*. It cannot green-light spending that a true cohort read would have
-refused. With flat installs it converges on the cohort figure.
+```
+R(L) = payments(W + L) / installs(W) = sum over k of  w[k] * (1 + g)^(L - k)
+```
 
-What it cannot do, stated so nobody discovers it later: it cannot attribute by
-acquisition channel, cannot answer *"of the users who installed in week 1, what
-share paid by week 8"* exactly, and inherits Finding 2's ambiguity like every
-other option. **None of those is what a ≥2% launch threshold is for.**
+* **`L = 0`** — every term has a negative exponent, so `R < c` while `g > 0`: it
+  **understates**, and converges to `c` as growth flattens. Conservative.
+* **`L` near the mean lag** — the numerator collects payments from *later, larger*
+  cohorts than its denominator. `(1+g)^(L-k)` is convex in `k`, so by Jensen the
+  weighted average exceeds `(1+g)^(L - mean k) = 1`: it **overstates**, strictly,
+  unless the lag is deterministic. Conversion lag is **not** deterministic — trial
+  lengths and decision time spread it.
+* **Deterministic lag, correct `L`** — exact, and unavailable for that reason.
+
+The table in Revision 2 above puts numbers on it: a **1.5%** product reads
+**2.25%** at lag 2 with doubling installs and **passes a 2% gate it should fail**.
+
+What no aggregate can do, stated so nobody discovers it later: it cannot attribute
+by acquisition channel, cannot answer *"of the users who installed in week 1, what
+share paid by week 8"* exactly, and inherits Finding 2's ambiguity like every other
+option. **None of those is what a ≥2% launch threshold is for.**
 
 ### 4. Nothing is measurable today under ANY option, and that is the real critical path
 
@@ -86,21 +133,32 @@ So `install→paid` is not blocked *first* on identity. It is blocked on a sink,
 emitter, and a legal revision — all three of which every option below needs
 equally. **Minting an identifier today would buy nothing that could be read.**
 
-## Decision 1 — Recommend the aggregate ratio; mint no identifier
+## Decision 1 — The gate's number is the SAME-WINDOW ratio; mint no identifier
 
-**Compute Gate 3's `install→paid` as a lagged window ratio of two counts, and
-record the estimator's bias beside the number.** No device identifier, no alias,
-no change to `PrivacyInfo.xcprivacy`, no new row in `docs/dpa-inventory.md`, no
-legal-version bump beyond the one #226 already owes.
+**Compute Gate 3's `install→paid` as `payments(W) / installs(W)` — same window,
+no lag — and treat that as the number the gate is read against.** No device
+identifier, no alias, no change to `PrivacyInfo.xcprivacy`, no new row in
+`docs/dpa-inventory.md`, no legal-version bump beyond the one #226 already owes.
+
+**The lagged ratio may be reported beside it as the optimistic bound.** Between
+the two lies the truth; the gate clears when the **conservative** one clears. That
+is the whole discipline, and it is one line to implement.
 
 The reasoning is not that the ratio is as good as a cohort join. It is that:
 
 * the join's **only** advantage over the ratio is precision the threshold does not
   use, and channel attribution the MVP does not buy;
-* the ratio's error runs **toward refusing spend**, which is the direction a gate
-  should fail in;
+* the same-window ratio's error runs **toward refusing spend**, which is the
+  direction a gate should fail in — and it is the *only* one of the three
+  estimators in Finding 3 for which that is true;
 * and the join's cost is the one identifier in this system that **survives
   sign-out** — see Decision 3.
+
+**The cost of the conservative choice, named rather than buried.** Under steep
+growth the same-window ratio reads far below the truth (0.56% against a real
+1.5%, in Finding 3's table), so it can hold spending back on a product that is
+actually clearing the bar. That is a real cost and it is the one worth paying:
+the opposite error spends money on a product that is not.
 
 ## Decision 2 — Ask the founder the definitional question FIRST, because it is free and it is larger
 
@@ -148,8 +206,11 @@ later session does not re-derive it:
 The issue's third option — a server call at first launch — is worse than both
 others on its own terms. It **is** the distinct id, with extra steps: an
 unauthenticated write surface reachable before any account exists, which must be
-rate-limited and abuse-resisted (this repo already has `#115`, an invoker-policy
-problem on a *authenticated* endpoint), and which produces a record that is either
+rate-limited and abuse-resisted. **#115 is the relevant precedent for the shape of
+that decision, not for the abuse risk**: it records that making a prod endpoint
+world-reachable is a security decision on a live system, founder-gated, and still
+open. A new pre-account surface would be a second one. The ping produces a record
+that is either
 identifier-bearing (Decision 3's costs, plus a network leg) or anonymous (in which
 case it is Decision 1's count, arrived at expensively).
 
@@ -164,10 +225,13 @@ does not read as an open question.
   server-side (ADR-060). **Gate 2 is unaffected** — both events are client-side and
   uid-keyed. **One threshold of four** was ever at stake, and this ADR does not
   leave it unmeasurable: it leaves it measurable with a stated bias.
-* **The estimator's bias must be reported with the number, every time.** A ratio
-  quoted without its lag and its growth assumption is a cohort figure that is
-  quietly wrong, and this ADR is the only place that says so — there is no test
-  that can enforce it, because nothing is computing it yet.
+* **The estimator's window must be reported with the number, every time.** A ratio
+  quoted without saying whether it is same-window or lagged is a cohort figure
+  that is quietly wrong **in an unknown direction** — and revision 1 of this very
+  ADR made that mistake in the direction that green-lights spend. There is no test
+  that can enforce it, because nothing is computing it yet; this paragraph is the
+  only guard, which is why the arithmetic is written out above rather than
+  summarised.
 * **Finding 2 is a live defect in a document, not a hypothetical.** `mvp.md`'s
   Gate 3 line is ambiguous *today*, and would have been read wrong by whoever
   first built the funnel — including under the identifier option. It is now

--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -75,10 +75,14 @@ installs end up paying" mean 2% produce a payment, or 2% become a paying person?
 Those differ by exactly 2×, which is the whole value of the threshold. No
 identifier fixes this — it is a definition, and it is free to settle now.
 
-**Second, the number may not need the join at all.** For a go/no-go decision,
-installs this month against payments next month answers *"is acquisition worth
-paying for"* without identifying anybody — and it errs on the cautious side, so it
-can only ever tell you to spend *less* than the truth, never more.
+**Second, the number may not need the join at all.** Comparing installs and
+payments **over the same month** answers *"is acquisition worth paying for"*
+without identifying anybody, and it errs on the cautious side — it can only ever
+tell you to spend *less* than the truth, never more. *(My first draft suggested
+comparing this month's installs against next month's payments. A review caught
+that: while installs are growing that version flatters the number and could tell
+you to spend on a product that has not earned it. The safe version is the plain
+same-month one.)*
 
 > **② When you next look at the privacy documents, answer one sentence: does
 > `install→paid` count payments, or paying people?** *(No rush, no cost, nothing

--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -1,12 +1,13 @@
 # Operator Checkpoint
 
-**Last Updated:** 2026-08-26 UTC (S085)
+**Last Updated:** 2026-08-27 UTC (S086)
 
 ## Current Status
 
-- Session: **085**
-- Goal: **#246 — make "Delete account and data" reach the markers left on the phone**
-- Status: **Shipped and closed.** Deleting your account now also removes the app's own private notes-to-self about your account from the phone you delete it on
+- Session: **086**
+- Goal: **#243 — decide how (or whether) to measure "installs that become paying users"**
+- Status: **Decided and recorded** (ADR-062). **Nothing built and no identifier created**, deliberately. One question below is yours
+- ⚠️ **NEW AND TIME-SENSITIVE: the 9 a.m. daily question needs ONE action from you before it can ever arrive. See "The one thing that unblocks notifications" below.**
 - ⚠️ **Item 16 is still waiting on you, and it is the oldest open honesty gap in the repo**
 - ⚠️ **The privacy document waiting for your lawyer now carries THREE small notes, not one — see item 16**
 - Completion: **~60%** of the iOS MVP as specified, to public launch
@@ -24,6 +25,64 @@
 The engineering is nearly done. **Content and instrumentation are the gap**, and most of what is left is yours rather than a session's.
 
 ## Latest Checkpoint
+
+**The one thing that unblocks notifications — please do this one first.**
+
+You asked for the daily question to arrive every morning at 9. **It is already
+written, on both sides, and tested.** The server picks 9 a.m. in each couple's own
+timezone, composes the message, and sends it; the app knows how to receive one.
+None of that is missing.
+
+**What is missing is that no phone has ever told us where to send it.** Measured
+today: **0 of 4 accounts have registered a device.** All four also say *"no
+report"*, which means their phones have never even reported *why* — because the
+last build was cut **2026-08-09** and the self-reporting was added after it.
+
+So one action unblocks everything:
+
+> **① Dispatch the release lane so a current build reaches TestFlight, install it,
+> open the app, and accept the notification prompt when it appears.**
+
+I cannot do this: the lane uploads a real binary under your developer account
+(§7), and the permission prompt has to be accepted on a real phone. **⚠️ If that
+prompt was ever declined on your phone, iOS will not show it again** — the app's
+Settings screen has a row that sends you to the system settings to re-enable it.
+
+Once that lands, `push_delivery_probe.py` stops saying *"no report"* and starts
+saying which link broke — or that it works. Everything after that is mine.
+
+*(A functions deploy may also be needed — prod has drifted from `main` since S077.
+That is item 4's territory and I will confirm it the moment a device registers,
+so you are not asked for two things when one may do.)*
+
+**S086 (2026-08-27) — a launch metric that cannot be measured, and the identifier I did not create.**
+
+Your Gate 3 targets include *install → paid ≥ 2%*. The app counts an install
+before anyone has an account, and a payment against a couple — **and there is
+deliberately no thread joining them**, because this product refuses to put an
+account identifier on anything it counts. That refusal is a safety choice for
+people for whom being identifiable is dangerous, and it has now been made three
+times.
+
+I did **not** create an identifier. Two findings say the question is smaller than
+it looks:
+
+**First, and this one needs a sentence from you.** *Install* counts **phones**.
+*Paid* counts **couples** — one subscription covers both partners. So a couple who
+both install and then subscribe once is **two installs and one payment**, and the
+number halves itself for exactly the people this app is for. **Does "2% of
+installs end up paying" mean 2% produce a payment, or 2% become a paying person?**
+Those differ by exactly 2×, which is the whole value of the threshold. No
+identifier fixes this — it is a definition, and it is free to settle now.
+
+**Second, the number may not need the join at all.** For a go/no-go decision,
+installs this month against payments next month answers *"is acquisition worth
+paying for"* without identifying anybody — and it errs on the cautious side, so it
+can only ever tell you to spend *less* than the truth, never more.
+
+> **② When you next look at the privacy documents, answer one sentence: does
+> `install→paid` count payments, or paying people?** *(No rush, no cost, nothing
+> waits on it except the eventual dashboard.)*
 
 **S085 (2026-08-26) — "delete my account" now reaches the phone, and nothing here needs you.**
 
@@ -364,35 +423,29 @@ Nothing blocks the *next session's engineering*. These block **launch**:
 
 ## Next Step
 
-Begin **S086 / #243** — one of the launch numbers you asked for cannot be
-computed, and fixing it would mean collecting something new. **The session will
-lay out the options; the choice is yours.**
+Begin **S087 / the 9 a.m. daily question** — founder-set, 2026-08-27. **Action ①
+above is yours and it is the only thing standing between the feature and a real
+notification.**
 
-S085 is closed: **#246** shipped and closed, deletion now reaches the phone.
-
-**Nothing blocks the next session's engineering.** The queue waiting on **you**
-is unchanged, and item **16** remains the one that matters most: a correction to
-your privacy policy, written and reviewed twice, sitting still — now with three
-small notes attached rather than one.
+S086 is closed: **#243** decided (ADR-062), nothing built, **no identifier
+created**, issue stays open for your one sentence (action ②).
 
 ## Next Session Goal
 
-**#243 — "how many people who install end up paying?" has no answer, on purpose.**
-Your Gate 3 targets include *install → paid ≥2%*. The app counts an install
-before anyone has an account, and a payment is recorded against a couple. **There
-is no shared thread between the two**, because the app deliberately refuses to put
-an account identifier on anything it counts — a choice made because this product
-is used by people for whom being identifiable is a safety question.
+**Make the 9 a.m. question actually arrive.** The honest headline: *the feature is
+finished and has never fired once.* The server picks 9 a.m. in each couple's own
+timezone, writes the message and sends it; the app knows how to receive one; both
+halves are tested. **Zero of four phones have ever said where to send it.**
 
-Joining them means giving every phone a lasting identifier at install and tying
-it to the account later. That is **collecting something new**: it goes in the App
-Store privacy answers, in the policy your lawyer is holding, and in the processor
-register. It is also the one identifier that would survive signing out.
+So the session will not "build notifications" — it will find out why a complete
+chain has delivered nothing, remove everything a session can remove, and hand you
+back a single instruction instead of a list. Two documentation defects were
+already found while measuring, and both are exactly what a person debugging this
+would read first: one comment says the question goes out at **8** when the code
+says **9**, and another says the phone-address code *"is not wired up yet"* when
+it has been for weeks.
 
-The next session writes the options down with honest costs — including simply
-**accepting that this one number cannot be measured**, which is a real answer and
-costs nothing. **It will not create any identifier.** That decision is yours, and
-it belongs beside the privacy-policy review you already have.
+**What it cannot do is put a build on your phone.** That stays action ①.
 
-**No accounts, no keys, no money, no phone — for the session. One decision, for
-you, whenever the policy review happens.**
+**No accounts, no keys, no money — for the session. One build install and one
+permission tap, for you.**

--- a/docs/past-prompts.md
+++ b/docs/past-prompts.md
@@ -4137,9 +4137,22 @@ drift therefore remains **unmeasured**, exactly as the blocker list says.
 
 **`install→paid` divides a couple count by a device count.** A couple who both install and subscribe once is two installs and one payment: the gate's own arithmetic halves itself for exactly the users the product is for, and it is invisible because both numbers are individually correct. A distinct id tells you which installs became which users; it does not tell you whether the founder means *2% produce a payment* or *2% become a paying user*, and with a couple-scoped subscription those differ by **2×** — 100% of the threshold's own value.
 
-### And a go/no-go threshold may not need the join at all
+### And a go/no-go threshold does not need the join — but the review refuted which aggregate
 
-Gate 3 is a spend/launch **decision instrument** (ADR-007), not a product feature. `installs in W / payments in W+lag` answers it with no identity, and the bias runs the safe way: while installs grow — the only regime a launch gate is read in — the denominator carries users who have not had time to convert, so the ratio **understates** conversion. A conservative estimator for a go/no-go fails toward *"do not spend yet"*; it cannot green-light spend a true cohort read would have refused.
+Revision 1 recommended a **lagged** window ratio, arguing its error *"runs the safe way"* under growth. **The design review refuted that at high confidence on both verifiers, and it was right.** The dilution argument is a property of the **same-window** ratio; applying a lag is exactly what removes it, and with a distributed conversion lag the lagged numerator collects payments from later, larger cohorts than its denominator — so by Jensen it **overstates**, in the one direction a spend gate must not fail.
+
+Worked rather than asserted, because the sign of an error is not a thing to reason about loosely. A product whose true cohort conversion is **1.5%** — which should **fail** a ≥2% gate — with installs doubling and half the cohort converting after one window, half after two:
+
+| lag | reads | gate verdict |
+|---|---|---|
+| **0 (same window)** | 0.56% | **fails** ✅ correct |
+| 1 | 1.13% | fails ✅ |
+| **2** | **2.25%** | **PASSES** ❌ green-lights spend on a product below the bar |
+| 3 | 4.50% | PASSES ❌ |
+
+With flat installs every lag is exact — which is why the error is invisible in a steady state and appears exactly when a launch is working. **The recommendation inverted**: the gate's number is the **same-window** ratio, *because* it is the one that cannot falsely pass, with the lagged ratio reported beside it as the optimistic bound. Revision 1 had the right instinct — prefer the estimator that fails safe — and named the wrong estimator.
+
+**The design review:** 4 lenses × 2 verifiers, `agents_error=0`, `agents_empty_result=0`, 6 findings, 6 verified, **0 dropped unverified**, 3 surviving. The other two were minor and both real: *"once per phone"* contradicted ADR-057 D4's own recorded bound that **a reinstall re-emits** (`SharedPreferences` does not survive app deletion), and Decision 4 mischaracterised **#115** — it is the precedent for *"making a prod endpoint world-reachable is a founder-gated security decision"*, not an abuse-resistance example. Three were killed: an unspecified lag (a decision-only ADR does not pin implementation parameters), store-provided metrics as a missed fourth option (they inherit Finding 2's ambiguity and are not ours to define), and Crashlytics' installation ID as a counterexample to the survives-sign-out claim (SDK-internal, not an identifier the app mints or can join on).
 
 **Decision 1** recommends the ratio and mints nothing. **Decision 2** hands the founder the definitional sentence *first*, because it is free and larger. **Decision 3** prices the identifier for the day it is reconsidered — it is collection, it needs a `CURRENT_LEGAL_VERSION` bump that re-gates every existing user, it reopens a line held twice, and it would be the only identifier here that survives sign-out in a product whose threat model is a partner holding the phone. **Decision 4** refuses the install-time server ping: it is the distinct id with extra steps, plus an unauthenticated pre-account write surface.
 

--- a/docs/past-prompts.md
+++ b/docs/past-prompts.md
@@ -4116,3 +4116,41 @@ drift therefore remains **unmeasured**, exactly as the blocker list says.
 `codegraph sync` reported already-up-to-date against merged `main`.
 
 **#246 closed by the merge.**
+
+---
+
+## Session 086 — 2026-08-27 — #243: the gate nobody can compute, and the identifier that would not fix it (ADR-062)
+
+**Objective (from resume-prompt.md):** #243 — record the options and their honest costs for Gate 3's `install→paid`. **Do not mint an identifier.**
+
+**Outcome:** decided and recorded (ADR-062, `Proposed`). **Nothing built, no identifier created.** #243 stays open for one founder sentence. **Session cut short by a founder redirect** — see the closing note.
+
+### The issue asked about identity; the arithmetic was the bigger problem
+
+#243 frames the gap as "the two emitters share no identity". True, and re-affirmed twice (ADR-057 D3, ADR-060 D3). But asking what each event **counts** — rather than what it is keyed by — found something no identifier fixes:
+
+| event | counts one per |
+|---|---|
+| `install` | **device** (`DeviceFlag.install`, once per phone) |
+| `signup` / `paired` | **uid** |
+| `paid` | **couple** (`subscriptions/{coupleId}`, ADR-013 D5 — one purchase entitles both) |
+
+**`install→paid` divides a couple count by a device count.** A couple who both install and subscribe once is two installs and one payment: the gate's own arithmetic halves itself for exactly the users the product is for, and it is invisible because both numbers are individually correct. A distinct id tells you which installs became which users; it does not tell you whether the founder means *2% produce a payment* or *2% become a paying user*, and with a couple-scoped subscription those differ by **2×** — 100% of the threshold's own value.
+
+### And a go/no-go threshold may not need the join at all
+
+Gate 3 is a spend/launch **decision instrument** (ADR-007), not a product feature. `installs in W / payments in W+lag` answers it with no identity, and the bias runs the safe way: while installs grow — the only regime a launch gate is read in — the denominator carries users who have not had time to convert, so the ratio **understates** conversion. A conservative estimator for a go/no-go fails toward *"do not spend yet"*; it cannot green-light spend a true cohort read would have refused.
+
+**Decision 1** recommends the ratio and mints nothing. **Decision 2** hands the founder the definitional sentence *first*, because it is free and larger. **Decision 3** prices the identifier for the day it is reconsidered — it is collection, it needs a `CURRENT_LEGAL_VERSION` bump that re-gates every existing user, it reopens a line held twice, and it would be the only identifier here that survives sign-out in a product whose threat model is a partner holding the phone. **Decision 4** refuses the install-time server ping: it is the distinct id with extra steps, plus an unauthenticated pre-account write surface.
+
+**`mvp.md` was deliberately NOT edited.** Gate thresholds and their definitions are the founder's (ADR-007); a session that quietly rewrote one would be deciding launch posture by commit.
+
+### Closing note — the session was redirected mid-flight, and this is what that means
+
+The founder set the next objective directly: **the daily question must arrive at 09:00 every morning.** ADR-062 was committed before the redirect and its design review was launched; **the review's outcome is folded below or the ADR carries `Proposed` with the gap named.** No implementation work for #243 existed to abandon — the session's whole deliverable was the record.
+
+**What the redirect surfaced, measured immediately:** the 09:00 feature is **complete on both sides and has never fired once.** `DAILY_QUESTION_LOCAL_HOUR = 9`, the composer, the sweep call, an emulator test, `firebase_messaging ^16.4.3`, `FcmPushTokenSource`, both entrypoints overriding the provider, `aps-environment` present — and **0 of 4 accounts registered**, all four *"no report"*, because the last build predates ADR-049's diagnostic. That is one operator action, and `operator-expected.md` now leads with it as a single numbered step.
+
+**Two stale comments found in the same measurement**, both on the path a debugger reads first: `payload-policy.ts:115` calls `dailyQuestion` *"the hour-8 sweep push"* beside a constant that is **9** (ADR-045 re-pointed it and the comment did not move), and `push_token_source_provider.dart:9` says *"nothing overrides this yet"* when both entrypoints do. **Handed to S087 rather than fixed here** — they belong to that objective, and `session-rules.md` §2 says a session does one thing.
+
+**Operator action IS required, and it is the point:** one release-lane dispatch, one install, one permission tap.

--- a/docs/resume-prompt.md
+++ b/docs/resume-prompt.md
@@ -1,4 +1,4 @@
-# Resume Prompt — Session 086
+# Resume Prompt — Session 087
 
 > **This file contains ONE objective. That objective is the session; nothing else is.**
 > (`project-rules.md` #1, `session-rules.md` §1.)
@@ -7,52 +7,92 @@
 > never-without-asking list) and `session-lessons.md` (numbered to **129**) first.
 > Re-derive the session number from `git log`.
 
-**Objective: #243 — Gate 3's `install→paid ≥2%` cannot be computed, because the
-two emitters share no identity. Record the options and their honest costs in an
-ADR. Do NOT mint an identifier.**
+**Objective (founder-set, 2026-08-27): the daily question must actually arrive on
+a phone at 09:00 every morning. Close the gap between "built" and "delivered" —
+and make the one operator step that remains a single, unambiguous instruction.**
 
-`install` is a **client** event fired before any account exists. `paid` is a
-**server** event keyed to a `coupleId` the RevenueCat webhook resolves. Nothing
-joins them — and the obvious join was removed on purpose: **ADR-057 D3 forbids a
-uid or `coupleId` on any client event, ever**, which is stronger than ADR-016
-requires because this is a DV-aware product.
+### ⚠️ Read this before planning: the feature is WRITTEN. It has never fired once.
 
-**This is a decision session, like S084/ADR-060 — decide and record, build
-nothing.** Minting a device-scoped id is **collection**, it lands in
-`PrivacyInfo.xcprivacy`, the #226 policy revision and `docs/dpa-inventory.md`'s
-processor register, and it is the one identifier that **survives sign-out**,
-which in a DV threat model is a property to decide deliberately rather than
-inherit from an SDK default. **That call is the founder's, alongside #226.**
+Measured 2026-08-27, not inherited:
 
-**The three options the ADR must price honestly**, per the issue: a device-scoped
-id aliased to the account at signup · **accepting the metric is uncomputable**
-and saying so in `mvp.md` · an install-time server ping. The second is a real
-answer, not a failure — Gate 2 and Gate 3's `trial→paid` are both computable
-without it (the issue's own table says so), so what is at stake is **one**
-headline threshold, and the ADR should say what the founder loses by dropping it.
+| link | state |
+|---|---|
+| `DAILY_QUESTION_LOCAL_HOUR` | **9**, `functions/src/notifications/daily-question.ts:48` — couple-local, ADR-045 |
+| the composer | `dailyQuestion` is a `PushKind`; `payload-policy.ts` composes it; content never travels |
+| the sweep | `question-rollover.ts:115` calls `runDailyQuestion` each hourly pass |
+| emulator proof | `functions/test/emulator/daily-question.test.ts` exists |
+| `firebase_messaging` | **^16.4.3, a real dependency** |
+| the token adapter | `FcmPushTokenSource` exists and **both entrypoints override the provider** (`main_dev.dart:239`, `main_prod.dart:234`) |
+| `aps-environment` | **present** in `Runner.entitlements` |
+| **devices registered** | **0 of 4.** All four accounts: *"no report"* |
 
-⚠️ **ADR-060 D2 deliberately left #243 open** and resolved the identity question
-*conservatively* (neither identifier on the server three), handing the
-**relaxation** to this issue. Read that decision before re-opening it.
+**So the objective is not "build the 9am notification". It is "find out why a
+complete, tested chain has delivered nothing, and remove what a session can."**
 
-**Acceptance:** an ADR that states which option is recommended and why, what each
-costs in paperwork that already exists, and exactly what the founder must decide.
-`operator-expected.md` gains the decision. **No identifier is minted, no
-`PrivacyInfo.xcprivacy` edit, no legal-version bump.**
+`python3 tool/ci/push_delivery_probe.py --from-firebase-cli` is the instrument.
+**Run it first.** Today it says: 0/4 registered, four *"no report"* — and ADR-049's
+own text says a no-report is **not distinguishable** from "no build carrying the
+diagnostic ever ran here" (lesson **65**). **The last build was cut 2026-08-09;
+ADR-049 merged after it.** That single fact explains all four rows, and it is why
+the operator step below is the whole game.
 
-## 1. Where things stand *(measured 2026-08-26 — re-measure, do not inherit)*
+### Two stale comments found while measuring — fix them, they are about this hour
+
+* `functions/src/notifications/payload-policy.ts:115` says *"dailyQuestion is the
+  **hour-8** sweep push"* — beside a constant that is **9**. ADR-045 re-pointed it
+  and the comment did not move. A reader debugging "why didn't it arrive at 9"
+  meets a comment saying 8.
+* `app/lib/features/notifications/domain/push_token_source_provider.dart:9` says
+  *"**Nothing overrides this yet**, and that is the design"* — **false since the
+  adapter landed**; both entrypoints override it. Lesson **123**'s exact shape.
+
+**Neither is cosmetic**: both are the first thing a session reads when this
+feature fails to deliver, and both would send it the wrong way.
+
+### Acceptance
+
+1. **The probe is run and its output quoted**, before anything is changed.
+2. **The two stale comments are corrected**, and the tree grepped for others in
+   the same family (lesson **126**).
+3. **The 09:00 path is proven end to end where a session CAN prove it** — the
+   emulator: a couple with a registered token, the sweep at couple-local hour 9,
+   the messaging port receiving exactly one `dailyQuestion` and no content. If
+   `daily-question.test.ts` already proves it, **say so and do not re-prove it**;
+   if it proves less than that, extend it and mutation-check the extension.
+4. **`operator-expected.md` carries ONE numbered step** the founder can do in
+   five minutes without reading anything else, and states what it unblocks.
+5. **No `UIBackgroundModes: remote-notification`** — see the warning below.
+
+### What is NOT this session's, and why
+
+**A delivered notification.** It needs a **release build** (§7, founder-only — the
+lane uploads a real binary) and **one permission grant on a real phone**, and if
+that prompt was ever declined iOS will not show it again. It may also need a
+**functions deploy** (§7). A session can make all three unnecessary to *think*
+about; it cannot do them.
+
+## 1. Where things stand *(measured 2026-08-27 — re-measure, do not inherit)*
 
 | | State |
 |---|---|
 | **#246** | **CLOSED by S085** (ADR-061). The delete path sweeps the device; the flag seam is typed so a flag cannot exist unclassified |
 | **#226** | **DRAFT on `main`, revision NOT landed.** `docs/legal/proposed/` holds version 3; `CURRENT_LEGAL_VERSION` is **still 2** and a test asserts it. Closes only when founder + lawyer approve |
-| **The legal-review cluster** | **#249**, **#258** and this objective all end at the same desk. Two are one-line notes already written into `docs/legal/proposed/README.md`; #243 is the one that needs a decision, not a clause |
+| **#243** | **DECIDED, nothing built** (ADR-062, S086). Recommends **no identifier**; stays open for one founder sentence (`install→paid` counts payments or paying users — they differ by **2×**) |
+| **The legal-review cluster** | **#249**, **#258** and **#243** all end at the same desk. Two are one-line notes already written into `docs/legal/proposed/README.md`; #243 needs a decision, not a clause |
 | **#136** | **Autonomous half DONE** (ADR-059). Stays open for **step 1** — whether the notification shade honours `U+2068`/`U+2069` — which is device-blocked |
 | **#242** | **DECIDED, not built** (ADR-060). Stays open for the emitter, which waits on a sink. `ProcessOutcome` must grow to carry the previous lane state first |
-| **Push, device side** | **STILL ZERO.** 0/4 accounts registered, all four "no report" |
-| **The build gap** | Last `release.yml` run is **2026-08-09, build 119**. ADR-046/049/051/052/053/057/059/**061** are on **nobody's phone** |
+| **Push, device side** | **STILL ZERO** — re-measured today with `push_delivery_probe.py`. 0/4 accounts registered, all four *"no report"*. **This objective's whole subject** |
+| **The 09:00 path itself** | **Fully written and emulator-tested, server AND client.** Hour constant 9, composer, sweep call, `firebase_messaging` ^16.4.3, `FcmPushTokenSource`, both entrypoints overriding, `aps-environment` present. Nothing is missing except a build on a phone |
+| **The build gap** | Last `release.yml` run is **2026-08-09, build 119**. ADR-046/049/051/052/053/057/059/**061** are on **nobody's phone** — and **ADR-049's push diagnostic is among them**, which is exactly why all four accounts read *"no report"* rather than a reason |
 | **Deployed rules / functions vs `main`** | Both **drifted or unmeasured** since S071/S077. A deploy is a **§7 founder ask** |
-| **Open issues** | **#242**, **#243**, **#247**–**#250**, **#253**, **#258**, plus the older set |
+| **Open issues** | **#242**, **#243**, **#247**–**#250**, **#253**, **#258**, plus the older set. **#246 closed by S085** |
+
+### What S086 left (one commit, no code)
+
+* **ADR-062 is `Proposed`**, decision-only. It recommends the aggregate ratio and
+  **mints no identifier**, and its two load-bearing findings are that the funnel's
+  events count **three different entities** (device / uid / couple) and that a
+  go/no-go threshold does not need a per-user join at all.
 
 ### What S085 changed that a later session will trip over
 
@@ -102,18 +142,23 @@ costs in paperwork that already exists, and exactly what the founder must decide
 
 ## 2. Then, in priority order
 
-**1 — #249** (the consent record is named in no collection list — the third note
-for the same legal desk) · **#248** (**thirteen** ADRs missing from the index now,
-049–061; the issue body was re-measured in S085 and the proposed fix is a test
-that asserts the file set equals the linked set — it would have failed thirteen
-sessions ago).
+**1 — #243's remaining half** (ADR-062, S086): the ADR is written and recommends
+**minting no identifier**. It stays open for **one founder sentence** — whether
+Gate 3's `install→paid` numerator counts *payments* or *paying users*, which
+differ by **2×** on the paired population because `install` counts **devices** and
+`paid` counts **couples**. Nothing to build.
 
 **2 — #253** (`partnerAnswered` names nobody: **no caller supplies
 `partnerName`**, which is also why ADR-059's `sanitizePushName` sits in a branch
-nothing calls — closing #253 is what activates it) · **#204** (`deliver` has
-failed to create the `tr` localization on **every** release since build 112, but
-the **name** is what Apple refuses, so its fix is founder-blocked) · **#165**
-(`rules-drift` built but unarmed) · **#121** · **#115** · **#41** · **#63/#71**.
+nothing calls — closing #253 is what activates it, and it is the *same feature
+family* as this session's objective) · **#249** (the consent record is named in no
+collection list) · **#248** (**fourteen** ADRs missing from the index now,
+049–062).
+
+**3 — #204** (`deliver` has failed to create the `tr` localization on **every**
+release since build 112, but the **name** is what Apple refuses, so its fix is
+founder-blocked) · **#165** (`rules-drift` built but unarmed) · **#121** · **#115**
+· **#41** · **#63/#71**.
 
 ⚠️ **Do not add `UIBackgroundModes: remote-notification`** without deciding SEC-3
 first. Token capture needs none of it; only background *delivery* does.

--- a/docs/resume-prompt.md
+++ b/docs/resume-prompt.md
@@ -142,8 +142,10 @@ about; it cannot do them.
 
 ## 2. Then, in priority order
 
-**1 — #243's remaining half** (ADR-062, S086): the ADR is written and recommends
-**minting no identifier**. It stays open for **one founder sentence** — whether
+**1 — #243's remaining half** (ADR-062 **revision 2**, S086): the ADR recommends
+**minting no identifier**, and — after its design review refuted revision 1 —
+the **same-window** ratio rather than a lagged one, because a lagged ratio
+*overstates* under growth and can pass a gate the truth fails. It stays open for **one founder sentence** — whether
 Gate 3's `install→paid` numerator counts *payments* or *paying users*, which
 differ by **2×** on the paired population because `install` counts **devices** and
 `paid` counts **couples**. Nothing to build.


### PR DESCRIPTION
Decision-only. **Nothing is built and no identifier is minted.** #243 stays open for one founder sentence.

## The issue asked about identity; the arithmetic was the bigger problem

Asking what each event **counts** — rather than what it is keyed by — found something no identifier fixes:

| event | counts one per |
|---|---|
| `install` | **device installation** (a reinstall re-emits — ADR-057 D4 own bound) |
| `signup` / `paired` | **uid** |
| `paid` | **couple** (`subscriptions/{coupleId}`, ADR-013 D5 — one purchase entitles both) |

`install→paid` divides a couple count by a device count. A couple who both install and subscribe once is two installs and one payment: the gate halves itself for exactly the users the product is for, invisibly, because both numbers are individually correct. A distinct id does not tell you whether the founder means *2% produce a payment* or *2% become a paying user* — and those differ by **2×**, which is 100% of the threshold value.

## The review refuted my own central claim, and the recommendation inverted

**4 lenses × 2 verifiers · `agents_error=0` · `agents_empty_result=0` · 6 findings · 6 verified · 0 dropped unverified · 3 surviving.**

Revision 1 recommended a **lagged** window ratio, arguing its error "runs the safe way" under growth. That dilution argument is a property of the **same-window** ratio; applying a lag is exactly what removes it. With a distributed conversion lag the lagged numerator collects payments from later, larger cohorts than its denominator — so by Jensen it **overstates**, in the one direction a spend gate must not fail.

Worked rather than asserted. True cohort conversion **1.5%** (should **fail** a ≥2% gate), installs doubling, half the cohort converting after one window and half after two:

| lag | reads | verdict |
|---|---|---|
| **0 (same window)** | 0.56% | **fails** ✅ correct |
| 1 | 1.13% | fails ✅ |
| **2** | **2.25%** | **PASSES** ❌ green-lights spend on a product below the bar |
| 3 | 4.50% | PASSES ❌ |

Flat installs make every lag exact — which is why the error is invisible in a steady state and appears exactly when a launch is working. **Decision 1 now recommends the same-window ratio**, because it is the one that cannot falsely pass, with the lagged ratio reported beside it as the optimistic bound. Its cost — holding spend back under steep growth — is named, not buried.

Two other survivors, both real and both mine: *"once per phone"* contradicted ADR-057 D4 recorded bound that a reinstall re-emits, and Decision 4 mischaracterised **#115** (it is the precedent for *"making a prod endpoint world-reachable is a founder-gated security decision"*, not an abuse-resistance example). Three findings killed and recorded.

`mvp.md` was deliberately **not** edited — gate definitions are the founder (ADR-007); a session that quietly rewrote one would be deciding launch posture by commit.

## The handoff, retargeted by the founder

The next objective is founder-set: **the daily question must arrive at 09:00 every morning.** Measured today rather than assumed — that feature is **complete on both sides and has never fired once**:

`DAILY_QUESTION_LOCAL_HOUR = 9`, the composer, the sweep call, an emulator test, `firebase_messaging ^16.4.3`, `FcmPushTokenSource`, both entrypoints overriding the provider, `aps-environment` present — and **0 of 4 accounts registered**, all four *"no report"*, because the last build (2026-08-09) predates ADR-049 diagnostic.

So S087 is not "build notifications"; it is "find out why a complete chain has delivered nothing, and reduce the operator ask to one instruction". `operator-expected.md` now **leads** with that single numbered step.

Two stale comments found while measuring and **handed to S087 rather than fixed here** (`session-rules.md` §2 — a session does one thing), both on the path a debugger reads first:
- `functions/src/notifications/payload-policy.ts:115` calls it *"the **hour-8** sweep push"* beside a constant that is **9**
- `app/lib/features/notifications/domain/push_token_source_provider.dart:9` says *"nothing overrides this yet"* when both entrypoints do

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)