### PR TITLE
docs(operator): the 12-day outage closes — billing restored, the webhook proven in one curl, and the file rewritten to open items only

### DIFF
--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -16,8 +16,8 @@
 |---|---|
 | Completion | **~58%** of the iOS MVP, to public launch |
 | Production Readiness | **Integration Ready** |
-| Production | 🔴 **DOWN for 12 days** (since 2026-08-22) — a new billing account is now linked but reads `open: false`; **an open one exists**, see item 1 |
-| Open operator items | **10** — item 2's IAM half and item 10 are done; the rest stand |
+| Production | 🟡 **Billing RESTORED 2026-09-03 ~22:05 UTC** after 12 days down. The webhook answers again; the first successful daily sweep is still pending — item 1 |
+| Open operator items | **items 1, 2 and 10 are DONE**; 3–9 stand |
 
 **Completion — ~58%.** Engineering (M0–M6.3) is **~95%** — every milestone closed,
 the code builds, signs and passes its gates. The question bank is **2.1%** — 21 of
@@ -40,204 +40,99 @@ checks measuring instead of skipping.
 
 Ordered by how much each unblocks. Every line below was verified on 2026-09-03.
 
-### 1. 🔴 Restore billing — 12 days down, and one link away
+### 1. ✅ Billing is RESTORED — waiting on the first successful sweep
 
-⚠️ **State as of 2026-09-03, measured against the Cloud Billing API directly —
-not inferred.** A new billing account has been attached to `hayatiapp-prod`, and
-it is **not working yet**:
+**Done 2026-09-03 ~22:05 UTC.** Account `01D7C5-DBC2D5-E53938` (the one already
+linked to `hayatiapp-prod`) was **activated** — the payment instrument is on
+someone else's identity, which is why our token could not see it open earlier.
+Both conditions now hold, which is the pair ADR-066 exists to keep apart:
 
 ```
-projects/hayatiapp-prod/billingInfo
-  billingAccountName : billingAccounts/01D7C5-DBC2D5-E53938
-  billingEnabled     : true          <-- means LINKED, not PAYING (ADR-066)
-
-billingAccounts/01D7C5-DBC2D5-E53938
-  open : false                       <-- this is the field that decides
+projects/hayatiapp-prod/billingInfo   billingEnabled : true    (LINKED)
+billingAccounts/01D7C5-DBC2D5-E53938  open           : true    (PAYING)
 ```
 
-**And there is an OPEN account already on the same identity.** All four visible:
+**What came back with it**, measured rather than assumed:
 
-| account | open | name |
+| | before | now |
 |---|---|---|
-| `012195-7EF76F-3A9083` | **false** | Firebase Payment — the original |
-| **`0197C1-36BA04-63DDFB`** | ✅ **true** | Firebase Payment |
-| `01D7C5-DBC2D5-E53938` | **false** | Firebase Payment — *currently linked to prod* |
-| `01D923-0AD9FC-3FF4C5` | **false** | My Billing Account |
+| Cloud Scheduler API | HTTP 403 — the API was off with billing | **readable**; job **ENABLED** |
+| `revenueCatWebhook` | HTML 500 *"billing is disabled"* | **the function's own JSON** — see item 2 |
 
-**So the remaining step is not "pay" — it is "link prod to the account that is
-already open".**
+⚠️ **Not finished yet, and the remaining line is honest:** no
+`question_rollover: sweep complete` record exists, because the **22:00 UTC sweep
+attempted and failed** (gRPC 13) — billing was restored a few minutes *after* it
+ran. `prod_pulse` still exits **1**, correctly: it is keyed on the sweep's own
+record, so a punctual scheduler over a backend that was dead at the time reads
+red (ADR-063).
 
-> <https://console.cloud.google.com/billing/linkedaccount?project=hayatiapp-prod>
-> → **Change billing account** → **`0197C1-36BA04-63DDFB`**.
+> **The next hourly sweep is the proof.** Re-run:
+> `python3 tool/ci/prod_pulse.py --project hayatiapp-prod --from-firebase-cli`
+> — **0** means the daily loop is genuinely running.
 
-Then re-measure (below). If the open account is not the one you intend to be
-charged, open `01D7C5-DBC2D5-E53938` in the console instead and find out why it
-is closed — a new account stays closed until its payment method is accepted.
+⚠️ **`hayatiapp-dev` stays unbilled** (your decision). It is still linked to the
+old closed `012195-7EF76F-3A9083` and reports `billingEnabled: false`. The cost is
+that dev Functions cannot be deployed or exercised, so `session-context.md`'s
+*"dev is a session's to exercise"* does not hold while this stands. CI is
+unaffected — the emulator suites run against `demo-hayati`.
 
-**`hayatiapp-dev` is deliberately left unbilled** (founder decision, 2026-09-03):
-it is linked to the old closed account and reports `billingEnabled: false`. Cost
-is the reason, and the cost of *that* is that dev Functions cannot be deployed or
-exercised — `session-context.md`'s *"dev is a session's to exercise"* does not
-hold while this stands. CI is unaffected: the emulator suites run against
-`demo-hayati`, not this project.
+⚠️ **Item 9 is now the urgent one.** Billing is live and **nothing is watching the
+bill.**
 
-**Blocked by this:** every server function. No daily question is assigned, no
-notification is composed, no purchase can be processed.
+### 2. ✅ The webhook works — only RevenueCat's own dashboard is unverified
 
-#### 1.1 — Why a paid plan is unavoidable
+Three things were needed and all three are now **proven by the function's own
+response**, not inferred:
 
-Not a preference — an architectural consequence. `functions/src/index.ts` exports
-**nine Cloud Functions**, and they are the product:
+```
+$ curl -X POST https://revenuecatwebhook-mzym2uw5gq-ew.a.run.app -d '{}'
+HTTP 401  {"error":"unauthorized"}
+```
 
-| function | what it is |
+That single line settles all of it, because of how the handler is ordered
+(`revenuecat-webhook.ts`): the **503 `unconfigured`** branch is checked
+**before** the token compare, *"so a misconfiguration can never be mistaken for
+an unauthorized caller"*. Getting **401 and not 503**, with no header sent, means:
+
+| | proof |
 |---|---|
