### PR TITLE
docs(operator): build 121 carries both halves and is on TestFlight

### DIFF
--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -264,15 +264,30 @@ it has no address. Apple documents the call as safe to repeat, so it costs
 nothing if the plugin was already doing it — and it is the whole feature if it
 was not.
 
-> **What is needed: one more TestFlight build.** It carries two things — the fix
-> above, and the callback that makes iOS *state its reason* if it refuses
-> (ADR-074) instead of failing silently. Either the notification arrives, or we
-> get the sentence that names the fault. **That is a release dispatch, which I do
-> not do without asking** (`session-context.md` §7) — say the word.
+> ✅ **Build 121 is on TestFlight** — release run **#21**, 2026-09-06 16:16:47
+> UTC, `assigned build 121 to 'Friends'` (7 testers), read from the job log. It
+> carries **both** halves: the fix above, and the callback that makes iOS *state
+> its reason* if it refuses (ADR-074) instead of failing silently.
+>
+> **Install 121 and open the app to the paired home screen.** You will not be
+> asked for permission again — iOS shows that dialog once per install and you
+> already granted it, which is exactly why this build had to do the asking on
+> its own side instead.
+>
+> Then tell me, and I re-read the report. **Three outcomes, all of them
+> progress:**
+>
+> | what the report says | what it means |
+> |---|---|
+> | a token is registered | **it worked** — I send a real test notification to prove the last link |
+> | `apnsRegistrationRefused` | iOS refused and **named the reason**; the sentence is in the device log, and the fault is finally addressable |
+> | `captureExhausted` still | the request went out and APNs stayed silent — which points at the network path, not at this app |
 
 ⚠️ Honest bound: the fix is a **candidate**, not a diagnosis. It removes a real
-dependency on vendor ordering, and it is the best-supported explanation left
-standing — but nothing here has touched a phone.
+dependency on vendor ordering and is the best-supported explanation left
+standing — but until 121 is installed, nothing here has touched a phone. As of
+this writing the last device report is still **2026-09-06T14:42:56Z**, which
+predates 121: it has not been installed yet.
 
 ### 5. The legal bundle — one decision, three drafted parts, six questions
 


### PR DESCRIPTION
Release run **#21** from `main` (`fd2bf6e`). Read from the `sign-upload` job log
rather than the green tick:

```
• Build Number: 121
Successfully uploaded package to App Store Connect     (2026-09-06 16:16:47 UTC)
assigned build 121 to 'Friends'                        (7 testers)
```

It carries **both halves** of the session's work — ADR-076's fix (the app asks
APNs for an address itself instead of depending on a vendor initialisation
ordering nobody here chose) and ADR-074's callback (iOS's refusal reason stops
going to an `NSLog` nobody can read).

Item **4.2** now states the three possible outcomes and why each is progress: a
registered token, a **named** refusal, or a still-silent APNs that points at the
network path rather than at this app. It also flags the thing that is easy to get
wrong on install — **iOS will not ask for permission again**, because it shows
that dialog once per install and the founder already granted it. That is exactly
why this build had to move the asking to the app's own side.

The honest bound is kept and sharpened: the last device report is still
**2026-09-06T14:42:56Z**, which predates 121 — so the fix is deployed and has
still not touched a phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeFqpZ4Hz4hHN7kGBofs69