### PR TITLE
docs(s090): the CI result — green, and honest about the two jobs that measured nothing

### DIFF
--- a/docs/past-prompts.md
+++ b/docs/past-prompts.md
@@ -4546,7 +4546,9 @@ TDD: the tests were written **first** and failed for the right reason (`TypeErro
 
 **Commits:** `9806756` (ADR rev 1, before code) → `506f71e` (rev 2, design pass) → `21a9b6e` (the code) → the close commit (rev 3 record + the two stale notes).
 
-**CI:** appended at close, below.
+**CI:** **green, PR and post-merge `main`.** PR #270 — `quality` 5m18s, `functions-rules` 2m18s, `ios-build-smoke` 7m58s (verified to have actually COMPILED: `Xcode build done. 271.5s` and `✓ Built build/ios/iphoneos/Runner.app`, read via `gh api repos/:owner/:repo/actions/jobs/<id>/logs`), `slack-notify`.
+
+**Post-merge `main` run `33297898578`: success — with `integration-emulator` and `ios-build-smoke` both SKIPPED by path filtering**, because this change touches only `tool/ci/*.py` and `docs/`. That is the shape S088 named as *"a green that measured nothing at all"*, and it is said here rather than reported as a clean sweep. **What it DID measure is the part that matters:** the `quality` job's step list carries **`prod pulse self-tests: success`** — so the new absence-assertions and the four-state floor are genuinely gated in CI, not merely green on this box. Confirmed by reading the job's steps, not by inferring it from the job's colour.
 
 **Docs touched:** `docs/adr/066-*.md`, `docs/operator-expected.md`, `docs/test-suite.md`, `docs/session-lessons.md` (**141**), `docs/past-prompts.md`, `docs/resume-prompt.md`.
 


### PR DESCRIPTION
Closes out S090's session log with the CI result, per `session-rules.md` §3 step 5.

**PR #270** — `quality` 5m18s, `functions-rules` 2m18s, `ios-build-smoke` 7m58s, `slack-notify` pass. `ios-build-smoke` was checked for having **actually compiled**: `Xcode build done. 271.5s` and `✓ Built build/ios/iphoneos/Runner.app`, read via `gh api repos/:owner/:repo/actions/jobs/<id>/logs` (`gh run view --job --log` returns zero lines on this repo).

**Post-merge `main` run `33297898578`: success — with `integration-emulator` and `ios-build-smoke` both SKIPPED** by path filtering, because this change touches only `tool/ci/*.py` and `docs/`. That is the shape S088 named as *"a green that measured nothing at all"*, and it is recorded that way rather than reported as a clean sweep: a run whose green comes from jobs that did not execute is not evidence about them.

**What it did measure is the part that matters**, confirmed by reading the job's step list rather than inferring it from the job's colour — the `quality` job carries **`prod pulse self-tests: success`**, so the new absence-assertions and the four-state distinctness floor are genuinely gated in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZxUPiKsJUSr6a8XD3WH51