-| `createInvite` · `invitePreview` · `joinInvite` | the entire pairing flow |
-| `questionRollover` | the sweep that assigns the daily question |
-| `answerReveal` | the reveal — the app's central moment |
-| `registerPushToken` · `unregisterPushToken` | notifications |
-| `revenueCatWebhook` | purchase → Premium |
-| `coachProxy` | the coach |
+| the container runs | a JSON body came back, not Google's HTML error page — **billing works** |
+| the request reaches it | not a Cloud Run 403 — **the invoker grant works** (granted 2026-09-03, `allUsers` → `roles/run.invoker`) |
+| `RC_WEBHOOK_TOKEN` is set and non-empty | the 503 branch was **not** taken — **the secret is bound and populated** (version 1, revision `revenuecatwebhook-00005-mok`) |
 
-**Cloud Functions do not run on the free (Spark) plan.** That is what item 1 has
-always been about, and it is why every other server item below is downstream.
-ADR-002 chose Firebase over Supabase with vendor lock-in recorded as an accepted
-trade-off; leaving it now would mean rewriting all nine functions, the security
-rules, auth, offline persistence, push and the data model. It is a rebuild, not a
-setting.
+This is `session-context.md` §8's own test — *"JSON = fixed, HTML 403 = broken"* —
+answering **fixed**.
 
-⚠️ **The app does not merely lose features without it — it does not start.** The
-boot initialises Firebase before the first frame; if that fails the app shows
-`BootFailureApp`, a failure screen (ADR-039).
+#### 2.1 — The one thing left: does RevenueCat send the same string?
 
-#### 1.2 — How to get it: two routes
+RevenueCat sends whatever is in its dashboard **verbatim** in the `Authorization`
+header — no `Bearer`, no HMAC (ADR-013 D1). Nothing here can read RevenueCat's
+console, so this is yours:
 
-**Route A — link prod to the account that is already open** (what the
-measurement above says to do; no new signup, no new card):
-
-1. <https://console.cloud.google.com/billing/linkedaccount?project=hayatiapp-prod>
-2. **Change billing account** → **`0197C1-36BA04-63DDFB`** (`open: true`).
-3. ⚠️ **Link `hayatiapp-prod` only.** Dev stays unbilled by decision — above.
-
-**Route B — create a fresh billing account** (if A refuses, e.g. the card or the
-account cannot be recovered):
-
-1. <https://console.cloud.google.com/billing> → **Create account**.
-2. Choose country and add a card. ⚠️ **The currency is fixed when the account is
-   created and cannot be changed afterwards** — pick deliberately.
-3. Link **`hayatiapp-prod` only**:
-   `https://console.cloud.google.com/billing/linkedaccount?project=hayatiapp-prod`
-   Dev stays unbilled by decision.
-
-**Then, on the Firebase side**, make sure `hayatiapp-prod` is on **Blaze**:
-Firebase Console → the project → ⚙ **Project settings** → **Usage and billing** →
-**Details & settings** → **Modify plan** → **Blaze (pay as you go)**.
-
-#### 1.3 — What it should cost, and the one thing to do while you are in there
-
-Blaze is pay-as-you-go and **keeps Spark's free quotas**. With **no live users**
-and production currently serving nothing, the expected bill is negligible. The
-real risk is not the amount — it is that **nobody is watching it**, which is
-exactly **item 9**.
-
-> **Do item 9 in the same sitting.** It takes a minute and it is the difference
-> between finding out in hours and finding out in days.
-
-#### 1.4 — How to confirm it worked
-
-✅ **Item 10 is done — the dev box is logged in, so this now measures for real:**
-
-```sh
-python3 tool/ci/prod_pulse.py --project hayatiapp-prod --from-firebase-cli
-```
-
-`0` = the daily loop is running. Today it exits **1** and names the cause:
-
-```
-FINDING: the linked billing account is CLOSED. The project still reports
-billingEnabled:true — that only means it is LINKED — while Cloud Run refuses
-every invocation with 'billing is disabled for this project'.
-most recent refusal (2026-08-29T01:00:02Z): billing is disabled for this project.
-```
-
-⚠️ **Do not read `billingEnabled: true` as success.** ADR-066 exists because that
-exact field produced a wrong instruction before: it means *linked*, and the
-account's own `open` field is what decides.
-
-### 2. The RevenueCat webhook — Google's side is DONE; RevenueCat's side is unverified
-
-✅ **`allUsers` → `roles/run.invoker` was granted on 2026-09-03** (authorised by
-you, `session-context.md` §7). Read back from the service's own policy:
-
-```
-bindings: [{ role: roles/run.invoker, members: [allUsers] }]
-```
-
-**Proven by the service, not by the API's reply.** The webhook's log message
-changed at exactly that moment:
-
-```
-21:50:23  W  The request was not authenticated. Either allow unauthenticated
-             invocations or set the proper Authorization header.        <- IAM refusing
-22:01:48  E  The request failed because billing is disabled for this project.
-```
-
-So the endpoint is reachable now and **billing is the only thing left in front of
-it** — Google's own words, not our inference. The old `gcloud run services
-add-iam-policy-binding` instruction is deleted because it is done.
-
-#### 2.1 — ⚠️ The webhook also needs a shared token, and this file had never said so
-
-`revenueCatWebhook` **fail-closes with 503 until `RC_WEBHOOK_TOKEN` is set**
-(ADR-013 D1). It is not an API key: RevenueCat sends whatever string you type into
-its dashboard **verbatim** in the `Authorization` header, and the Function compares
-it constant-time. **You invent the string; it must be identical in two places:**
-
-1. Google **Secret Manager** in `hayatiapp-prod`, as `RC_WEBHOOK_TOKEN`
-   (ADR-048 lists it there alongside `LLM_API_KEY`);
-2. the RevenueCat dashboard's webhook **Authorization** field.
-
-✅ **It already exists, and it is already bound.** Measured 2026-09-03 — and *not*
-through Secret Manager, which still refuses this token with HTTP 403. The deployed
-Cloud Run service's own container config says it, which needs only
-`run.services.get`:
-
-```
-revenuecatwebhook  (revision revenuecatwebhook-00005-mok)
-  SECRET  RC_WEBHOOK_TOKEN -> projects/hayatiapp-prod/secrets/RC_WEBHOOK_TOKEN : 1
-```
-
-So the Function side is **complete**: deployed, secret created, secret bound.
-⚠️ **The one thing left is the other end** — whether the RevenueCat dashboard's
-webhook `Authorization` field holds **the same string** as version 1 of that
-secret. That is in RevenueCat's console, which nothing here can read.
-
-> Read the value: Secret Manager → `RC_WEBHOOK_TOKEN` → version 1 → *View secret
-> value*. (Or, after `gcloud auth login`:
+> **Read the value:** Secret Manager → `RC_WEBHOOK_TOKEN` → version 1 → *View
+> secret value*. (Or, after `gcloud auth login`:
 > `gcloud secrets versions access 1 --secret=RC_WEBHOOK_TOKEN --project=hayatiapp-prod`.)
 >
-> Then RevenueCat → your project → **Integrations → Webhooks**:
+> **RevenueCat** → your project → **Integrations → Webhooks**:
 > URL `https://revenuecatwebhook-mzym2uw5gq-ew.a.run.app`,
