### PR TITLE
docs(operator): the diagnostic in build 121 can actually record — measured, and it is a near-miss (#293)

### DIFF
--- a/docs/operator-expected.md
+++ b/docs/operator-expected.md
@@ -289,6 +289,27 @@ standing — but until 121 is installed, nothing here has touched a phone. As of
 this writing the last device report is still **2026-09-06T14:42:56Z**, which
 predates 121: it has not been installed yet.
 
+#### 4.3 — A near-miss worth knowing about (issue #293)
+
+Before handing you a build, one thing was checked that could have made the whole
+exercise pointless: **can your phone actually WRITE the new diagnostic?**
+
+The new report value rides a security rule with a closed list of allowed values.
+If production were running the old list, your phone would try to report
+`apnsRegistrationRefused`, Firestore would reject it, the app would swallow the
+rejection by design — and **build 121's whole diagnostic half would have been
+silently dead on the one build cut to carry it.**
+
+Measured instead of assumed: the live production ruleset contains **no mention of
+this field at all** — it is 62 lines behind the code and never received that gate.
+So the write is unconstrained and **the report will record.** ✅
+
+**It works because of a gap, not because of a guarantee**, and that is filed as
+**#293**: the rule that is supposed to validate this field is doing nothing in
+production, in either direction. Deploying the current ruleset is a prod deploy
+and therefore yours to authorise — it is **not** needed for the notification test
+and should not be mixed into it.
+
 ### 5. The legal bundle — one decision, three drafted parts, six questions
 
 `docs/legal/proposed/` holds the version-3 draft of all three privacy policies. It


### PR DESCRIPTION
Before handing the founder a build, the obvious way for the whole exercise to be
pointless got checked: **can the phone actually WRITE the new diagnostic value?**

ADR-074's fifth `detail` rides a `firestore.rules` clause with a **closed
vocabulary**. If production were serving the OLD list, the phone would report
`apnsRegistrationRefused`, Firestore would reject it,
`FirestorePushDiagnosticRecorder` would swallow the denial **by design**
(ADR-039 D1) — and the instrument built to name an APNs refusal would have been
**silently inert on the one build cut to carry it**.

## Measured, not reasoned about

Fetched the live ruleset from the Firebase Rules API:

```
grep -c pushDiagnostic  <live prod ruleset>   ->  0
live: 280 lines          this ref: 342 lines
```

`pushDiagnosticValid()` has never been deployed. The live `match /users/{uid}`
update rule freezes only the server-owned fields (`createdAt`, `coupleId`,
`notificationPrivacy`, `coupleEnded`, `consent`, `fcmTokens`) and leaves
`pushDiagnostic` **unconstrained**. So the write is accepted and **the report
will record.** ✅

## ⚠️ It works because of a gap, not a guarantee

The parity test cannot see this — it proves a *file* agrees with a *file*.
`rules_drift` is the only thing that would have said so, and it is **skipped in
CI** for want of a read-only secret (#165), so it has been reporting to nobody.

Filed as **#293**, with the observation that the shape validation is currently
doing nothing in production **in either direction**: a junk `pushDiagnostic` is
equally accepted today.

Item **4.3** says plainly that deploying the ruleset is a prod deploy, is the
founder's to authorise, is **not** needed for the notification test, and should
not be mixed into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeFqpZ4Hz4hHN7kGBofs69