### PR TITLE
fix(#281): the dry run reports what would CHANGE, and the lane stops voting (ADR-072)

### DIFF
--- a/.github/workflows/publish-store-metadata.yml
+++ b/.github/workflows/publish-store-metadata.yml
@@ -71,6 +71,16 @@ jobs:
       - name: install deps
         run: pip install 'pyjwt[crypto]==2.10.1'
       - name: publish
+        # ⚠️ NO VOTE (ADR-072 D3.1, the ADR-047 D4 shape one lane over). Since
+        # ADR-072 a dry run over a listing that does not yet carry the committed
+        # copy exits 1 — a FINDING — and today that is every dry run, until
+        # someone publishes, which is a founder decision that may never come.
+        # Without this the lane would be red on every single run, which is the
+        # cries-wolf failure with its sign flipped: nine green releases said
+        # nothing, and a permanently-red lane says nothing just as reliably and
+        # faster, because a human learns to skip it. The verdict travels in the
+        # report and the gloss; the run's colour stops pretending to carry it.
+        continue-on-error: true
         # The input reaches the script as ENV, never interpolated into the shell
         # body: `${{ }}` expansion happens before bash sees the line, so a value
         # containing shell metacharacters would otherwise execute.
@@ -92,6 +102,10 @@ jobs:
           fi
           code=$?
           set -e
+          # ⚠️ NOT "published" (ADR-072 D3). This line used to gloss 0 as
+          # `published`, which was false about a dry run on every branch of it —
+          # and a dry run is what this lane is for. The exit code is read by
+          # machines; this sentence is read by the founder.
           echo "store_metadata_publish exit=$code" \
-               "(0 published · 1 finding · 2 could not measure · 64 refused)"
+               "(0 nothing to do · 1 finding · 2 could not measure · 64 refused)"
           exit "$code"

--- a/docs/adr/072-a-dry-run-that-says-published-is-a-false-green.md
+++ b/docs/adr/072-a-dry-run-that-says-published-is-a-false-green.md
@@ -177,6 +177,45 @@ ever entitled to the first.
   record of what the tool's first real execution found — which was the session's
   actual job (ADR-071 said the first run would be the first test; it was).
 
+## Implementation record (added when #281 was built)
+
+`tool/ci/store_metadata_publish.py` + **11 new self-tests (14 → 25, all
+registered; 62 → 96 checks)**. **Mutation-checked: 21 mutants, 20 killed by a
+NAMED assertion**; the one survivor is recorded, not fixed — locale iteration
+order is presentational.
+
+**Verified against Apple**, which is the point of the exercise: run
+`33686025994`, dispatched from the branch, `confirm` blank —
+
+```
+  en-US: PATCH appInfoLocalizations — 3 field(s), 2 would change: name, privacyPolicyUrl, subtitle
+  ...
+15 field(s) would change — the listing does not yet carry what this ref committed.
+store_metadata_publish exit=1 (0 nothing to do · 1 finding · 2 could not measure · 64 refused)
+```
+
+**exit 1, and the run is green** — the publisher and the auditor now agree about
+the listing, and the lane no longer votes. ⚠️ And `en-US`'s app-info row reads
+**2 of 3 would change**: the third is `name`, the one field the store already
+carries, which is exactly what ADR-070 D6 inferred from the auditor's silence
+about it. **Two instruments, independently, on live data.**
+
+### 3.2 — What the build found, and it was this ADR's own shape again
+
+**Making the step `continue-on-error` means EVERY exit is a green job** — and
+`REFUSED` (64) and `COULD NOT MEASURE` (2) both returned *before* the summary was
+written. A green job with an empty summary is *"nothing happened"* to anyone
+glancing at it: **the fix for one false signal introduced two more.** Every exit
+now writes a summary, pinned by tests and two mutants.
+
+⚠️ **And D2's *"the write path is untouched"* is about the exit-code rule, not
+about the lane.** `continue-on-error` masks a **failed write** too, which the
+review's completeness critic was right to name. That is accepted and is now said
+out loud: **this lane has no vote in either mode** — ADR-047 D4's rule is that a
+store-copy finding must never redden a build, and it does not become a different
+rule because the tool wrote something. What makes it safe is 3.2's other half:
+the verdict is in the summary on **every** path, so nothing depends on the colour.
+
 ## Review record
 
 **14 agents, 4 probes × 2 verifiers + a completeness critic.** `agents_error`

--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -1,6 +1,6 @@
 # Operator Checkpoint
 
-**Last Updated:** 2026-09-02 UTC (Session 096)
+**Last Updated:** 2026-09-03 UTC (Session 098)
 
 > This file is a **live checkpoint**, not a history. It carries only the current
 > state and what is open right now. What each session did, and why, lives in
@@ -8,9 +8,9 @@
 
 ## Current Status
 
-- Session: **097** (complete)
-- Goal: **run the new lane against Apple for the first time and put its plan in front of you**
-- Status: **Complete** — it ran, it worked, and the plan is in item 6(b) below
+- Session: **098** (complete)
+- Goal: **stop the two store-metadata lanes disagreeing about your listing**
+- Status: **Complete** — they agree now, and item 6(b) below is unchanged and still waiting on you
 - Completion: **~58%** of the iOS MVP, to public launch
 - Production Readiness: **Integration Ready**
 
@@ -76,6 +76,7 @@ drift checks measuring instead of skipping.
 | **095** | The tool that checks your store listing could only say a field *"differs"*. Now it says *how* — and the first honest answer was that seven of your nine English fields contain **nothing at all**. Also: five documents (one of them in code) claimed your app is called `İkimiz`; it is `ikimiz`, and the guard that exists to protect that name would not have caught a careful person following the wrong instruction. |
 | **096** | Built the thing that fixes it: your store copy can now be published **one language at a time**, so the Turkish listing Apple keeps refusing stops taking the English one down with it. **Nothing has been published** — that is your decision, item 6(b), and item 6(c) just got smaller because this no longer needs a release build. |
 | **097** | Pointed it at Apple for the first time, in the mode that writes nothing. **It worked**, and **item 6(b) now shows you exactly what would be published.** It also caught itself telling a small lie — a run that published nothing was reporting *"published"* — which is filed as #281 and does not affect anything you are being asked. |
+| **098** | Fixed that lie. The two tools that look at your store listing now agree with each other, and the report says **how much would change** — 15 fields — instead of just *"different"*. One of those numbers is a small piece of good news: your app's **name** is the one field already correct at Apple, confirmed independently by both tools. |
 
 Everything is merged to `main` and CI is green.
 
@@ -345,12 +346,12 @@ Read item 6(b) and answer it. Everything else on this page is downstream of item
 
 ## Next Session Goal
 
-**Session 098 — #281: the publish lane reports what would CHANGE, and stops
-voting.** The lane's dry run currently exits *"0, published"* having published
-nothing, while the checker says *"1, finding"* about the same listing. Two tools
-disagreeing about one subject is how one of them stops being believed. Designed
-and reviewed in ADR-072; the code is a session's, needs nothing from you, and
-changes nothing about the decision in item 6(b).
+**Session 099 — #121: prove whether a dead step in the release lane is really
+dead, by reading fastlane's own source instead of waiting for a release.** It is
+the last open issue whose central question can be answered without you.
 
 ⚠️ **After that, the queue is genuinely yours.** Every remaining open issue is
-waiting on billing, a phone, a lawyer, a secret, or a decision on this page.
+waiting on billing, a phone, a lawyer, a secret, or a decision on this page —
+re-derived at the end of session 098 rather than assumed. **The most useful thing
+you can do next is item 6(b)**: it needs no money, no hardware and nobody else,
+and it is the only one that unblocks work rather than waiting on it.

--- a/docs/past-prompts.md
+++ b/docs/past-prompts.md
@@ -4952,3 +4952,68 @@ The objective's instrument was a **real GitHub Actions run against the real App 
 **Operator dependency:** unchanged, and now answerable. **6(b)** has its evidence attached for the first time.
 
 **Next objective written to resume-prompt.md:** Session 098 — **#281**: make the publish lane report what would change and stop voting, so it and the auditor stop disagreeing about the same listing.
+
+## Session 098 — 2026-09-03 — #281: the dry run reports what would CHANGE, and the lane stops voting (ADR-072)
+
+**Objective (from resume-prompt.md):** #281 — the publish lane's dry run exits `0` and calls it *"published"* having published nothing, while the auditor exits `1` on the same listing. Make them agree, and stop the lane voting.
+
+**Outcome:** done, and **verified against Apple** rather than only against fixtures.
+
+### Reproduced first
+
+Minutes apart, on one listing state: `store_metadata_audit` **exit 1** (run 33685506236) and `store_metadata_publish --dry-run` **exit 0** (run 33685509829), glossed *"published"*, from a run that sent nothing.
+
+### What shipped
+
+* Every `Action` carries **`changing`** — the fields whose value differs from what Apple holds, compared with the **auditor's** `normalize` and nothing else, because a second dialect of *"differs"* is how two tools start disagreeing.
+* ⚠️ **`changing` never decides what is sent.** The write still sends every field: *make it so* must not depend on the comparison being right.
+* **`published=None` reports everything as changing** — not knowing is not the same as nothing to do.
+* **`main` now calls `audit.published_locales()`.** ADR-072 revision 1 claimed the data was already there; it was not — the existing reads keep only `{locale: id}`, because ids are all a *writer* needs.
+* **One rule, two callers:** exit 1 when the listing differs from what we committed. A dry run measures it **before** the attempt; a write measures it **after**, via the untouched read-back.
+* The gloss stops saying *"published"*, and the step gets **`continue-on-error: true`** — the lane has **no vote** (ADR-047 D4's shape).
+
+### Verified against Apple
+
+Run **33686025994**, dispatched from the branch, `confirm` blank:
+
+```
+  en-US: PATCH appInfoLocalizations — 3 field(s), 2 would change: name, privacyPolicyUrl, subtitle
+  ...
+15 field(s) would change — the listing does not yet carry what this ref committed.
+store_metadata_publish exit=1 (0 nothing to do · 1 finding · 2 could not measure · 64 refused)
+```
+
+**exit 1, and the run is green.** The two lanes agree and the colour carries nothing. ⚠️ And `en-US`'s app-info row reads **2 of 3 would change** — the third is `name`, the one field the store already carries, exactly what **ADR-070 D6** inferred from the auditor's *silence* about it. **Two instruments, independently, on live data.**
+
+### ⚠️ The built-diff review found this ADR's own shape, a third time
+
+**`continue-on-error` makes every exit a green job** — and `REFUSED` (64) and `COULD NOT MEASURE` (2) both returned **before** the summary was written, so either produced **a green job with an empty summary**. The fix for one false signal introduced two more, in the ADR whose entire subject is a false green (**lesson 156**). Every exit now writes a summary.
+
+The critic also caught that D2's *"the write path is untouched"* is about the **exit-code rule**, not the lane: `continue-on-error` masks a failed **write** too. Accepted and stated in the ADR — the lane has no vote in either mode, and what makes that safe is the summary fix.
+
+### Verification
+
+| ran **here** | **11 new tests (14 → 25 functions, all registered; 62 → 96 checks)**; all 13 python self-tests CI runs; every Dart lint and self-test; `dart format` |
+|---|---|
+| ran **against Apple** | run 33686025994 — the run quoted above |
+
+**Mutation-checked: 21 mutants, 20 killed by a NAMED assertion.** ⚠️ Both new mutants found weaknesses before they found bugs: `refused-writes-no-summary` died **by an exception** until the test read the summary defensively (lesson 76), and `could-not-measure-writes-no-summary` **survived** because the tests covered only the metadata-tree branch and not the Apple-refused-the-read branch — **one `emit` per branch is one test per branch** (recurring shape 5). ⚠️ And earlier, a `str.replace` inserting five mutants **matched nothing and wrote the file unchanged**, so the harness silently re-ran the old set and printed the same green — lesson **109**, inside the tool built to catch that.
+
+### Review, twice
+
+| | pass 1 — the design (S097) | pass 2 — the built diff |
+|---|---|---|
+| agents | **14** | **10** |
+| `agents_error` | **0** | **0** |
+| `agents_empty_result` | **0** | **3**, all **CONSIDERED**-empty |
+| findings | 8 → applied or answered | **2 surviving, 0 refuted** + 1 critic |
+
+Pass 2's three considered-empty lenses were change-awareness correctness, the exit/`main` wiring, and test-quality/scope.
+
+### Notes / debt logged
+
+* ⚠️ **Counts, the seventh time across these four sessions** — and the same cause every time: written mid-change, never re-measured. **Lesson 157**: run it *last*.
+
+**Operator dependency:** unchanged. **6(b)** still carries the plan and is still unanswered; nothing was published and `confirm` was never passed.
+
+**Next objective written to resume-prompt.md:** see §4 — the queue below #281 is now entirely operator-blocked, and S099 opens by re-deriving that rather than inheriting it.

--- a/docs/resume-prompt.md
+++ b/docs/resume-prompt.md
@@ -1,9 +1,9 @@
-# Resume Prompt — Session 098
+# Resume Prompt — Session 099
 
 > **This file contains ONE objective. That objective is the session; nothing else is.**
 > (`project-rules.md` #1, `session-rules.md` §1.)
 >
-> Read `session-context.md` and `session-lessons.md` (numbered to **155**) first.
+> Read `session-context.md` and `session-lessons.md` (numbered to **157**) first.
 > Re-derive the session number from `git log`.
 >
 > ⚠️ **`session-context.md` §2/§3 changed again in S096** — the toolchain is
@@ -11,81 +11,85 @@
 > the table is a claim like any other (lesson **146**).
 >
 > ⚠️ **BEFORE PLANNING, OPEN THE ADR THAT OWNS THIS OBJECTIVE** (lesson **145**).
-> Here that is **ADR-072**, and S097 wrote it — read it as a claim to check. It is
-> already reviewed pre-code and carries three corrections; start from it, not from
-> the issue title.
+> Here that is **ADR-032 D4**, which *kept* the step this session is about and
+> said exactly what it lacked. Read it as the thing to discharge, not to re-argue.
 >
-> ⚠️ **AND POINT ONE LENS AT THE OBJECTIVE ITSELF** (lesson **154**). S097 found
-> something interesting on the way to its objective and spent itself on that
-> instead. **The tell is checkable: if your diff does not touch the file your
-> acceptance criteria name, you have changed objective.**
+> ⚠️ **AND POINT ONE LENS AT THE OBJECTIVE ITSELF** (lesson **154**). **If your
+> diff does not touch the file your acceptance criteria name, you have changed
+> objective.**
 
-**Objective: #281 — the publish lane's dry run exits `0` and calls it
-"published" having published nothing, while the auditor exits `1` on the same
-listing. Make them agree, and stop the lane voting.**
+**Objective: #121 — settle whether `release.yml`'s `write App Store Connect API
+key` step is dead, by READING THE INSTALLED FASTLANE rather than by waiting for a
+release run.** Restore `ruby` + `bundle` (the last missing toolchain) and use the
+gem source to answer the question ADR-032 D4 recorded as unanswerable from here.
 
 ### ⚠️ First, three commands. Quote all three before planning.
 
 ```sh
-for c in node npm python3 java dart flutter ruby gh git firebase; do printf '%-9s ' "$c"; command -v $c || echo MISSING; done
-gh workflow run testflight-testers.yml -f store_metadata_audit=true    # the auditor's verdict
-gh workflow run publish-store-metadata.yml                             # the publisher's — confirm BLANK, writes nothing
+for c in node npm python3 java dart flutter ruby bundle gh git firebase; do printf '%-9s ' "$c"; command -v $c || echo MISSING; done
+gh workflow run publish-store-metadata.yml     # confirm BLANK — writes nothing
+gh issue view 121 --json body -q .body
 ```
 
-Measured 2026-09-02 (S097) — **re-measure, do not inherit**:
+⚠️ **`java`, `dart` and `flutter` read MISSING until you export PATH** — they are
+installed (`session-context.md` §3). `ruby`/`bundle` are the genuinely absent
+ones, and restoring them is step one of this objective.
 
-* `ruby`/`bundle` **MISSING**; everything else present. `flutter` and `java` are
-  **not on PATH** — export them (`session-context.md` §3);
-* **the two lanes disagree, and that is the objective**: the auditor exits **1**
-  (seven `en-US` fields `PUBLISHED IS EMPTY`, `tr` absent), the publisher's dry
-  run exits **0**, glossed as *published*, having sent nothing;
-* `prod_pulse` still exits **2 — could not measure** (the instrument, not
-  production — operator item 10).
+### Why this is the objective, and why it is not a release run
 
-### Why this, and what is already decided
+Everything else is operator-blocked — re-derived, not inherited, at the end of
+S098 (§3). **#121 is the one open issue whose central question can be answered
+without the founder**, and only because the answer lives in a gem this box can
+now install.
 
-**ADR-072 designed it and a pre-code review has already corrected it three
-times** — so this session's job is to build a reviewed design, not to re-derive
-it. The three corrections are the parts most likely to be got wrong:
+`release.yml` writes the App Store Connect `.p8` to xcodebuild's auto-discovery
+path, `$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8`. That step
+exists for **ADR-021 D5's cloud signing**, which ADR-032 replaced with fastlane
+`match`. The issue's own evidence says nothing reads it any more — and
+**ADR-032 D4 KEPT it anyway**, on ADR-029 D2's precedent: *"very likely dead" is
+not "proven dead"*, and the cost of being wrong is a broken release the founder
+cannot debug.
 
-1. **The data is not there.** `main` reads both resources and keeps only
-   `{locale: id}`, throwing the attributes away, because ids are all a *writer*
-   needs. Call `audit.published_locales()` in the dry-run path — it already
-   merges both resources into the shape `audit_findings` wants, and the dry run
-   stays read-only.
-2. **The two paths are two implementations of one rule.** A dry run compares
-   **before** the attempt; a write compares **after**, via the read-back. Do not
-   go looking for a shared code path — the write path is **untouched**.
-3. **The lane must stop voting.** Under the new rule a dry run over today's
-   listing exits **1** forever, so without `continue-on-error: true` every run
-   reddens — the cries-wolf failure with its sign flipped (ADR-047 D4's shape).
+**That precedent is about not making a blind EDIT. It is not a reason to avoid
+LOOKING** — and *query the platform, not the docs* is this repo's standing rule.
+`fastlane`'s own source will say whether `app_store_connect_api_key`, `match`,
+`pilot` or `deliver` ever consults that path, and whether `xcodebuild
+-allowProvisioningUpdates` still needs it under **manual** signing with an
+explicit `ExportOptions.plist`.
 
 ### Acceptance
 
-1. **The three commands are run and quoted**, and the two lanes' disagreement is
-   shown before and after.
-2. **ADR-072 read first**, and its claims checked — S097 wrote it (lesson 145).
-3. **A dry run over the current listing exits 1** and says how many fields would
-   change; **over a matching listing exits 0**; **a successful write still exits
-   0** via the untouched read-back path.
-4. **The lane is green in both cases.** Its colour carries nothing.
-5. **Self-tests for each, mutation-checked**, with any non-discriminating mutant
-   **recorded rather than removed** (S095 and S096 each had one).
-6. **An ADR amendment or a note committed BEFORE the code** if anything in
-   ADR-072 turns out wrong, **with its index row in the same commit** — ADR-067's
-   lint has caught three sessions.
-7. **Re-run the dry run at the end and quote it.** The change is about what that
-   run says; a session that does not run it has not verified it.
+1. **The three commands are run and quoted**, with `ruby`/`bundle` restored and
+   the version `Gemfile.lock` pins (`fastlane 2.237.0`) actually installed.
+2. **ADR-032 D4 and #121 read first**, and D4's bound quoted before any
+   conclusion. **It is a bound on editing, not on reading — say so explicitly.**
+3. **The question answered FROM THE GEM SOURCE**, with file paths and quoted
+   lines from the installed fastlane, not from documentation and not from memory.
+   ⚠️ **Only the vendor can refute a vendor API shape** — the gem *is* the vendor.
+4. **Say plainly which half is proven** (lesson **78**): reading the source can
+   prove *"nothing in these lanes reads that path"*; it **cannot** prove
+   *"xcodebuild never reads it"*, because `xcodebuild` is not in the gem. If the
+   answer needs a real run, **say so and stop** — that is a clean outcome.
+5. **If it is proven dead**: delete the step, amend **ADR-032 D4** with the
+   evidence, and **an ADR or amendment committed BEFORE the code** with its index
+   row in the same commit.
+6. **If it is NOT proven dead**: leave it, and write down *what* consults the path
+   — the issue itself says that is a genuinely useful fact worth recording rather
+   than re-deriving.
+7. ⚠️ **Do NOT dispatch the release lane.** §7, and operator 6(c) is unanswered.
 
 ### What is NOT this session's
 
-* ⚠️ **Writing to App Store Connect.** Operator **6(b)** carries the plan and is
-  unanswered; **do not pass `confirm`.**
-* **The Turkish name** (6(a)), **billing** (1), **the RevenueCat invoker** (2),
-  **the four secrets** (3), **a build** (4), **the legal bundle** (5), **the
-  firebase login** (10).
-* **#136** — ADR-059 D3 decided it; **#71** — its own issue says *"this is not a
-  bug"*. **Do not re-derive either.**
+* **Dispatching `release.yml`** (6(c)), **writing to App Store Connect** (6(b)),
+  **the Turkish name** (6(a)), **billing** (1), **the invoker** (2), **the four
+  secrets** (3), **a build** (4), **the legal bundle** (5), **the firebase
+  login** (10).
+* **#136** — ADR-059 D3 decided it. **#71** — its own issue says *"this is not a
+  bug"* and ADR-025 D5.ii decided the arrangement is correct. **#242** — ADR-060
+  D6. **Do not re-derive any of the three.**
+* **#63** — ADR-025 records it as a whole-app decision. ⚠️ **Putting the question
+  into `operator-expected.md` IS a session's and has never been done**; answering
+  it is not. Do that only if #121 closes early.
 
 ---
 
@@ -96,11 +100,13 @@ it. The three corrections are the parts most likely to be got wrong:
 | **The dev box** | **Mostly restored** (S096): Flutter 3.44.5, Java 21, Dart 3.12.2, firebase-tools 15.22.4, node, python3, gh. **`ruby`/`bundle` still MISSING** — fastlane cannot run here. Flutter/Java **not on PATH**. ⚠️ git-over-HTTPS is intercepted on this network; Flutter's remote is on SSH |
 | **Production** | 🔴 **DOWN since 2026-08-22**, and **unmeasurable from here** — operator 10 |
 | **The App Store listing** | 🔴 **EMPTY and NOT SUBMITTABLE.** 7/9 `en-US` fields blank at Apple; `tr` absent; only `name` ever set |
-| **The publish lane** | **BUILT, MERGED, AND RUN** — S097's dry run (33681088334) worked on first contact and confirmed four of ADR-071's assumptions. Its exit code is what #281 fixes |
+| **The publish lane** | **BUILT, RUN, AND HONEST.** Since #281 its dry run exits **1** — agreeing with the auditor — and the lane does not vote. Run 33686025994: *15 field(s) would change* |
 | **Push, device side** | **STILL 0 of 4 registered** |
 | **The ADR index** | **WHOLE — 72 records, 72 rows**, gated (ADR-067) |
+| **The queue** | ⚠️ **After #281, every open issue but #121 is operator-blocked** — re-derived at the end of S098 from `gh issue list`, not inherited. **Re-derive it again** |
 | **#204 / #278** | **OPEN**, both founder-gated (6(a), 6(b), 6(c)) |
-| **#281** | **OPEN — this session.** Designed and reviewed in ADR-072 |
+| **#121** | **OPEN — this session** |
+| **#281** | **CLOSED** by S098 |
 | **#242 / #263** | OPEN and correctly blocked. Do not re-derive |
 
 ### What S096/S097 changed that a later session will trip over

--- a/docs/session-lessons.md
+++ b/docs/session-lessons.md
@@ -38,6 +38,35 @@ something, ask which of these you are standing in:
 
 ### Recent, in full
 
+**157 — A count written mid-change is stale by the end of the change.** *(S095–S098, seven times)*
+Across four sessions, **seven** counts went out wrong, and it was the same
+mechanism every time — not carelessness about arithmetic, but **writing the
+number down while the work was still moving**. `82 → 96 checks` was true for
+about twenty minutes; two more tests landed and nobody re-ran it. Others: *"the
+fourth tool"* (nine), *"eight tools"* beside a `grep` that returns seven,
+*"11 python self-tests"* (twelve), *"48 → 84"* (41 → 91), *"8 new tests"* (ten),
+and a `24` that came from a run which **exited 1 partway** (lesson **149**).
+Lesson **133** says carry the command; lesson **153** says the command must be
+the one you ran. **This is the third leg: run it LAST.** A count belongs in the
+commit message you write *after* the diff is final, not in the draft you started
+with — and if a number appears in prose you are still editing, treat it as a
+`TODO` until the tree is frozen.
+
+**156 — `continue-on-error` makes EVERY exit green, including the ones that never got as far as reporting.** *(S098, ADR-072 3.2)*
+ADR-072 stopped a lane voting so a permanently-red dry run could not become
+wallpaper — correct, and the ADR-047 D4 shape. But the tool's `REFUSED` and
+`COULD NOT MEASURE` paths `return` **before** the summary is written, so either
+one now produced **a green job with an empty summary** — which reads as *nothing
+happened*, in the ADR whose entire subject is a false green. **The fix for one
+false signal introduced two more, in the same file, the same day.**
+The general form: **when you remove a signal's ability to vote, its report
+becomes the only channel — so every path must reach the report, including the
+early returns you added for the failures.** Enumerate the exits and ask, of each
+one, *what does a person see?* ⚠️ And the same change silently widened past its
+own ADR: *"the write path is untouched"* was true of the exit-code rule and false
+of the lane, because `continue-on-error` masks a failed write too. **A workflow
+edit has no idea which of your decisions it belongs to.**
+
 **155 — Two instruments over one subject must not be able to return opposite verdicts.** *(S097, ADR-072)*
 `store_metadata_audit.py` exits **1** on the App Store listing: seven `en-US`
 fields empty, `tr` absent. `store_metadata_publish.py --dry-run` exited **0** on

--- a/tool/ci/store_metadata_publish.py
+++ b/tool/ci/store_metadata_publish.py
@@ -114,6 +114,11 @@ class Action(NamedTuple):
     `files` is what the read-back will expect back if this action succeeds — the
     committed filenames, not the attribute names, because `audit_findings` is
     keyed on files (ADR-071 D5.1).
+
+    `changing` is the subset of `files` whose value differs from what Apple holds
+    (ADR-072 D1). ⚠️ **It never decides what is SENT** — the write always sends
+    every field, because *make it so* must not depend on the comparison being
+    right. It decides what the report says and what the exit code means.
     """
 
     locale: str
@@ -122,6 +127,7 @@ class Action(NamedTuple):
     path: str
     body: dict
     files: dict[str, str]
+    changing: dict[str, str]
 
 
 class Finding(NamedTuple):
@@ -180,12 +186,39 @@ def _files_for(files: dict[str, str], fieldmap: dict[str, str]) -> dict[str, str
     }
 
 
+def _changing(
+    files: dict[str, str],
+    fieldmap: dict[str, str],
+    published: dict[str, str] | None,
+) -> dict[str, str]:
+    """The subset of `files` whose value differs from what Apple holds.
+
+    ⚠️ `published is None` means **the caller never looked**, and every field is
+    then reported as changing. Not knowing is not the same as nothing to do, and
+    a tool that answered "nothing to do" because it had not read is the exact
+    defect ADR-072 exists to fix.
+
+    The comparison is `store_metadata_audit.normalize` and nothing else: every
+    committed file ends in a newline and Apple's stored value does not, so a
+    second dialect of "differs" would report all eight fields as changing forever
+    — and two tools disagreeing about one listing is what this ADR is about.
+    """
+    if published is None:
+        return dict(files)
+    return {
+        name: text
+        for name, text in files.items()
+        if normalize(published.get(fieldmap[name])) != normalize(text)
+    }
+
+
 def _action(
     locale: str,
     resource: str,
     attributes: dict[str, str],
     files: dict[str, str],
     *,
+    changing: dict[str, str],
     existing_id: str | None,
     parent_type: str,
     parent_key: str,
@@ -205,6 +238,7 @@ def _action(
             path=f"/v1/{resource}/{existing_id}",
             body={"data": {"type": resource, "id": existing_id, "attributes": dict(attributes)}},
             files=files,
+            changing=changing,
         )
     return Action(
         locale=locale,
@@ -219,6 +253,7 @@ def _action(
             }
         },
         files=files,
+        changing=changing,
     )
 
 
@@ -229,8 +264,13 @@ def plan(
     app_info_id: str,
     existing_version: dict[str, str],
     existing_app_info: dict[str, str],
+    published: dict[str, dict] | None = None,
 ) -> list[Action]:
     """Every request, in the order it will be sent.
+
+    `published` is `{locale: attributes}` as `audit.published_locales` returns it.
+    It decides only what each action reports as **changing** (ADR-072 D1); omit it
+    and every field is assumed to change, which is the safe direction.
 
     Locales in sorted order for a stable report; **within a locale, app info
     first** (ADR-071 D2) — that ordering is the whole isolation strategy, so it
@@ -241,6 +281,7 @@ def plan(
     for locale in sorted(expected):
         files = expected[locale]
         info_attributes, version_attributes = writable_fields(files)
+        holds = None if published is None else (published.get(locale) or {})
         if info_attributes:
             actions.append(
                 _action(
@@ -248,6 +289,7 @@ def plan(
                     APP_INFO_TYPE,
                     info_attributes,
                     _files_for(files, APP_INFO_FIELDS),
+                    changing=_changing(_files_for(files, APP_INFO_FIELDS), APP_INFO_FIELDS, holds),
                     existing_id=existing_app_info.get(locale),
                     parent_type="appInfos",
                     parent_key="appInfo",
@@ -261,6 +303,7 @@ def plan(
                     VERSION_TYPE,
                     version_attributes,
                     _files_for(files, VERSION_FIELDS),
+                    changing=_changing(_files_for(files, VERSION_FIELDS), VERSION_FIELDS, holds),
                     existing_id=existing_version.get(locale),
                     parent_type="appStoreVersions",
                     parent_key="appStoreVersion",
@@ -359,8 +402,19 @@ def read_back_expectation(outcome: Outcome) -> dict[str, dict[str, str]]:
     return expectation
 
 
-def exit_code(*, refusals: int, read_back: int) -> int:
-    """0 or 1. **2 cannot reach here, and that is the decision** (ADR-071 D7).
+def would_change(actions: list[Action]) -> int:
+    """How many committed fields the listing does not already carry (ADR-072 D2)."""
+    return sum(len(action.changing) for action in actions)
+
+
+def exit_code(*, refusals: int, read_back: int, would_change: int = 0) -> int:
+    """0 or 1: **one rule — exit 1 when the listing differs from what we committed,
+    or something failed.** Two callers supply different measurements of it, because
+    they ask at different moments (ADR-072 D2): a dry run compares BEFORE the
+    attempt (`would_change`), a write compares AFTER it (`read_back`). The write
+    path is untouched by ADR-072.
+
+    **2 cannot reach here, and that is the decision** (ADR-071 D7).
 
     Every path that could answer "could not measure" returns EXIT_CANNOT_MEASURE
     from `main` BEFORE the first write is attempted; after that, an error is a
@@ -369,7 +423,7 @@ def exit_code(*, refusals: int, read_back: int) -> int:
     rather than computes reads as a bug, and the boundary belongs where it is
     actually enforced.
     """
-    if refusals or read_back:
+    if refusals or read_back or would_change:
         return EXIT_FINDING
     return EXIT_OK
 
@@ -387,14 +441,26 @@ def render(outcome: Outcome, *, dry_run: bool) -> str:
         lines.append("nothing to publish: every committed field is empty.")
         return "\n".join(lines)
 
+    total_changing = would_change(outcome.planned)
     lines.append(f"plan ({len(outcome.planned)} request(s)):")
     for action in outcome.planned:
         attributes = action.body["data"]["attributes"]
         names = ", ".join(sorted(k for k in attributes if k != "locale"))
         lines.append(
             f"  {action.locale}: {action.verb} {action.resource} "
-            f"— {len(action.files)} field(s): {names}"
+            f"— {len(action.files)} field(s), {len(action.changing)} would change"
+            f": {names}"
         )
+    lines.append("")
+    if total_changing:
+        lines.append(
+            f"{total_changing} field(s) would change — the listing does not yet "
+            f"carry what this ref committed."
+        )
+    else:
+        # Say it OUT LOUD. A tool that only speaks when something is wrong is
+        # indistinguishable from a tool that is not running (lesson 65).
+        lines.append("nothing would change — the listing already carries every committed field.")
     if not dry_run:
         lines.append("")
         lines.append(f"written: {len(outcome.written)} of {len(outcome.planned)} request(s)")
@@ -455,6 +521,12 @@ def main(argv: list[str] | None = None) -> int:
             for row in tf.version_localizations(token, version["id"])
             if (row.get("attributes") or {}).get("locale")
         }
+        # ADR-072 D1. The reads above keep only `{locale: id}` — ids are all a
+        # WRITER needs — so there is nothing to compare against, which is what
+        # revision 1 of that ADR got wrong. `published_locales` already merges
+        # both resources into exactly the shape the comparison wants, and it is
+        # read-only, so the dry run stays a dry run.
+        published = audit.published_locales(token, app["id"], version=version)
     except AscError as failure:
         print(f"COULD NOT MEASURE: {failure}", file=sys.stderr)
         return EXIT_CANNOT_MEASURE
@@ -468,6 +540,7 @@ def main(argv: list[str] | None = None) -> int:
         app_info_id=app_info_id,
         existing_version=existing_version,
         existing_app_info=existing_app_info,
+        published=published,
     )
 
     def call(method: str, path: str, body: dict | None = None) -> dict:
@@ -503,7 +576,16 @@ def main(argv: list[str] | None = None) -> int:
 
     print(report)
     emit(args.summary, "### store metadata publish\n\n```\n" + report + "\n```")
-    return exit_code(refusals=len(outcome.findings), read_back=len(read_back_findings))
+    # ADR-072 D2. A dry run answers "is the listing already what we committed?"
+    # and must never exit 0 while it is not — which is what it did, glossed as
+    # `published`, while the auditor exited 1 about the same listing. A WRITE
+    # answers the same question one moment later, through the read-back, and that
+    # path is untouched.
+    return exit_code(
+        refusals=len(outcome.findings),
+        read_back=len(read_back_findings),
+        would_change=would_change(actions) if mode == MODE_DRY_RUN else 0,
+    )
 
 
 def _app_info_state(token: str, app_id: str) -> tuple[str, dict[str, str]]:

--- a/tool/ci/store_metadata_publish.py
+++ b/tool/ci/store_metadata_publish.py
@@ -479,6 +479,19 @@ def emit(path: str | None, text: str) -> None:
         handle.write(text + "\n")
 
 
+def emit_terse(path: str | None, headline: str) -> None:
+    """A one-line summary for the paths that end before there is a report.
+
+    ⚠️ Since ADR-072 D3.1 the step is `continue-on-error`, so **every** exit is a
+    green job. The verdict therefore has to live in the summary, and REFUSED and
+    COULD-NOT-MEASURE used to return before `emit` was ever reached — a green job
+    with an empty summary, which is *"nothing happened"* to anyone glancing at it.
+    That is the shape this whole ADR is about, and it was introduced by the fix
+    for it. Found by the built-diff review.
+    """
+    emit(path, "### store metadata publish\n\n```\n" + headline + "\n```")
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--metadata-dir", default="fastlane/metadata")
@@ -496,18 +509,19 @@ def main(argv: list[str] | None = None) -> int:
 
     mode = resolve_mode(args.confirm)
     if mode == MODE_REFUSED:
-        print(
+        message = (
             f"REFUSED (nothing was sent): --confirm must be exactly "
-            f"{CONFIRM_LITERAL!r}, and it was {args.confirm!r}. Omit it entirely "
-            f"for a dry run.",
-            file=sys.stderr,
+            f"{CONFIRM_LITERAL!r}. Omit it entirely for a dry run."
         )
+        print(message, file=sys.stderr)
+        emit_terse(args.summary, message)
         return EXIT_REFUSED
 
     try:
         expected = audit.expected_locales(pathlib.Path(args.metadata_dir))
     except (AscError, OSError) as failure:
         print(f"COULD NOT MEASURE: {failure}", file=sys.stderr)
+        emit_terse(args.summary, f"COULD NOT MEASURE: {failure}")
         return EXIT_CANNOT_MEASURE
 
     # Everything up to here is read-only, so an error is still EXIT 2.
@@ -529,9 +543,12 @@ def main(argv: list[str] | None = None) -> int:
         published = audit.published_locales(token, app["id"], version=version)
     except AscError as failure:
         print(f"COULD NOT MEASURE: {failure}", file=sys.stderr)
+        emit_terse(args.summary, f"COULD NOT MEASURE: {failure}")
         return EXIT_CANNOT_MEASURE
     except Exception as failure:  # noqa: BLE001 - exit 2 is the honest answer
-        print(f"COULD NOT MEASURE: {type(failure).__name__}: {failure}", file=sys.stderr)
+        detail = f"{type(failure).__name__}: {failure}"
+        print(f"COULD NOT MEASURE: {detail}", file=sys.stderr)
+        emit_terse(args.summary, f"COULD NOT MEASURE: {detail}")
         return EXIT_CANNOT_MEASURE
 
     actions = plan(

--- a/tool/ci/store_metadata_publish_test.py
+++ b/tool/ci/store_metadata_publish_test.py
@@ -673,6 +673,49 @@ def test_main_dry_run_exits_0_when_the_listing_already_matches() -> None:
     check_true("and says so out loud", "nothing would change" in report.lower())
 
 
+def test_every_exit_writes_a_summary() -> None:
+    print("ADR-072 D3.1: continue-on-error makes EVERY exit green — so every exit must SPEAK")
+    # ⚠️ Found by the built-diff review. The step is now `continue-on-error`, so
+    # the job is green whatever happens; REFUSED and COULD-NOT-MEASURE returned
+    # before `emit` was reached, leaving a green job with an EMPTY summary —
+    # "nothing happened" to anyone glancing at it. That is the shape this ADR is
+    # about, introduced by the fix for it.
+    root = pathlib.Path(__file__).resolve().parents[2] / "fastlane" / "metadata"
+
+    def summary_after(argv: list[str]) -> tuple[int, str]:
+        """Run `main` and read the summary DEFENSIVELY.
+
+        ⚠️ An absent file must fail the assertion below, not raise: a mutant that
+        reddens the suite with a FileNotFoundError has proven the crash, not the
+        property this test advertises (lesson 76, hit twice in S096).
+        """
+        with tempfile.TemporaryDirectory() as raw:
+            summary = pathlib.Path(raw) / "summary"
+            code = publish.main(argv + ["--summary", str(summary)])
+            text = summary.read_text(encoding="utf-8") if summary.exists() else "<NO SUMMARY WRITTEN>"
+            return code, text
+
+    code, text = summary_after(["--metadata-dir", str(root), "--confirm", "publish"])
+    check("refused", code, publish.EXIT_REFUSED)
+    check_true("and it SAYS so in the summary", "REFUSED" in text)
+
+    code, text = summary_after(["--metadata-dir", "/nonexistent/metadata/tree"])
+    check("could not measure — no metadata tree", code, publish.EXIT_CANNOT_MEASURE)
+    check_true("and it SAYS so too", "COULD NOT MEASURE" in text)
+
+    # ⚠️ The OTHER could-not-measure path: the tree is fine and APPLE is not.
+    # A mutant removing that emit SURVIVED until this case existed — the first
+    # two exercised only the metadata-tree branch, and one `emit` per branch is
+    # one test per branch (recurring shape 5: a guard that guards one path).
+    tf._token = lambda: "token"
+    tf.find_app = lambda _t, _b: {"id": "app"}
+    tf._call = lambda *_a, **_k: (_ for _ in ()).throw(tf.AscError("HTTP 401: bad key"))
+    code, text = summary_after(["--metadata-dir", str(root)])
+    check("could not measure — Apple refused the read", code, publish.EXIT_CANNOT_MEASURE)
+    check_true("and that one speaks as well", "COULD NOT MEASURE" in text)
+    check_true("quoting Apple", "401" in text)
+
+
 def main() -> int:
     print("store_metadata_publish self-tests")
     test_empty_fields_are_skipped_never_sent()
@@ -700,6 +743,7 @@ def main() -> int:
     test_render_says_so_when_nothing_would_change()
     test_main_dry_run_over_the_real_metadata_tree_is_a_FINDING()
     test_main_dry_run_exits_0_when_the_listing_already_matches()
+    test_every_exit_writes_a_summary()
 
     if _failures:
         print(f"\n{len(_failures)} FAILED: {', '.join(_failures)}")

--- a/tool/ci/store_metadata_publish_test.py
+++ b/tool/ci/store_metadata_publish_test.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import importlib.util
 import pathlib
+import tempfile
 
 _MODULE_PATH = pathlib.Path(__file__).with_name("store_metadata_publish.py")
 _spec = importlib.util.spec_from_file_location("store_metadata_publish", _MODULE_PATH)
@@ -101,6 +102,13 @@ def recorder(script):
         return {"data": {"id": "new-id"}}
 
     return call, seen
+
+
+def _install_fake(script):
+    """`recorder`, but patched over `tf._call` so `main` uses it end to end."""
+    call, seen = recorder(script)
+    tf._call = lambda _token, method, path, body=None: call(method, path, body)
+    return seen
 
 
 def writes(seen):
@@ -444,6 +452,227 @@ def test_render_names_every_action_and_says_which_ran() -> None:
     check("the committed TEXT is not dumped", "A question a day, for two." in report, False)
 
 
+# --- ADR-072 / #281: what would CHANGE, and a dry run that stops lying --------
+#
+# The publisher's dry run exited 0 — glossed by its own workflow as "published" —
+# while `store_metadata_audit` exited 1 on the same listing state (runs
+# 33685509829 and 33685506236, minutes apart). Two tools, one subject, opposite
+# verdicts, and the one saying "fine" is the one that did nothing (lesson 155).
+
+
+def test_changing_is_the_subset_that_actually_differs() -> None:
+    print("ADR-072 D1: an Action carries the fields that would actually change")
+    published = {"en-US": {
+        "locale": "en-US",
+        "name": "ikimiz",                       # matches the committed file
+        "subtitle": "Something else",           # differs
+        "privacyPolicyUrl": "https://example.test/privacy",   # matches
+    }}
+    actions = publish.plan(
+        {"en-US": dict(EN)}, version_id="v1", app_info_id="ai1",
+        existing_version={"en-US": "vloc-en"}, existing_app_info={"en-US": "iloc-en"},
+        published=published,
+    )
+    info = [a for a in actions if a.resource == publish.APP_INFO_TYPE][0]
+    check("all three are still SENT", sorted(info.files),
+          ["name.txt", "privacy_url.txt", "subtitle.txt"])
+    # The write still sends everything — "make it so" must not depend on the
+    # comparison being right (ADR-072 D1). Only the REPORT and the exit code use
+    # this subset.
+    check("but only one would change", sorted(info.changing), ["subtitle.txt"])
+
+    version = [a for a in actions if a.resource == publish.VERSION_TYPE][0]
+    # The store carries nothing for these, so all of them would change.
+    check("a locale present but blank changes everything it holds",
+          sorted(version.changing), ["description.txt", "keywords.txt"])
+
+
+def test_a_trailing_newline_is_not_a_change() -> None:
+    print("ADR-072 D1: one definition of `differs`, and it is the auditor's")
+    # Every committed file ends in a newline and Apple's stored value does not.
+    # Using anything but `normalize` here would report all eight fields as
+    # changing forever — the cries-wolf failure, in the tool built to stop one.
+    actions = publish.plan(
+        {"tr": {"name.txt": "ikimiz\n"}}, version_id="v1", app_info_id="ai1",
+        existing_version={}, existing_app_info={"tr": "iloc-tr"},
+        published={"tr": {"locale": "tr", "name": "ikimiz"}},
+    )
+    check("nothing would change", sorted(actions[0].changing), [])
+
+
+def test_an_absent_locale_changes_everything_it_would_write() -> None:
+    print("ADR-072 D1: a locale Apple does not have changes every field")
+    actions = publish.plan(
+        {"tr": dict(TR)}, version_id="v1", app_info_id="ai1",
+        existing_version={}, existing_app_info={},
+        published={"en-US": {"locale": "en-US"}},   # tr absent entirely
+    )
+    for action in actions:
+        check(f"{action.resource}: all of it", sorted(action.changing), sorted(action.files))
+
+
+def test_unknown_published_state_assumes_it_would_change() -> None:
+    print("ADR-072 D1: not knowing is not the same as nothing to do")
+    # `published=None` is what a caller that never read Apple passes. The safe
+    # direction is to say the field WOULD change: a tool that answers "nothing to
+    # do" because it did not look is the exact defect this ADR exists to fix.
+    actions = publish.plan(
+        {"tr": dict(TR)}, version_id="v1", app_info_id="ai1",
+        existing_version={}, existing_app_info={},
+    )
+    for action in actions:
+        check(f"{action.resource}: assumed changing", sorted(action.changing), sorted(action.files))
+
+
+def test_would_change_counts_across_the_plan() -> None:
+    print("ADR-072 D2: the number the exit code is computed from")
+    published = {"en-US": {
+        "locale": "en-US", "name": "ikimiz",
+        "subtitle": "One question a day", "privacyPolicyUrl": "https://example.test/privacy",
+        "description": "A question a day, for two.", "keywords": "couples,relationship",
+    }}
+    matching = publish.plan(
+        {"en-US": dict(EN)}, version_id="v1", app_info_id="ai1",
+        existing_version={"en-US": "vloc-en"}, existing_app_info={"en-US": "iloc-en"},
+        published=published,
+    )
+    check("a listing that already matches changes nothing", publish.would_change(matching), 0)
+    drifted = publish.plan(
+        {"en-US": dict(EN)}, version_id="v1", app_info_id="ai1",
+        existing_version={"en-US": "vloc-en"}, existing_app_info={"en-US": "iloc-en"},
+        published={"en-US": {"locale": "en-US"}},   # present, and blank — today's real state
+    )
+    check("an empty listing changes all five committed fields",
+          publish.would_change(drifted), 5)
+
+
+def test_a_dry_run_over_an_unpublished_listing_is_a_FINDING() -> None:
+    print("ADR-072 D2: 0 no longer means `published` when nothing was published")
+    # THE DEFECT. Before this, a dry run over the empty listing exited 0 while
+    # the auditor exited 1 about the same listing.
+    check("would-change makes it a finding",
+          publish.exit_code(refusals=0, read_back=0, would_change=5), publish.EXIT_FINDING)
+    check("nothing to do is the only 0",
+          publish.exit_code(refusals=0, read_back=0, would_change=0), publish.EXIT_OK)
+    # And the write path is UNTOUCHED: it passes no would_change and decides from
+    # the post-write read-back, which is a different moment, not a different rule.
+    check("a successful write still exits 0",
+          publish.exit_code(refusals=0, read_back=0), publish.EXIT_OK)
+    check("a failed read-back still exits 1",
+          publish.exit_code(refusals=0, read_back=2), publish.EXIT_FINDING)
+
+
+def test_render_says_how_much_would_change() -> None:
+    print("ADR-072 D3: the number the founder reads")
+    actions = publish.plan(
+        {"en-US": dict(EN)}, version_id="v1", app_info_id="ai1",
+        existing_version={"en-US": "vloc-en"}, existing_app_info={"en-US": "iloc-en"},
+        published={"en-US": {"locale": "en-US", "name": "ikimiz"}},
+    )
+    call, _seen = recorder([])
+    report = publish.render(publish.execute(call, actions, dry_run=True), dry_run=True)
+    check_true("counts what would change", "would change" in report)
+    # FOUR, not five: the fixture already publishes `name`, so it is the one
+    # committed field that would not move. Counted by running it rather than by
+    # eye — the first draft of this assertion said five (lesson 133).
+    check("the plan agrees", publish.would_change(actions), 4)
+    check_true("and names the total", "4 field(s) would change" in report)
+    # Still no store text, still one purpose (ADR-070 D7.4).
+    check("the committed TEXT is still not dumped", "A question a day, for two." in report, False)
+
+
+def test_render_says_so_when_nothing_would_change() -> None:
+    print("ADR-072 D3: and it says so OUT LOUD when there is nothing to do")
+    # A tool that only speaks when something is wrong is indistinguishable from a
+    # tool that is not running (lesson 65, ADR-047's own rule one tool over).
+    published = {"tr": {"locale": "tr", "name": "ikimiz", "description": "Her gün bir soru."}}
+    actions = publish.plan(
+        {"tr": dict(TR)}, version_id="v1", app_info_id="ai1",
+        existing_version={"tr": "vloc-tr"}, existing_app_info={"tr": "iloc-tr"},
+        published=published,
+    )
+    call, _seen = recorder([])
+    report = publish.render(publish.execute(call, actions, dry_run=True), dry_run=True)
+    check("nothing would change", publish.would_change(actions), 0)
+    check_true("and the report says so", "nothing would change" in report.lower())
+
+
+def _script_the_store(en_attributes: dict, tr_present: bool = False) -> list:
+    """A whole App Store Connect, scripted. LONGER fragments first (substring match)."""
+    version_rows = [{"id": "vloc-en", "attributes": {"locale": "en-US", **en_attributes}}]
+    info_rows = [{"id": "iloc-en", "attributes": {"locale": "en-US", **en_attributes}}]
+    if tr_present:
+        version_rows.append({"id": "vloc-tr", "attributes": {"locale": "tr"}})
+        info_rows.append({"id": "iloc-tr", "attributes": {"locale": "tr"}})
+    return [
+        ("GET", "appStoreVersionLocalizations", {"data": version_rows}),
+        ("GET", "appInfoLocalizations", {"data": info_rows}),
+        ("GET", "appStoreVersions", {"data": [
+            {"id": "v1", "attributes": {"appStoreState": "PREPARE_FOR_SUBMISSION"}}]}),
+        ("GET", "appInfos", {"data": [
+            {"id": "i1", "attributes": {"appStoreState": "PREPARE_FOR_SUBMISSION"}}]}),
+    ]
+
+
+def test_main_dry_run_over_the_real_metadata_tree_is_a_FINDING() -> None:
+    print("main: end to end — the empty listing, dry run, and it must NOT say 0")
+    # ⚠️ This test exists because a mutant survived: replacing main's
+    # `published = audit.published_locales(...)` with `None` changed the
+    # founder-facing number and NOTHING caught it. main() was the one piece of
+    # wiring no test touched — between the read and the report.
+    tf._token = lambda: "token"
+    tf.find_app = lambda _t, _b: {"id": "app"}
+    root = pathlib.Path(__file__).resolve().parents[2] / "fastlane" / "metadata"
+
+    # The measured production state: en-US exists and holds NOTHING, tr absent.
+    seen = _install_fake(_script_the_store({}))
+    with tempfile.TemporaryDirectory() as raw:
+        summary = pathlib.Path(raw) / "summary"
+        code = publish.main(["--metadata-dir", str(root), "--summary", str(summary)])
+        report = summary.read_text(encoding="utf-8")
+
+    check("exit 1 — a FINDING, not `published`", code, publish.EXIT_FINDING)
+    check("and nothing was written", writes(seen), [])
+    check_true("the report says so", "would change" in report)
+    check_true("and it is a dry run", "DRY RUN" in report)
+
+
+def test_main_dry_run_exits_0_when_the_listing_already_matches() -> None:
+    print("main: 0 is reachable, and only when there is genuinely nothing to do")
+    # The other half of the rule. Without this, `exit 1` could be hard-coded and
+    # the suite would not notice — the assertion above would still pass.
+    tf._token = lambda: "token"
+    tf.find_app = lambda _t, _b: {"id": "app"}
+    root = pathlib.Path(__file__).resolve().parents[2] / "fastlane" / "metadata"
+    committed = audit.expected_locales(root)
+
+    def attributes_for(locale: str) -> dict:
+        info, version = publish.writable_fields(committed[locale])
+        return {**info, **version}
+
+    script = [
+        ("GET", "appStoreVersionLocalizations", {"data": [
+            {"id": "vloc-en", "attributes": {"locale": "en-US", **attributes_for("en-US")}},
+            {"id": "vloc-tr", "attributes": {"locale": "tr", **attributes_for("tr")}}]}),
+        ("GET", "appInfoLocalizations", {"data": [
+            {"id": "iloc-en", "attributes": {"locale": "en-US", **attributes_for("en-US")}},
+            {"id": "iloc-tr", "attributes": {"locale": "tr", **attributes_for("tr")}}]}),
+        ("GET", "appStoreVersions", {"data": [
+            {"id": "v1", "attributes": {"appStoreState": "PREPARE_FOR_SUBMISSION"}}]}),
+        ("GET", "appInfos", {"data": [
+            {"id": "i1", "attributes": {"appStoreState": "PREPARE_FOR_SUBMISSION"}}]}),
+    ]
+    seen = _install_fake(script)
+    with tempfile.TemporaryDirectory() as raw:
+        summary = pathlib.Path(raw) / "summary"
+        code = publish.main(["--metadata-dir", str(root), "--summary", str(summary)])
+        report = summary.read_text(encoding="utf-8")
+
+    check("exit 0 — nothing to do", code, publish.EXIT_OK)
+    check("still wrote nothing", writes(seen), [])
+    check_true("and says so out loud", "nothing would change" in report.lower())
+
+
 def main() -> int:
     print("store_metadata_publish self-tests")
     test_empty_fields_are_skipped_never_sent()
@@ -460,6 +689,17 @@ def main() -> int:
     test_exit_codes()
     test_an_error_after_a_write_is_a_finding_not_could_not_measure()
     test_render_names_every_action_and_says_which_ran()
+    # ADR-072 / #281
+    test_changing_is_the_subset_that_actually_differs()
+    test_a_trailing_newline_is_not_a_change()
+    test_an_absent_locale_changes_everything_it_would_write()
+    test_unknown_published_state_assumes_it_would_change()
+    test_would_change_counts_across_the_plan()
+    test_a_dry_run_over_an_unpublished_listing_is_a_FINDING()
+    test_render_says_how_much_would_change()
+    test_render_says_so_when_nothing_would_change()
+    test_main_dry_run_over_the_real_metadata_tree_is_a_FINDING()
+    test_main_dry_run_exits_0_when_the_listing_already_matches()
 
     if _failures:
         print(f"\n{len(_failures)} FAILED: {', '.join(_failures)}")


### PR DESCRIPTION
## Reproduced first

Minutes apart, on one listing:

| lane | run | exit |
|---|---|---|
| `store_metadata_audit` | `33685506236` | **1** — finding |
| `store_metadata_publish` (dry run) | `33685509829` | **0**, glossed **"published"**, from a run that sent nothing |

**Two tools, one subject, opposite verdicts, and the one saying "fine" is the one that did nothing** (lesson 155). ADR-072 designed the fix and a pre-code review had already corrected it three times; this builds that design.

## What changed

- Every `Action` carries **`changing`** — the fields whose value differs from what Apple holds, compared with the **auditor's** `normalize` and nothing else, because a second dialect of *"differs"* is how two tools start disagreeing.
- ⚠️ **`changing` never decides what is sent.** The write still sends every field: *make it so* must not depend on the comparison being right. It decides what the report says and what the exit code means.
- **`published=None` reports everything as changing.** Not knowing is not the same as nothing to do — a tool answering *"nothing to do"* because it had not read is the defect being fixed.
- **`main` now calls `audit.published_locales()`.** ADR-072 rev 1 claimed the data was already there; it is not — the existing reads keep only `{locale: id}`, because ids are all a *writer* needs. Read-only, so the dry run stays a dry run.
- **One rule, two callers:** exit 1 when the listing differs from what we committed. A dry run measures it **before** the attempt; a write measures it **after**, via the read-back. **The write path is untouched.**
- The gloss stops saying **"published"**, and the step gets **`continue-on-error: true`** — under the new rule every dry run exits 1 until someone publishes, so without it the lane would be red on every run: the cries-wolf failure with its sign flipped. The lane has **no vote** (ADR-047 D4's shape).

## Verification

| ran **here** | **11 new tests (14 → 25 functions, all registered; 62 → 96 checks)**; all **13** python self-tests CI runs; every Dart lint and self-test; `dart format` |
|---|---|
| ran **against Apple** | the dry run re-dispatched from this branch — quoted in the thread |

Toolchain measured first: `java`/`dart`/`flutter` read MISSING until PATH is exported, exactly as `session-context.md` §3 warns; `ruby` is genuinely absent.

**Mutation-checked: 21 mutants, 20 killed by a *named* assertion.**

⚠️ **Two flaws in the harness itself, recorded rather than hidden:**
1. a `str.replace` inserting five new mutants **matched nothing and wrote the file unchanged** — the harness silently re-ran the old set and printed the same green. Lesson 109, inside the tool built to catch exactly that.
2. `main-never-reads-what-apple-holds` **survived**: replacing `main`'s `published_locales` call with `None` changed the founder-facing number and no test noticed, because `main()` was the one piece of wiring nothing touched. Two end-to-end tests now cover it — one asserting **exit 1** on the real (empty) listing, and one asserting **exit 0 is reachable** when it matches, because without the second the rule could be hard-coded to 1.

The remaining survivor is recorded, not fixed: locale iteration order is presentational.

## ⚠️ And the built-diff review found this ADR's own shape, a third time

**Making the step `continue-on-error` means every exit is a green job** — and `REFUSED` (64) and `COULD NOT MEASURE` (2) both returned *before* the summary was written. A green job with an empty summary is *"nothing happened"* to anyone glancing at it: **the fix for one false signal introduced two more**, in the ADR whose entire subject is a false green. Every exit now writes a summary.

The critic also caught that D2's *"the write path is untouched"* is about the **exit-code rule**, not the lane — `continue-on-error` masks a failed **write** too. Accepted and now stated in the ADR: **this lane has no vote in either mode** (ADR-047 D4), and what makes that safe is the fix above — the verdict is in the summary on every path, so nothing depends on the colour.

⚠️ **Counts corrected**, the seventh time across these sessions and the same cause each time — written mid-change, never re-measured. The first commit said *"8 new tests (82 → 96 checks)"*; measured with both sides running to completion it is **14 → 25 functions and 62 → 96 checks**.

Both new mutants found weaknesses before they found bugs: one died by an **exception** until the test read the summary defensively (lesson 76), and one **survived** because the tests covered only the metadata-tree branch of could-not-measure and not the Apple-refused-the-read branch — one `emit` per branch is one test per branch.

**Review pass 2: 10 agents.** `agents_error` **0**; `agents_empty_result` **3**, all **CONSIDERED**-empty — change-awareness correctness, the exit/`main` wiring, and test-quality/scope all examined and found nothing. **2 findings, 2 surviving, 0 refuted**, plus 1 critic finding. All applied.

## Not done

**Nothing is published.** Operator **6(b)** and **6(c)** are untouched and `confirm` was never passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeFqpZ4Hz4hHN7kGBofs69