-> **Authorization** = that exact string, sent verbatim with no `Bearer` prefix.
+> **Authorization** = that exact string, no prefix.
+>
+> **Then press RevenueCat's "Send test event".** A 200 there is end-to-end proof.
+> A 401 means the two strings differ.
 
-⚠️ **Public + no token is not a hole.** Until `RC_WEBHOOK_TOKEN` exists the
-Function refuses everyone with 503, so the order of these two steps cannot expose
-anything. It also means the endpoint is now internet-reachable and will burn a
-little quota answering strangers — one more reason to do **item 9**.
-
-**Where RevenueCat's three credentials actually go**, since they are easy to mix up
-and only two of them exist in this repo:
+**Where RevenueCat's three credentials go**, since they are easy to confuse and
+only two exist here:
 
 | credential | shape | where it lives |
 |---|---|---|
-| iOS **publishable** SDK key | `appl_…` | repo **variable** `REVENUECAT_IOS_API_KEY` — ships inside the binary, public by design. **Already set.** |
-| webhook **shared token** | a string you choose | Secret Manager `RC_WEBHOOK_TOKEN` + the same string in the RC dashboard. **Above.** |
-| **v2 secret API key** | `sk_…` | ⚠️ **nothing in this repository reads one.** ADR-013's mirror is webhook-driven and never calls RevenueCat's REST API; #41 lists RC-REST reconciliation as future work. Do not add one until something needs it |
+| iOS **publishable** SDK key | `appl_…` | repo **variable** `REVENUECAT_IOS_API_KEY` — ships in the binary, public by design. **Already set** |
+| webhook **shared token** | a string you choose | Secret Manager `RC_WEBHOOK_TOKEN` **and** the RC dashboard. **Google side done** |
+| **v2 secret API key** | `sk_…` | ⚠️ **nothing in this repository reads one.** ADR-013's mirror is webhook-driven and never calls RevenueCat's REST API; #41 lists RC-REST reconciliation as future work |
 
 ⚠️ **No credential is ever committed** (`architecture.md` §9). Secrets reach CI via
 `gh secret set` and the Function via Secret Manager — never a file in the tree, and
-never a `workflow_dispatch` input, because this repository is **public** and
-dispatch inputs are recorded in run metadata. ⚠️ **A key pasted into a chat, an
-issue or a PR is a burned key — rotate it rather than reusing it.**
+never a `workflow_dispatch` input, because this repository is **public**. **A key
+pasted into a chat, an issue or a PR is a burned key — rotate it.**
 
 ### 3. Four secrets — without them, nothing is watching production
 
@@ -445,8 +340,8 @@ session can fix it.
 
 These block **public launch**:
 
-1. **Nothing runs on the server** — item 1. Every item below is downstream.
-2. **Payments cannot complete** — the invoker grant is done; what remains is `RC_WEBHOOK_TOKEN` (item 2.1), and the serving layer refuses everything until item 1 anyway.
+1. ~~Nothing runs on the server~~ — **billing restored 2026-09-03**; awaiting the first successful sweep (item 1).
+2. **Payments** — Google's side is done and proven; what remains is matching the token in RevenueCat's dashboard (item 2.1).
 3. **Push has never been delivered** — item 4; 0 of 4 devices registered.
 4. **The App Store listing is not submittable** — seven of nine English fields empty at Apple, Turkish absent. Items 6(a) and 6(b).
 5. **Prod-vs-`main` drift is unmeasured**, not passing — both checks skip for one missing secret (item 3).

--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -17,7 +17,7 @@
 | Completion | **~58%** of the iOS MVP, to public launch |
 | Production Readiness | **Integration Ready** |
 | Production | 🔴 **DOWN for 12 days** (since 2026-08-22) — a new billing account is now linked but reads `open: false`; **an open one exists**, see item 1 |
-| Open operator items | **10**, none closed yet |
+| Open operator items | **10** — item 2's IAM half and item 10 are done; the rest stand |
 
 **Completion — ~58%.** Engineering (M0–M6.3) is **~95%** — every milestone closed,
 the code builds, signs and passes its gates. The question bank is **2.1%** — 21 of
@@ -163,19 +163,27 @@ most recent refusal (2026-08-29T01:00:02Z): billing is disabled for this project
 exact field produced a wrong instruction before: it means *linked*, and the
 account's own `open` field is what decides.
 
-### 2. Grant the RevenueCat webhook a public invoker — money is at stake
+### 2. The RevenueCat webhook — the IAM half is DONE; a token is still missing
 
-Verified today: the webhook answers **HTTP 403**, so RevenueCat cannot deliver.
-**A real purchase would charge the customer and never unlock Premium** (#115).
+✅ **`allUsers` → `roles/run.invoker` was granted on 2026-09-03** (authorised by
+you, `session-context.md` §7). Read back from the service's own policy:
 
-```sh
-gcloud run services add-iam-policy-binding revenuecatwebhook \
-  --region=europe-west1 --project=hayatiapp-prod \
-  --member=allUsers --role=roles/run.invoker
+```
+bindings: [{ role: roles/run.invoker, members: [allUsers] }]
 ```
 
-⚠️ **This is an IAM grant, not a key.** No RevenueCat API key belongs here, and
-none belongs in this repository at all.
+**Proven by the service, not by the API's reply.** The webhook's log message
+changed at exactly that moment:
+
+```
+21:50:23  W  The request was not authenticated. Either allow unauthenticated
+             invocations or set the proper Authorization header.        <- IAM refusing
+22:01:48  E  The request failed because billing is disabled for this project.
+```
+
+So the endpoint is reachable now and **billing is the only thing left in front of
+it** — Google's own words, not our inference. The old `gcloud run services
+add-iam-policy-binding` instruction is deleted because it is done.
 
 #### 2.1 — ⚠️ The webhook also needs a shared token, and this file had never said so
 
@@ -193,6 +201,11 @@ returns HTTP 403 on the Secret Manager API, which needs `secretmanager.viewer`.
 *Could not measure* is not *missing*: check it in the console before creating a
 second one.
 
+⚠️ **Public + no token is not a hole.** Until `RC_WEBHOOK_TOKEN` exists the
+Function refuses everyone with 503, so the order of these two steps cannot expose
+anything. It also means the endpoint is now internet-reachable and will burn a
+little quota answering strangers — one more reason to do **item 9**.
+
 **Where RevenueCat's three credentials actually go**, since they are easy to mix up
 and only two of them exist in this repo:
 
@@ -205,7 +218,8 @@ and only two of them exist in this repo:
 ⚠️ **No credential is ever committed** (`architecture.md` §9). Secrets reach CI via
 `gh secret set` and the Function via Secret Manager — never a file in the tree, and
 never a `workflow_dispatch` input, because this repository is **public** and
-dispatch inputs are recorded in run metadata.
+dispatch inputs are recorded in run metadata. ⚠️ **A key pasted into a chat, an
+issue or a PR is a burned key — rotate it rather than reusing it.**
 
 ### 3. Four secrets — without them, nothing is watching production
 
@@ -414,7 +428,7 @@ session can fix it.
 These block **public launch**:
 
 1. **Nothing runs on the server** — item 1. Every item below is downstream.
-2. **Payments cannot complete** — item 2, and refused by the serving layer anyway until item 1.
+2. **Payments cannot complete** — the invoker grant is done; what remains is `RC_WEBHOOK_TOKEN` (item 2.1), and the serving layer refuses everything until item 1 anyway.
 3. **Push has never been delivered** — item 4; 0 of 4 devices registered.
 4. **The App Store listing is not submittable** — seven of nine English fields empty at Apple, Turkish absent. Items 6(a) and 6(b).
 5. **Prod-vs-`main` drift is unmeasured**, not passing — both checks skip for one missing secret (item 3).

--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -17,7 +17,7 @@
 | Completion | **~58%** of the iOS MVP, to public launch |
 | Production Readiness | **Integration Ready** |
 | Production | 🟡 **Billing RESTORED 2026-09-03 ~22:05 UTC** after 12 days down. The webhook answers again; the first successful daily sweep is still pending — item 1 |
-| Open operator items | **items 1, 2 and 10 are DONE**; 3–9 stand |
+| Open operator items | **1, 2 and 10 DONE**; **9 is now the urgent one** — billing is live and nothing watches the bill; 3–8 stand |
 
 **Completion — ~58%.** Engineering (M0–M6.3) is **~95%** — every milestone closed,
 the code builds, signs and passes its gates. The question bank is **2.1%** — 21 of
@@ -66,9 +66,24 @@ ran. `prod_pulse` still exits **1**, correctly: it is keyed on the sweep's own
 record, so a punctual scheduler over a backend that was dead at the time reads
 red (ADR-063).
 
+**The scheduler's own record, read today**, so the next reader knows exactly what
+to look for rather than re-deriving it:
+
+```
+state           : ENABLED
+schedule        : 0 * * * *   (Etc/UTC — hourly, on the hour)
+lastAttemptTime : 2026-09-03T22:00:00Z
+status.code     : 13          <-- that attempt FAILED; billing was still off
+scheduleTime    : 2026-09-03T23:00:00Z   <-- the next attempt
+```
+
 > **The next hourly sweep is the proof.** Re-run:
 > `python3 tool/ci/prod_pulse.py --project hayatiapp-prod --from-firebase-cli`
 > — **0** means the daily loop is genuinely running.
+
+⚠️ **`status.code` has no `message` field.** Reading it with a `.get("message",
+"…succeeded")`-shaped default prints a confident success line while the code says
+13 — which happened today. Read `status.code`, not a message that is not there.
 
 ⚠️ **`hayatiapp-dev` stays unbilled** (your decision). It is still linked to the
 old closed `012195-7EF76F-3A9083` and reports `billingEnabled: false`. The cost is
@@ -289,18 +304,38 @@ Turkish solo pack, a known placeholder. Target: 400/300/300.
 - **Sandbox purchase test**, once Apple's pricing propagation clears.
 - **Enable Dependabot alerts** (~1 min); optionally make `gemfile-lock-verify` a required check.
 
-### 9. A Firebase budget alert
+### 9. ⚠️ A budget alert — now the most urgent thing on this page
 
 Item 3's watcher catches the *symptom* days late; a budget alert catches the
-*cause*. **Had one existed, the current outage would have been hours rather than
-days.**
+*cause*. **Had one existed, the outage just closed would have been hours rather
+than 12 days.** Billing is live again as of today and **nothing is watching the
+bill.**
 
-> <https://console.cloud.google.com/billing/012195-7EF76F-3A9083/budgets> →
-> **Create budget** → scope it to the billing account → set an amount and the
-> alert thresholds → make sure the notification email is one you read.
+⚠️ **The URL this item carried was the CLOSED account** (`012195-7EF76F-3A9083`)
+and would have sent you to the wrong place. The live one:
 
-⚠️ **Do this in the same sitting as item 1**, while you are already in the billing
-console. It is the cheapest protection on this page.
+> <https://console.cloud.google.com/billing/01D7C5-DBC2D5-E53938/budgets>
+> → **CREATE BUDGET**
+
+| field | what to choose |
+|---|---|
+| **Scope** | Projects → **`hayatiapp-prod`** only. The account now carries someone else's spending too; scoping to the project keeps their costs out of your alerts |
+| **Amount** | a small **monthly** figure. With no live users real spend should be ≈ zero, so this is an **early warning**, not a cap — set it low enough to fire before a runaway costs anything |
+| **Thresholds** | 50% / 90% / 100%, on **Actual** spend (not *Forecasted* — you want what happened, not a prediction) |
+| **Email** | ⚠️ see below |
+
+⚠️ **Check the email recipients explicitly.** Budget alerts default to the billing
+account's admins, and **the account is on someone else's identity now** — so the
+warning could land with them and not you. Verified today that your identity does
+hold `billing.accounts.update` and `billing.budgets.create` on it, so you should
+be among the defaults; confirm it on the creation screen anyway. **An alert sent
+to an address you do not read is not an alert.**
+
+⚠️ **A session cannot do this one for you**, and the reason is worth recording so
+nobody retries it: the Cloud Billing Budget API answers `SERVICE_DISABLED` for the
+firebase CLI's own consumer project (`563584335869` — Google's, not yours), so the
+API path is closed from here even though the permission is present. **The console
+enables it for you in the same flow.**
 
 ### 10. ✅ DONE — the dev box is signed in (kept for the trap it left behind)
 

--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -16,7 +16,7 @@
 |---|---|
 | Completion | **~58%** of the iOS MVP, to public launch |
 | Production Readiness | **Integration Ready** |
-| Production | 🔴 **DOWN for 12 days** (since 2026-08-22) |
+| Production | 🔴 **DOWN for 12 days** (since 2026-08-22) — a new billing account is now linked but reads `open: false`; **an open one exists**, see item 1 |
 | Open operator items | **10**, none closed yet |
 
 **Completion — ~58%.** Engineering (M0–M6.3) is **~95%** — every milestone closed,
@@ -40,10 +40,46 @@ checks measuring instead of skipping.
 
 Ordered by how much each unblocks. Every line below was verified on 2026-09-03.
 
-### 1. 🔴 Restore billing — 12 days down, everything waits on it
+### 1. 🔴 Restore billing — 12 days down, and one link away
 
-Account **`012195-7EF76F-3A9083`** is **closed**, and both projects report billing
-**off at the project**, not only at the card.
+⚠️ **State as of 2026-09-03, measured against the Cloud Billing API directly —
+not inferred.** A new billing account has been attached to `hayatiapp-prod`, and
+it is **not working yet**:
+
+```
+projects/hayatiapp-prod/billingInfo
+  billingAccountName : billingAccounts/01D7C5-DBC2D5-E53938
+  billingEnabled     : true          <-- means LINKED, not PAYING (ADR-066)
+
+billingAccounts/01D7C5-DBC2D5-E53938
+  open : false                       <-- this is the field that decides
+```
+
+**And there is an OPEN account already on the same identity.** All four visible:
+
+| account | open | name |
+|---|---|---|
+| `012195-7EF76F-3A9083` | **false** | Firebase Payment — the original |
+| **`0197C1-36BA04-63DDFB`** | ✅ **true** | Firebase Payment |
+| `01D7C5-DBC2D5-E53938` | **false** | Firebase Payment — *currently linked to prod* |
+| `01D923-0AD9FC-3FF4C5` | **false** | My Billing Account |
+
+**So the remaining step is not "pay" — it is "link prod to the account that is
+already open".**
+
+> <https://console.cloud.google.com/billing/linkedaccount?project=hayatiapp-prod>
+> → **Change billing account** → **`0197C1-36BA04-63DDFB`**.
+
+Then re-measure (below). If the open account is not the one you intend to be
+charged, open `01D7C5-DBC2D5-E53938` in the console instead and find out why it
+is closed — a new account stays closed until its payment method is accepted.
+
+**`hayatiapp-dev` is deliberately left unbilled** (founder decision, 2026-09-03):
+it is linked to the old closed account and reports `billingEnabled: false`. Cost
+is the reason, and the cost of *that* is that dev Functions cannot be deployed or
+exercised — `session-context.md`'s *"dev is a session's to exercise"* does not
+hold while this stands. CI is unaffected: the emulator suites run against
+`demo-hayati`, not this project.
 
 **Blocked by this:** every server function. No daily question is assigned, no
 notification is composed, no purchase can be processed.
@@ -75,13 +111,12 @@ boot initialises Firebase before the first frame; if that fails the app shows
 
 #### 1.2 — How to get it: two routes
 
-**Route A — reopen the account you already have** (preferred; keeps the history
-and the same id):
+**Route A — link prod to the account that is already open** (what the
+measurement above says to do; no new signup, no new card):
 
-1. Open <https://console.cloud.google.com/billing/012195-7EF76F-3A9083>
-2. If it reads *closed*, use the reactivate/reopen action and attach a working
-   payment method.
-3. Confirm **both** `hayatiapp-prod` **and** `hayatiapp-dev` are linked to it.
+1. <https://console.cloud.google.com/billing/linkedaccount?project=hayatiapp-prod>
+2. **Change billing account** → **`0197C1-36BA04-63DDFB`** (`open: true`).
+3. ⚠️ **Link `hayatiapp-prod` only.** Dev stays unbilled by decision — above.
 
 **Route B — create a fresh billing account** (if A refuses, e.g. the card or the
 account cannot be recovered):
@@ -89,11 +124,11 @@ account cannot be recovered):
 1. <https://console.cloud.google.com/billing> → **Create account**.
 2. Choose country and add a card. ⚠️ **The currency is fixed when the account is
    created and cannot be changed afterwards** — pick deliberately.
-3. Link both projects. Per project:
+3. Link **`hayatiapp-prod` only**:
    `https://console.cloud.google.com/billing/linkedaccount?project=hayatiapp-prod`
-   and the same URL with `project=hayatiapp-dev`.
+   Dev stays unbilled by decision.
 
-**Then, on the Firebase side**, make sure each project is on **Blaze**:
+**Then, on the Firebase side**, make sure `hayatiapp-prod` is on **Blaze**:
 Firebase Console → the project → ⚙ **Project settings** → **Usage and billing** →
 **Details & settings** → **Modify plan** → **Blaze (pay as you go)**.
 
@@ -109,15 +144,24 @@ exactly **item 9**.
 
 #### 1.4 — How to confirm it worked
 
-The Firebase Console showing **Blaze** on both projects is the first check. The
-authoritative one needs **item 10** done first:
+✅ **Item 10 is done — the dev box is logged in, so this now measures for real:**
 
 ```sh
-python3 tool/ci/prod_pulse.py --from-firebase-cli   # 0 = the loop is running
+python3 tool/ci/prod_pulse.py --project hayatiapp-prod --from-firebase-cli
 ```
 
-⚠️ Until item 10 is done this answers **`2 — could not measure`**, which means
-*"I cannot see"*, **not** *"production is down"*. Do not read one as the other.
+`0` = the daily loop is running. Today it exits **1** and names the cause:
+
+```
+FINDING: the linked billing account is CLOSED. The project still reports
+billingEnabled:true — that only means it is LINKED — while Cloud Run refuses
+every invocation with 'billing is disabled for this project'.
+most recent refusal (2026-08-29T01:00:02Z): billing is disabled for this project.
+```
+
+⚠️ **Do not read `billingEnabled: true` as success.** ADR-066 exists because that
+exact field produced a wrong instruction before: it means *linked*, and the
+account's own `open` field is what decides.
 
 ### 2. Grant the RevenueCat webhook a public invoker — money is at stake
 
@@ -298,14 +342,19 @@ days.**
 ⚠️ **Do this in the same sitting as item 1**, while you are already in the billing
 console. It is the cheapest protection on this page.
 
-### 10. The dev box needs YOUR Firebase sign-in
+### 10. ✅ DONE — the dev box is signed in (kept for the trap it left behind)
 
 The machine was rebuilt around **2026-08-31**. A session restored everything it
 could by itself — Flutter, Java, the Dart SDK and `firebase-tools` are all back and
 app-side checks run locally again. **What is left is the one step that is yours**,
 because it is an interactive sign-in with your Google identity:
 
-> On the dev box: `firebase login`
+✅ **Done on 2026-09-03.** `prod_pulse.py --from-firebase-cli` now returns a real
+verdict instead of *"could not measure"*, and that is how item 1's state above was
+established.
+
+**This item stays on the page only for its trap**, which cost a measurement
+earlier the same day and will recur on the next rebuild:
 
 ⚠️ **Do not check this by looking for the file.**
 `~/.config/configstore/firebase-tools.json` **exists today and is still not a
@@ -316,14 +365,11 @@ to run a probe:
 python3 tool/ci/prod_pulse.py --from-firebase-cli   # 2 = still not logged in
 ```
 
-**Blocked by this:** every local production check — `prod_pulse.py`,
-`push_delivery_probe.py`, `rules_drift.py`, `functions:log`, `functions:list`. They
-all answer *"could not measure"*, which is honest, but it means **a session cannot
-tell the difference between "production is down" and "I cannot see production"**
-without you.
-
-Not urgent while production is down anyway. **It becomes urgent the moment you do
-item 1**, because that is when someone needs to confirm it worked.
+`~/.config/configstore/firebase-tools.json` **existed while still not being a
+login** — installing `firebase-tools` creates it empty, and only the `tokens` key
+appearing makes it real. The only honest check is to run a probe and read its exit
+code. **Delete this item once it has survived one rebuild without anyone falling
+for it.**
 
 ---
 

--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -163,7 +163,7 @@ most recent refusal (2026-08-29T01:00:02Z): billing is disabled for this project
 exact field produced a wrong instruction before: it means *linked*, and the
 account's own `open` field is what decides.
 
-### 2. The RevenueCat webhook — the IAM half is DONE; a token is still missing
+### 2. The RevenueCat webhook — Google's side is DONE; RevenueCat's side is unverified
 
 ✅ **`allUsers` → `roles/run.invoker` was granted on 2026-09-03** (authorised by
 you, `session-context.md` §7). Read back from the service's own policy:
@@ -196,10 +196,28 @@ it constant-time. **You invent the string; it must be identical in two places:**
    (ADR-048 lists it there alongside `LLM_API_KEY`);
 2. the RevenueCat dashboard's webhook **Authorization** field.
 
-**Could not measure whether prod already holds it** — the dev box's firebase token
-returns HTTP 403 on the Secret Manager API, which needs `secretmanager.viewer`.
-*Could not measure* is not *missing*: check it in the console before creating a
-second one.
+✅ **It already exists, and it is already bound.** Measured 2026-09-03 — and *not*
+through Secret Manager, which still refuses this token with HTTP 403. The deployed
+Cloud Run service's own container config says it, which needs only
+`run.services.get`:
+
+```
+revenuecatwebhook  (revision revenuecatwebhook-00005-mok)
+  SECRET  RC_WEBHOOK_TOKEN -> projects/hayatiapp-prod/secrets/RC_WEBHOOK_TOKEN : 1
+```
+
+So the Function side is **complete**: deployed, secret created, secret bound.
+⚠️ **The one thing left is the other end** — whether the RevenueCat dashboard's
+webhook `Authorization` field holds **the same string** as version 1 of that
+secret. That is in RevenueCat's console, which nothing here can read.
+
+> Read the value: Secret Manager → `RC_WEBHOOK_TOKEN` → version 1 → *View secret
+> value*. (Or, after `gcloud auth login`:
+> `gcloud secrets versions access 1 --secret=RC_WEBHOOK_TOKEN --project=hayatiapp-prod`.)
+>
+> Then RevenueCat → your project → **Integrations → Webhooks**:
+> URL `https://revenuecatwebhook-mzym2uw5gq-ew.a.run.app`,
+> **Authorization** = that exact string, sent verbatim with no `Bearer` prefix.
 
 ⚠️ **Public + no token is not a hole.** Until `RC_WEBHOOK_TOKEN` exists the
 Function refuses everyone with 503, so the order of these two steps cannot expose

--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -174,6 +174,39 @@ gcloud run services add-iam-policy-binding revenuecatwebhook \
   --member=allUsers --role=roles/run.invoker
 ```
 
+⚠️ **This is an IAM grant, not a key.** No RevenueCat API key belongs here, and
+none belongs in this repository at all.
+
+#### 2.1 — ⚠️ The webhook also needs a shared token, and this file had never said so
+
+`revenueCatWebhook` **fail-closes with 503 until `RC_WEBHOOK_TOKEN` is set**
+(ADR-013 D1). It is not an API key: RevenueCat sends whatever string you type into
+its dashboard **verbatim** in the `Authorization` header, and the Function compares
+it constant-time. **You invent the string; it must be identical in two places:**
+
+1. Google **Secret Manager** in `hayatiapp-prod`, as `RC_WEBHOOK_TOKEN`
+   (ADR-048 lists it there alongside `LLM_API_KEY`);
+2. the RevenueCat dashboard's webhook **Authorization** field.
+
+**Could not measure whether prod already holds it** — the dev box's firebase token
+returns HTTP 403 on the Secret Manager API, which needs `secretmanager.viewer`.
+*Could not measure* is not *missing*: check it in the console before creating a
+second one.
+
+**Where RevenueCat's three credentials actually go**, since they are easy to mix up
+and only two of them exist in this repo:
+
+| credential | shape | where it lives |
+|---|---|---|
+| iOS **publishable** SDK key | `appl_…` | repo **variable** `REVENUECAT_IOS_API_KEY` — ships inside the binary, public by design. **Already set.** |
+| webhook **shared token** | a string you choose | Secret Manager `RC_WEBHOOK_TOKEN` + the same string in the RC dashboard. **Above.** |
+| **v2 secret API key** | `sk_…` | ⚠️ **nothing in this repository reads one.** ADR-013's mirror is webhook-driven and never calls RevenueCat's REST API; #41 lists RC-REST reconciliation as future work. Do not add one until something needs it |
+
+⚠️ **No credential is ever committed** (`architecture.md` §9). Secrets reach CI via
+`gh secret set` and the Function via Secret Manager — never a file in the tree, and
+never a `workflow_dispatch` input, because this repository is **public** and
+dispatch inputs are recorded in run metadata.
+
 ### 3. Four secrets — without them, nothing is watching production
 
 **None of these four exists.** Verified today: `gh secret list` returns five

--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -16,23 +16,24 @@
 |---|---|
 | Completion | **~58%** of the iOS MVP, to public launch |
 | Production Readiness | **Integration Ready** |
-| Production | 🟡 **Billing RESTORED 2026-09-03 ~22:05 UTC** after 12 days down. The webhook answers again; the first successful daily sweep is still pending — item 1 |
+| Production | 🟢 **UP.** Billing restored 2026-09-03 ~22:05 UTC after 12 days down; the **23:00 UTC sweep completed** (`assigned=1, failed=0`) and `prod_pulse` exits **0** — item 1 |
 | Open operator items | **1, 2 and 10 DONE**; **9 is now the urgent one** — billing is live and nothing watches the bill; 3–8 stand |
 
-**Completion — ~58%.** Engineering (M0–M6.3) is **~95%** — every milestone closed,
-the code builds, signs and passes its gates. The question bank is **2.1%** — 21 of
+**Completion — ~58%.** Engineering (M0–M6.3) is **~95%** — the code builds, signs
+and passes its gates. ⚠️ *"Every milestone closed" is not true and was written
+here: **M5.3 has no ✅** in `implementation-plan.md`.* The question bank is **2.1%** — 21 of
 1000 questions (measured today: 7 each in `solo_ar`, `solo_en`, `solo_tr`).
 Weighting engineering at 60% and content at 40%: `(0.60 × 95) + (0.40 × 2.1) ≈ 58`.
 **The engineering is nearly done; content and the items below are the gap.**
 
-**Integration Ready**, not Beta Ready: production has been down 12 days, no push
-has ever reached any phone, the RevenueCat webhook answers **HTTP 403** (verified
-today), and nothing is watching production. *Beta Ready* would mean real people
+**Integration Ready**, not Beta Ready: no push has ever reached any phone, the
+listing is unpublished, and nothing is watching production. *(The webhook's
+**HTTP 403** stood here until 2026-09-03; it now answers its own JSON — item 2.)* *Beta Ready* would mean real people
 using real features on real devices, and that has never happened.
 
-**To reach Beta Ready:** billing restored and verified · one push delivered to a
-real phone · a current build on devices (the last is **25 days** old) · the drift
-checks measuring instead of skipping.
+**To reach Beta Ready:** ~~billing restored and verified~~ ✅ · one push delivered
+to a real phone · a current build on devices (**a build is in flight** — item 4) ·
+the drift checks measuring instead of skipping.
 
 ---
 
@@ -40,7 +41,7 @@ checks measuring instead of skipping.
 
 Ordered by how much each unblocks. Every line below was verified on 2026-09-03.
 
-### 1. ✅ Billing is RESTORED — waiting on the first successful sweep
+### 1. ✅ CLOSED — billing restored and the sweep proven
 
 **Done 2026-09-03 ~22:05 UTC.** Account `01D7C5-DBC2D5-E53938` (the one already
 linked to `hayatiapp-prod`) was **activated** — the payment instrument is on
@@ -77,9 +78,10 @@ status.code     : 13          <-- that attempt FAILED; billing was still off
 scheduleTime    : 2026-09-03T23:00:00Z   <-- the next attempt
 ```
 
-> **The next hourly sweep is the proof.** Re-run:
-> `python3 tool/ci/prod_pulse.py --project hayatiapp-prod --from-firebase-cli`
-> — **0** means the daily loop is genuinely running.
+**The next hourly sweep was the proof, and it passed.** The **23:00 UTC** run
+completed — `question_rollover: sweep complete`, `assigned=1, failed=0,
+seasonalCalendarUnavailable=False` — and `prod_pulse` now exits **0**. The daily
+loop is genuinely running. **Nothing further is needed from you on this item.**
 
 ⚠️ **`status.code` has no `message` field.** Reading it with a `.get("message",
 "…succeeded")`-shaped default prints a confident success line while the code says
@@ -113,7 +115,7 @@ an unauthorized caller"*. Getting **401 and not 503**, with no header sent, mean
 |---|---|
 | the container runs | a JSON body came back, not Google's HTML error page — **billing works** |
 | the request reaches it | not a Cloud Run 403 — **the invoker grant works** (granted 2026-09-03, `allUsers` → `roles/run.invoker`) |
-| `RC_WEBHOOK_TOKEN` is set and non-empty | the 503 branch was **not** taken — **the secret is bound and populated** (version 1, revision `revenuecatwebhook-00005-mok`) |
+| `RC_WEBHOOK_TOKEN` is set and non-empty | the 503 branch was **not** taken — **the secret is bound and populated** (**version 2**, revision `revenuecatwebhook-00007-tof`, redeployed 2026-09-03; the invoker grant survived the redeploy and `functions_drift` exits **0**) |
 
 This is `session-context.md` §8's own test — *"JSON = fixed, HTML 403 = broken"* —
 answering **fixed**.
@@ -124,9 +126,9 @@ RevenueCat sends whatever is in its dashboard **verbatim** in the `Authorization
 header — no `Bearer`, no HMAC (ADR-013 D1). Nothing here can read RevenueCat's
 console, so this is yours:
 
-> **Read the value:** Secret Manager → `RC_WEBHOOK_TOKEN` → version 1 → *View
-> secret value*. (Or, after `gcloud auth login`:
-> `gcloud secrets versions access 1 --secret=RC_WEBHOOK_TOKEN --project=hayatiapp-prod`.)
+> **Read the value:** Secret Manager → `RC_WEBHOOK_TOKEN` → **version 2** (the
+> live one — version 1 is superseded) → *View secret value*. (Or, after
+> `gcloud auth login`: `gcloud secrets versions access 2 --secret=RC_WEBHOOK_TOKEN --project=hayatiapp-prod`.)
 >
 > **RevenueCat** → your project → **Integrations → Webhooks**:
 > URL `https://revenuecatwebhook-mzym2uw5gq-ew.a.run.app`,
@@ -166,15 +168,22 @@ the deploy one are **read-only** service accounts.
 
 ### 4. Cut a build, install it, allow notifications
 
-The last build is **119, cut 2026-08-09 — 25 days ago.** Everything merged since
-is on nobody's phone.
+The last build on devices is **119, cut 2026-08-09 — 26 days ago.** Everything
+merged since is on nobody's phone.
 
-> Dispatch the release lane → install from TestFlight → open the app to the paired
-> home screen → tap **Allow** on the notification prompt.
+**A new build was dispatched 2026-09-04** (release run **#20**, from `main`) at
+your request. Its number is `100 + run number`.
 
-⚠️ **Do this after item 1.** Before billing is restored the registration call is
-refused, so you would spend the permission prompt — which iOS shows **once per
-install** — and learn nothing.
+> Install it from TestFlight → open the app to the paired home screen → tap
+> **Allow** on the notification prompt.
+
+✅ **Item 1's precondition is now met**, which is why this is your turn: before
+billing was restored the registration call was refused, and you would have spent
+the permission prompt — which iOS shows **once per install** — for nothing.
+
+⚠️ **This is the first push ever attempted.** 0 of 4 registered devices have
+received one. A silent failure here is a *finding*, not a mistake — report what
+the phone does.
 
 ### 5. The legal bundle — one decision, three drafted parts, six questions
 
@@ -182,11 +191,15 @@ install** — and learn nothing.
 is **not in force**: `CURRENT_LEGAL_VERSION` is still **2** and nobody has been
 re-prompted.
 
-| | the gap it closes |
-|---|---|
-| **#226** | the notice denies push, and never names the device address or the phone's own status report |
-| **#249** | the record of your consent — version, when, age confirmation — is stored, handed over on request, and named nowhere |
-| **#258** | what account deletion actually removes was under-described |
+| | the gap it closes | issue |
+|---|---|---|
+| **#226** | the notice denies push, and never names the device address or the phone's own status report | **OPEN** |
+| **#249** | the record of your consent — version, when, age confirmation — is stored, handed over on request, and named nowhere | **closed** — the clause is in the draft |
+| **#258** | what account deletion actually removes was under-described | **closed** — the clause is in the draft |
+
+⚠️ **Two of those three issues are closed and the third is not.** Closing them
+recorded that the *wording exists*; it did not put it in force. The decision below
+is what puts it in force, and it is unaffected by the issue tracker.
 
 **What is needed from you:** read the draft, put it in front of your lawyer with
 the **six** questions in `docs/legal/README.md`, and say go — or say what to change.
@@ -308,8 +321,8 @@ Turkish solo pack, a known placeholder. Target: 400/300/300.
 
 Item 3's watcher catches the *symptom* days late; a budget alert catches the
 *cause*. **Had one existed, the outage just closed would have been hours rather
-than 12 days.** Billing is live again as of today and **nothing is watching the
-bill.**
+than 12 days.** Billing has been live since **2026-09-03** and **nothing is watching
+the bill.**
 
 ⚠️ **The URL this item carried was the CLOSED account** (`012195-7EF76F-3A9083`)
 and would have sent you to the wrong place. The live one:

--- a/docs/session-context.md
+++ b/docs/session-context.md
@@ -46,7 +46,7 @@ _Environment facts below were last re-measured **2026-08-05**._
 * **A concurrent session on another machine can merge to `main` and consume your session
   number.** Re-derive the session number and the queue from `git log` + `gh issue list`,
   never from a document's prose.
-* `gcloud` is **not installed** and there is **no ADC**. ~~Cloud Scheduler and Eventarc state
+* ⚠️ **`gcloud` IS installed** since the rebuild — `/snap/bin/gcloud`, measured S099 — but it has **no credentialed accounts** (`gcloud auth list` → *No credentialed accounts*), so every `gcloud` command needs an interactive `gcloud auth login` first. There is still **no ADC**. *(This line said `gcloud` was not installed at all until S099; the conclusion below is unaffected, because the firebase-CLI token is still the credential a session actually has.)* ~~Cloud Scheduler and Eventarc state
   cannot be verified from here.~~ **That was wrong, and it cost 37 hours (S068, #219.)**
   The firebase CLI's stored refresh token carries the **`cloud-platform`** scope, so
   `tool/ci/rules_drift.py`'s existing `token_from_firebase_cli()` mints a token that reads


### PR DESCRIPTION
The branch was opened to record a finding — *prod's billing account is linked but
CLOSED* — and by the time it merges that finding is **closed**, along with the
outage it described. The title is updated because it becomes the merge commit's
subject, and the original would have recorded the opposite of what happened.

## What the eight commits establish

| | measured |
|---|---|
| **Billing** | `billingEnabled: true` **and** account `01D7C5-DBC2D5-E53938` `open: true`. ADR-066's two conditions, kept apart, both true |
| **The sweep** | 23:00 UTC completed — `assigned=1, failed=0, seasonalCalendarUnavailable=False`; `prod_pulse` exits **0** |
| **The webhook** | `curl -X POST … -d '{}'` → **HTTP 401 `{"error":"unauthorized"}`**. The handler checks its 503 `unconfigured` branch *before* the token compare, so 401-not-503 proves the container runs, the invoker grant works, and `RC_WEBHOOK_TOKEN` is bound and non-empty — three facts from one request |
| **The redeploy** | revision `revenuecatwebhook-00007-tof` on secret **version 2**; the `allUsers` → `roles/run.invoker` grant survived it; `functions_drift` exits **0** |

## What `operator-expected.md` became

Rewritten to hold **open items only**, at the founder's request, with the item
numbers preserved — ADRs and `resume-prompt.md` cite them by number (lesson 71),
so renumbering would silently break every citation. Items 1, 2 and 10 keep their
numbers as short DONE records because each carries a trap worth inheriting.

It also gains the thing the file never had: **how to obtain the Firebase
membership**, and a disambiguation table for RevenueCat's three credentials —
the publishable `appl_…` key, the webhook shared token, and the `sk_…` v2 key
that **nothing in this repository reads**.

## Corrections in the last commit

Five claims this file made that a re-read contradicts: `every milestone closed`
(M5.3 has no ✅), the webhook's stale `HTTP 403`, #249/#258 listed as open gaps
when both are closed, the build age, and item 2.1 pointing the founder at secret
**version 1** — the superseded one — to compare against RevenueCat's dashboard.

⚠️ **Still open and now the urgent one: item 9.** Billing is live and nothing is
watching the bill. Had a budget alert existed, the outage just closed would have
been hours rather than 12 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeFqpZ4Hz4hHN7kGBofs69
